### PR TITLE
Fix autocompletion

### DIFF
--- a/definitions/logger.d.ts
+++ b/definitions/logger.d.ts
@@ -9,6 +9,4 @@ interface ILogger {
 
 	out(formatStr: any, ...args): void;
 	write(...args): void;
-
-	setLoggerConfiguration(config: any, logLevel: string): void;
 }

--- a/dispatchers.ts
+++ b/dispatchers.ts
@@ -15,8 +15,6 @@ export class CommandDispatcher implements ICommandDispatcher {
 
 	public dispatchCommand(beforeExecuteCommandHook?: (command: ICommand, commandName: string) => void): IFuture<void> {
 		return(() => {
-			this.$logger.setLoggerConfiguration(this.$config, options.log);
-
 			if (options.version) {
 				this.$logger.out(this.$config.version);
 				return;

--- a/logger.ts
+++ b/logger.ts
@@ -2,14 +2,15 @@
 
 import log4js = require("log4js");
 import util = require("util");
+import options = require("./options");
 
 export class Logger implements ILogger {
 	private log4jsLogger = null;
 	
-	public setLoggerConfiguration(config: any, logLevel: string): void {
+	constructor($config) {
 		var appenders = [];
 
-		if (!config.CI_LOGGER) {
+		if (!$config.CI_LOGGER) {
 			appenders.push({
 				type: "console",
 				layout: {
@@ -22,10 +23,10 @@ export class Logger implements ILogger {
 
 		this.log4jsLogger = log4js.getLogger();
 
-		if (logLevel) {
-			this.log4jsLogger.setLevel(logLevel);
+		if (options.log) {
+			this.log4jsLogger.setLevel(options.log);
 		} else {
-			this.log4jsLogger.setLevel(config.DEBUG ? "TRACE" : "INFO");
+			this.log4jsLogger.setLevel($config.DEBUG ? "TRACE" : "INFO");
 		}
 	}
 


### PR DESCRIPTION
When the autocompletion is activated, `setLoggerConfiguration` wasn't called and thus produces the exception. So I removed the `setLoggerConfiguration` and moved all logic from it into constructor.
