### PR TITLE
Make unziping under Darwin behave like under Windows

### DIFF
--- a/file-system.ts
+++ b/file-system.ts
@@ -58,7 +58,9 @@ export class FileSystem implements IFileSystem {
 	public unzip(zipFile: string, destinationDir: string): IFuture<void> {
 		if (helpers.isDarwin()) {
 			var $childProcess = $injector.resolve("$childProcess");
-			var unzipProc = $childProcess.spawn('unzip', ['-uqo', zipFile, '-d', destinationDir],
+
+			this.createDirectory(destinationDir).wait();
+			var unzipProc = $childProcess.spawn('unzip', ['-u', zipFile, '-d', destinationDir],
 				{ stdio: "ignore", detached: true });
 			return this.futureFromEvent(unzipProc, "close");
 		}


### PR DESCRIPTION
Make unziping under Darwin behave like under Windows
- create missing parent directories
- fix unzip command line args to working ones
