### PR TITLE
Fixed spelling error which crashes all CLIs at startup

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -12,6 +12,6 @@ $injector.require("cancellation", "./common/services/cancellation");
 $injector.require("httpClient", "./common/http-client");
 $injector.require("childProcess", "./common/child-process");
 $injector.require("projectHelper", "./common/project-helper");
-$injector.require("propertiesParser", "./commmon/properties-parser");
+$injector.require("propertiesParser", "./common/properties-parser");
 
 $injector.requireCommand(["help", "/?"], "./common/commands/help");


### PR DESCRIPTION
An extra 'm' leads to times of saddness
