### PR TITLE
Fix tracing code in Http module to show the real content

### DIFF
--- a/http-client.ts
+++ b/http-client.ts
@@ -141,7 +141,7 @@ export class HttpClient implements Server.IHttpClient {
 				}
 			});
 
-			this.$logger.trace("httpRequest: Sending:\n%s", body);
+			this.$logger.trace("httpRequest: Sending:\n%s", body ? (typeof body  === "string" ? body : JSON.stringify(body)) : "[empty request body]");
 
 			if (!body || !body.pipe) {
 				request.end(body);


### PR DESCRIPTION
Fix tracing code in Http module to show the real content instead of "undefined" and "[object Object]"
