### PR TITLE
Fix livesync to Android devices

### DIFF
--- a/mobile/android/android-device.ts
+++ b/mobile/android/android-device.ts
@@ -215,9 +215,10 @@ export class AndroidDevice implements Mobile.IDevice {
 	}
 
 	private getLiveSyncUrl(projectType: number): string {
+		var projectTypes = $injector.resolve("$projectTypes");
 		switch (projectType) {
-			case 0: return "icenium://";
-			case 1: return "nativescript://";
+			case projectTypes.Cordova: return "icenium://";
+			case projectTypes.NativeScript: return "nativescript://";
 			default: throw new Error("Unsupported project type");
 		}
 	}


### PR DESCRIPTION
We are using non-consecutive numbers in our enum to distinguish project types, but the old code uses consecutive ones.

Fix: Use named constants instead of hard-coded numbers. We must resolve the constants inside the method, instead of constructor injection, because these imports are available only in the Cordova CLI.

Fixes bug #273415
