### PR TITLE
Fix Bug 262230

### DIFF
--- a/mobile/ios/ios-core.ts
+++ b/mobile/ios/ios-core.ts
@@ -585,6 +585,8 @@ class WinSocket implements Mobile.IiOSDeviceSocket {
 		});
 		if (result < 0) {
 			this.$errors.fail("Error receiving data: %s", result);
+		} else if (result === 0) {
+			return null;
 		}
 
 		return data;


### PR DESCRIPTION
Fix Bug "[CLI] disconecting ios device when open-device-log-stream is active causes CLI to become unresponsive"
http://teampulse.telerik.com/view#item/262230

**recv** returns zero if the connection has as been gracefully closed
http://msdn.microsoft.com/en-us/library/windows/desktop/ms740121(v=vs.85).aspx
