### PR TITLE
Disable ~ as a valid project name

### DIFF
--- a/validators/project-name-validator.ts
+++ b/validators/project-name-validator.ts
@@ -8,13 +8,13 @@ export class ProjectNameValidator implements IProjectNameValidator {
 	private static MAX_FILENAME_LENGTH = 30;
 	private static EMPTY_FILENAME_ERROR_MESSAGE = "Name cannot be empty.";
 	private static NOT_VALID_NAME_ERROR_MESSAGE = "Name should contain only the following symbols: A-Z, a-z, 0-9, _, ., - and space";
-	private static RESERVED_NAME_ERROR_MESSAGE = "Name is among the reserved names: CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9.";
+	private static RESERVED_NAME_ERROR_MESSAGE = "Name is among the reserved names: ~, CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9.";
 	private static INVALID_EXTENSION_ERROR_MESSAGE = "Unsupported file type.";
 	private static TOO_LONG_NAME_ERROR_MESSAGE = "Name is too long.";
 	private static TRAILING_DOTS_ERROR_MESSAGE = "Name cannot contain trailing dots.";
 	private static LEADING_SPACES_ERROR_MESSAGE = "Name cannot contain leading spaces.";
 	private static TRAILING_SPACES_ERROR_MESSAGE = "Name cannot contain trailing spaces.";
-	private static INVALID_FILENAMES = [ "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"];
+	private static INVALID_FILENAMES = [ "~", "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"];
 	private static INVALID_EXTENSIONS:string[] = [];
 
 	constructor(private $errors: IErrors) {}


### PR DESCRIPTION
Keeping in sync with the other AB clients...

Refs http://teampulse.telerik.com/view#item/275484
