### PR TITLE
Add validation of  --options passed to commands

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -106,7 +106,8 @@ interface ICommandOptions {
 }
 
 declare enum ErrorCodes {
-	UNKNOWN = 127
+	UNKNOWN = 127,
+	INVALID_ARGUMENT = 128
 }
 
 interface IFutureDispatcher	 {

--- a/options.ts
+++ b/options.ts
@@ -1,21 +1,23 @@
 ///<reference path="../.d.ts"/>
 "use strict";
+
 import path = require("path");
 import helpers = require("./../common/helpers");
 
-var knownOpts:any = {
-		"log" : String,
-		"verbose" : Boolean,
-		"path" : String,
+var knownOpts: any = {
+		"log": String,
+		"verbose": Boolean,
+		"path": String,
 		"version": Boolean,
 		"help": Boolean,
 		"json": Boolean,
 		"watch": Boolean,
-		"avd": String
+		"avd": String,
+		"profile-dir": String,
 	},
 	shorthands = {
-		"v" : "verbose",
-		"p" : "path"
+		"v": "verbose",
+		"p": "path"
 	};
 
 var parsed = helpers.getParsedOptions(knownOpts, shorthands);


### PR DESCRIPTION
Validate arguments passed to command line. The execution stops when the argument is not part of known options or if it requires value, but the user had not passed one. The function will not validate the arguments if the command is _mocha (used for our tests). 

Add profile-dir to common known options.

http://teampulse.telerik.com/view#item/262916
http://teampulse.telerik.com/view#item/250186
