### PR TITLE
Fix starting of emulator when a physical device is connected as well

### DIFF
--- a/mobile/android/android-device.ts
+++ b/mobile/android/android-device.ts
@@ -1,5 +1,5 @@
 ///<reference path="../../../.d.ts"/>
-"use strict"
+"use strict";
 import MobileHelper = require("./../mobile-helper");
 import util = require("util");
 import Future = require("fibers/future");

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -68,7 +68,10 @@ class AndroidEmulatorServices implements Mobile.IEmulatorPlatformServices {
 
 			// adb does not always wait for the emulator to fully startup. wait for this
 			this.$logger.trace("waiting for the emulator device to appear");
-			this.$childProcess.spawnFromEvent(this.$staticConfig.adbFilePath, ["wait-for-device"], "exit").wait();
+			while (runningEmulators.length === 0) {
+				this.sleep(1000);
+				runningEmulators = this.getRunningEmulators().wait();
+			}
 
 			// waits for the boot animation property of the emulator to switch to 'stopped'
 			this.waitForEmulatorBootToComplete().wait();


### PR DESCRIPTION
Revert to old code for checking whether the emulator is started

refs https://github.com/NativeScript/nativescript-cli/issues/116 https://github.com/NativeScript/nativescript-cli/issues/114
