### PR TITLE
Remove validation of common options

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -55,9 +55,8 @@ export function enumerateFilesInDirectorySync(directoryPath: string, filterCallb
 	return result;
 }
 
-export function getParsedOptions(options: any, shorthands: any, defaultProfileDir?: string) {
+export function getParsedOptions(options: any, shorthands: any) {
 	var yargs: any = require("yargs");
-
 	Object.keys(options).forEach((opt) => {
 		var type = options[opt];
 		if (type === String) {
@@ -72,22 +71,24 @@ export function getParsedOptions(options: any, shorthands: any, defaultProfileDi
 	});
 
 	var parsed = yargs.argv;
-	validateYargsArguments(parsed, options);
-
-	parsed["profile-dir"] = parsed["profile-dir"] || defaultProfileDir;
+	validateYargsArguments(parsed, options, shorthands);
 
 	return parsed;
 }
 
-export function validateYargsArguments(parsed: any, knownOpts: any, isInTestMode?: boolean): void {
+export function validateYargsArguments(parsed: any, knownOpts: any, shorthands: any, isInTestMode?: boolean): void {
 	if (path.basename(process.argv[1]) === "appbuilder.js" || isInTestMode) {
 		_.each(_.keys(parsed), (opt) => {
-			if (opt !== "_" && opt !== "$0" && !knownOpts[opt]) {
+			var option = shorthands[opt] ? shorthands[opt] : opt;
+
+			if (option !== "_" && option !== "$0" && !knownOpts[option]) {
 				breakExecution(util.format("The option '%s' is not supported. To see command's options, use '$ appbuilder %s --help'. To see all commands use '$ appbuilder help'.", opt, process.argv[2]));
-			} else if (knownOpts[opt] !== Boolean && typeof (parsed[opt]) === 'boolean') {
+			} else if (knownOpts[option] !== Boolean && typeof (parsed[opt]) === 'boolean') {
 				breakExecution(util.format("The option '%s' requires a value.", opt));
-			} else if (knownOpts[opt] === String && parsed[opt].trim().length === 0) {
+			} else if (knownOpts[option] === String && parsed[opt].trim().length === 0) {
 				breakExecution(util.format("The option '%s' requires nonempty value.", opt));
+			} else if (knownOpts[option] === Boolean && typeof (parsed[opt]) !== 'boolean') {
+				breakExecution(util.format("The option '%s' does not accept values.", opt));
 			}
 		});
 	}

--- a/options.ts
+++ b/options.ts
@@ -3,6 +3,8 @@
 
 import path = require("path");
 import helpers = require("./../common/helpers");
+import osenv = require("osenv");
+var yargs: any = require("yargs");
 
 var knownOpts: any = {
 		"log": String,
@@ -20,11 +22,12 @@ var knownOpts: any = {
 		"p": "path"
 	};
 
-var parsed = helpers.getParsedOptions(knownOpts, shorthands);
-
+var parsed = yargs.argv;
 Object.keys(parsed).forEach((opt) => exports[opt] = parsed[opt]);
+var defaultProfileDir = path.join(osenv.home(), ".appbuilder-cli");
+exports["profile-dir"] = exports["profile-dir"] || defaultProfileDir;
 
 exports.knownOpts = knownOpts;
-
+exports.shorthands = shorthands
 declare var exports:any;
 export = exports;


### PR DESCRIPTION
Remove validation of common options and move the logic of validation outside of lib. This is required as when you pass option that's not common, but is still valid, validating the common options would cause process exit. Add validation of shorthands options in validateYargsArguments. Add validation for boolean options - if you pass value to a boolean known option, the process exits (the boolean options doesn't accept values, they are included or not, for example --help).
