### PR TITLE
Add validation for number params

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -70,9 +70,17 @@ export function getParsedOptions(options: any, shorthands: any) {
 		yargs.alias(key, shorthands[key]);
 	});
 
-	var parsed = yargs.argv;
-	validateYargsArguments(parsed, options, shorthands);
+	var argv = yargs.argv;
+	var parsed = {};
+	_.each(_.keys(argv), (opt) => {
+		if (typeof argv[opt] === "number") {
+			parsed[opt] = argv[opt].toString();
+		} else {
+			parsed[opt] = argv[opt];
+		}
+	});
 
+	validateYargsArguments(parsed, options, shorthands);
 	return parsed;
 }
 
@@ -85,8 +93,8 @@ export function validateYargsArguments(parsed: any, knownOpts: any, shorthands: 
 				breakExecution(util.format("The option '%s' is not supported. To see command's options, use '$ appbuilder %s --help'. To see all commands use '$ appbuilder help'.", opt, process.argv[2]));
 			} else if (knownOpts[option] !== Boolean && typeof (parsed[opt]) === 'boolean') {
 				breakExecution(util.format("The option '%s' requires a value.", opt));
-			} else if (knownOpts[option] === String && parsed[opt].trim().length === 0) {
-				breakExecution(util.format("The option '%s' requires nonempty value.", opt));
+			} else if (knownOpts[option] === String && isNullOrWhitespace(parsed[opt])) {
+				breakExecution(util.format("The option '%s' requires non-empty value.", opt));
 			} else if (knownOpts[option] === Boolean && typeof (parsed[opt]) !== 'boolean') {
 				breakExecution(util.format("The option '%s' does not accept values.", opt));
 			}

--- a/options.ts
+++ b/options.ts
@@ -41,7 +41,13 @@ exports.setProfileDir = (profileDir: string) => {
 exports.knownOpts = knownOpts;
 exports.shorthands = shorthands
 
-Object.keys(parsed).forEach((opt) => exports[opt] = parsed[opt]);
+Object.keys(parsed).forEach((opt) => {
+	if (typeof (parsed[opt]) === "number") {
+		exports[opt] = parsed[opt].toString();
+	} else {
+		exports[opt] = parsed[opt];
+	}
+});
 
 declare var exports: any;
 export = exports;


### PR DESCRIPTION
Remove trim call for parsed[opt] as it is causing exception when the passed argument is not string. Add validation for null value, undefined value - if such is passed to a parameter, that should be string, the process is stopped. Add validation for strings - use isNullOrWhitespace function to check if the passed string is valid. Add validation for numbers - if the passed argument is number and it is NaN or Infinity, the process is stopped.

http://teampulse.telerik.com/view#item/276923
