### PR TITLE
Add validation for command parameters

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -11,7 +11,9 @@ $injector.require("logger", "./common/logger");
 $injector.require("dispatcher", "./common/dispatchers");
 $injector.require("commandDispatcher", "./common/dispatchers");
 
+$injector.require("stringParameter", "./common/command-params");
 $injector.require("commandsService", "./common/services/commands-service");
+
 $injector.require("cancellation", "./common/services/cancellation");
 $injector.require("analyticsService", "./common/services/analytics-service");
 $injector.require("hooksService", "./common/services/hooks-service");
@@ -23,7 +25,7 @@ $injector.require("projectHelper", "./common/project-helper");
 $injector.require("propertiesParser", "./common/properties-parser");
 
 $injector.requireCommand(["help", "/?"], "./common/commands/help");
-$injector.requireCommand("feature-usage-tracking", "./common/services/analytics-service");
+$injector.requireCommand("feature-usage-tracking", "./common/commands/analytics");
 
 $injector.require("iOSCore", "./common/mobile/ios/ios-core");
 $injector.require("coreFoundation", "./common/mobile/ios/ios-core");

--- a/command-params.ts
+++ b/command-params.ts
@@ -1,0 +1,21 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+export class StringCommandParameter implements ICommandParameter {
+	constructor(public mandatory?: boolean, public errorMessage?: string) { }
+
+	public validate(validationValue: string): IFuture<boolean> {
+		return (() => {
+			if(!validationValue) {
+				if(this.errorMessage) {
+					$injector.resolve("errors").fail(this.errorMessage);
+				}
+
+				return false;
+			}
+
+			return true;
+		}).future<boolean>()();
+	}
+}
+$injector.register("stringParameter", StringCommandParameter);

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -1,0 +1,53 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import util = require("util");
+
+export class AnalyticsCommand implements ICommand {
+	constructor(private $analyticsService: IAnalyticsService,
+		private $logger: ILogger,
+		private $errors: IErrors) { }
+
+	execute(args: string[]): IFuture<void> {
+		return(() => {
+			var arg = args[0];
+			switch(arg) {
+				case "enable":
+					this.$analyticsService.setAnalyticsStatus(true).wait();
+					this.$logger.info("Feature usage tracking is now enabled.");
+					break;
+				case "disable":
+					this.$analyticsService.disableAnalytics().wait();
+					this.$logger.info("Feature usage tracking is now disabled.");
+					break;
+				case "status":
+				case undefined:
+					this.$logger.out(this.$analyticsService.getStatusMessage().wait());
+					break;
+				default:
+					this.$errors.fail(util.format("The value '%s' is not valid. Valid values are 'enable', 'disable' and 'status'.", arg));
+			}
+		}).future<void>()();
+	}
+
+	allowedParameters = [new AnalyticsCommandParameter(this.$errors)];
+}
+$injector.registerCommand("feature-usage-tracking", AnalyticsCommand);
+
+export class AnalyticsCommandParameter implements ICommandParameter {
+	constructor(private $errors: IErrors) { }
+	mandatory = false;
+	validate(validationValue: string): IFuture<boolean> {
+		return (() => {
+			switch(validationValue) {
+				case "enable":
+				case "disable":
+				case "status":
+				case undefined:
+					return true;
+				default:
+					this.$errors.fail(util.format("The value '%s' is not valid. Valid values are 'enable', 'disable' and 'status'.", validationValue));
+			}
+		}).future<boolean>()();
+	}
+}

--- a/commands/help.ts
+++ b/commands/help.ts
@@ -3,6 +3,7 @@
 
 import path = require("path");
 import util = require("util");
+import commandParams = require("../command-params");
 
 export class HelpCommand implements ICommand {
 	constructor(private $logger: ILogger,
@@ -12,6 +13,7 @@ export class HelpCommand implements ICommand {
 		private $staticConfig: Config.IStaticConfig) {}
 
 	public enableHooks = false;
+	public allowedParameters: ICommandParameter[] = [new commandParams.StringCommandParameter(), new commandParams.StringCommandParameter()];
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -168,6 +168,9 @@ interface IAnalyticsService {
 	checkConsent(featureName: string): IFuture<void>;
 	trackFeature(featureName: string): IFuture<void>;
 	trackException(exception: any, message: string): IFuture<void>;
+	setAnalyticsStatus(enabled: boolean): IFuture<void>;
+	disableAnalytics(): IFuture<void>;
+	getStatusMessage(): IFuture<string>;
 }
 
 interface IPrompter extends IDisposable {
@@ -206,4 +209,11 @@ interface IHook {
 interface ITypeScriptCompilationService {
 	initialize(typeScriptFiles: string[]): void;
 	compileAllFiles(): IFuture<void>;
+}
+
+interface IRemoteProjectService {
+	makeTapServiceCall<T>(call: () => IFuture<T>): IFuture<T>;
+	getProjectProperties(projectName: string): IFuture<any>;
+	getProjects(): IFuture<any>;
+	getProjectName(projectId: string): IFuture<string>;
 }

--- a/definitions/commands.d.ts
+++ b/definitions/commands.d.ts
@@ -1,5 +1,13 @@
 interface ICommand extends ICommandOptions {
 	execute(args: string[]): IFuture<void>;
+	allowedParameters: ICommandParameter[];
+
+	// Implement this method in cases when you want to have your own logic for validation. In case you do not implement it,
+	// the command will be evaluated from CommandsService's canExecuteCommand method.
+	// One possible case where you can use this method is when you have two commandParameters, neither of them is mandatory,
+	// but at least one of them is required. Used in prop|add, prop|set, etc. commands as their logic is complicated and 
+	// default validation in CommandsService is not applicable.
+	canExecute?(args: string[]): IFuture<boolean>;
 }
 
 interface ISimilarCommand {
@@ -8,3 +16,8 @@ interface ISimilarCommand {
 }
 
 interface ICommandArgument { }
+
+interface ICommandParameter {
+	mandatory: boolean;
+	validate(value: string, errorMessage?: string): IFuture<boolean>;
+}

--- a/definitions/yok.d.ts
+++ b/definitions/yok.d.ts
@@ -13,6 +13,7 @@ interface IInjector extends IDisposable {
 	dynamicCallRegex: RegExp;
 	dynamicCall(call: string, args?: any[]): any;
 	isDefaultCommand(commandName: string): boolean;
+	isValidHierarchicalCommand(commandName: string, commandArguments: string[]): boolean;
 	getChildrenCommandsNames(commandName: string): string[];
 }
 

--- a/helpers.ts
+++ b/helpers.ts
@@ -148,20 +148,6 @@ export function toBoolean(str: string) {
 	return str === "true";
 }
 
-export function registerCommand(module: string, commandName: any, executor: (module: any, args: string[]) => IFuture<void>, opts?: ICommandOptions) {
-	var factory = ():ICommand => {
-		return {
-			execute: (args:string[]):IFuture<void> => {
-				var mod = $injector.resolve(module);
-				return executor(mod, args);
-			},
-			disableAnalytics: opts && opts.disableAnalytics
-		};
-	};
-
-	$injector.registerCommand(commandName, factory);
-}
-
 export function block(operation: () => void): void {
 	if (isInteractive()) {
 		process.stdin.setRawMode(false);

--- a/services/analytics-service.ts
+++ b/services/analytics-service.ts
@@ -22,7 +22,7 @@ export class AnalyticsService implements IAnalyticsService {
 
 	public checkConsent(featureName: string): IFuture<void> {
 		return ((): void => {
-			if (this.$analyticsSettingsService.canDoRequest().wait()) {
+			if(this.$analyticsSettingsService.canDoRequest().wait()) {
 
 				if(this.isNotConfirmed().wait() && helpers.isInteractive() && !_.contains(this.excluded, featureName)) {
 					this.$logger.out("Do you want to help us improve " +
@@ -43,7 +43,7 @@ export class AnalyticsService implements IAnalyticsService {
 			if(this.$analyticsSettingsService.canDoRequest().wait()) {
 				try {
 					this.start().wait();
-					if (this._eqatecMonitor) {
+					if(this._eqatecMonitor) {
 						var category = options.client ||
 							(helpers.isInteractive() ? "CLI" : "Non-interactive");
 						this._eqatecMonitor.trackFeature(category + "." + featureName);
@@ -61,11 +61,11 @@ export class AnalyticsService implements IAnalyticsService {
 				try {
 					this.start().wait();
 
-					if (this._eqatecMonitor) {
+					if(this._eqatecMonitor) {
 						this._eqatecMonitor.trackException(exception, message);
 					}
 
-				} catch (e) {
+				} catch(e) {
 					this.$logger.trace("Analytics exception: '%s'", e.toString());
 				}
 			}
@@ -73,7 +73,7 @@ export class AnalyticsService implements IAnalyticsService {
 	}
 
 	public analyticsCommand(arg: string): IFuture<any> {
-		return(() => {
+		return (() => {
 			switch(arg) {
 				case "enable":
 					this.setAnalyticsStatus(true).wait();
@@ -94,7 +94,7 @@ export class AnalyticsService implements IAnalyticsService {
 		}).future<any>()();
 	}
 
-	private setAnalyticsStatus(enabled: boolean): IFuture<void> {
+	public setAnalyticsStatus(enabled: boolean): IFuture<void> {
 		this.analyticsStatus = enabled ? AnalyticsStatus.enabled : AnalyticsStatus.disabled;
 		return this.$userSettingsService.saveSetting(this.$staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, enabled.toString());
 	}
@@ -104,7 +104,7 @@ export class AnalyticsService implements IAnalyticsService {
 			if(!this.analyticsStatus) {
 				var trackFeatureUsage = this.$userSettingsService.getSettingValue<string>(this.$staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME).wait();
 
-				if (trackFeatureUsage) {
+				if(trackFeatureUsage) {
 					var isEnabled = helpers.toBoolean(trackFeatureUsage);
 					if(isEnabled) {
 						this.analyticsStatus = AnalyticsStatus.enabled;
@@ -121,7 +121,7 @@ export class AnalyticsService implements IAnalyticsService {
 	}
 
 	private start(): IFuture<void> {
-		return(() => {
+		return (() => {
 			if(this._eqatecMonitor || this.isDisabled().wait()) {
 				return;
 			}
@@ -141,7 +141,7 @@ export class AnalyticsService implements IAnalyticsService {
 			this._eqatecMonitor = global._eqatec.createMonitor(settings);
 
 			var guid = this.$userSettingsService.getSettingValue(this.$staticConfig.ANALYTICS_INSTALLATION_ID_SETTING_NAME).wait();
-			if (!guid) {
+			if(!guid) {
 				guid = helpers.createGUID(false);
 				this.$userSettingsService.saveSetting(this.$staticConfig.ANALYTICS_INSTALLATION_ID_SETTING_NAME, guid).wait();
 			}
@@ -150,7 +150,7 @@ export class AnalyticsService implements IAnalyticsService {
 
 			try {
 				this._eqatecMonitor.setUserID(this.$analyticsSettingsService.getUserId().wait());
-			} catch (e) {
+			} catch(e) {
 				// user not logged in. don't care.
 			}
 
@@ -170,8 +170,8 @@ export class AnalyticsService implements IAnalyticsService {
 		return userAgentString;
 	}
 
-	private disableAnalytics(): IFuture<void> {
-		return(() => {
+	public disableAnalytics(): IFuture<void> {
+		return (() => {
 			this.setAnalyticsStatus(false).wait();
 
 			if(this._eqatecMonitor) {
@@ -194,8 +194,8 @@ export class AnalyticsService implements IAnalyticsService {
 		}).future<boolean>()();
 	}
 
-	private getStatusMessage(): IFuture<string> {
-		if (options.json) {
+	public getStatusMessage(): IFuture<string> {
+		if(options.json) {
 			return this.getJsonStatusMessage();
 		}
 
@@ -204,9 +204,9 @@ export class AnalyticsService implements IAnalyticsService {
 
 	private getHumanReadableStatusMessage(): IFuture<string> {
 		return (() => {
-			var status:string = null;
+			var status: string = null;
 
-			if (this.isNotConfirmed().wait()) {
+			if(this.isNotConfirmed().wait()) {
 				status = "disabled until confirmed";
 			} else {
 				status = AnalyticsStatus[this.getAnalyticsStatus().wait()];
@@ -225,9 +225,6 @@ export class AnalyticsService implements IAnalyticsService {
 	}
 }
 $injector.register("analyticsService", AnalyticsService);
-
-helpers.registerCommand("analyticsService", "feature-usage-tracking",
-	(analyticsService: AnalyticsService, args: string[]) => analyticsService.analyticsCommand(args[0]));
 
 enum AnalyticsStatus {
 	enabled,


### PR DESCRIPTION
Add validation for the parameters that each command accepts. Add logic to check if command has mandatory parameters and all of them are provided - if any of them is missing, command is not executed. Add logic to validate all arguments passed to command - if the command does not accept arguments, but there are some passed to it, it is not executed. Add ICommandParameter interface to describe command parameter. Add allowedParameters property to ICommand interface. Add canExecute method to ICommand interface. It is not mandatory to implement it and it is used when the command will validate the parameters on its own. The common validation is implemented in CommandsService.

ICommandParameter describes one parameter that the command accepts. It can be mandatory for the command or not. That's why I've added mandatory boolean parameter to the interface. Each parameter have its own logic for valid values, that's why ICommandParameter has validate method. It is called from the CommandsService when the arguments are validated. CommandsService itself tries to validate all command arguments. One special case is when the command is hierarchical. In this situation the root command is validated first, but it doesn't have own definition, so it doesn't have allowed parameters. That's why CommandsService checks if the command is valid hierarchical command.  If command has canExecute method implemented, CommandsService will use it to validate the arguments. If not, it will try to validate all passed command line arguments with the allowed parameters of the command, by checking their count, calling validate method, etc.

Each command has different number of allowed parameters. In most of the cases the command parameter is string and the only requirement for it is to be non-empty. That's why new StringCommandParameter class is added. It is used to define such parameters. In case the parameter has more complicated logic, new class, that implements ICommandParameter is added for it.
