### PR TITLE
Fix setting of profile-dir

### DIFF
--- a/options.ts
+++ b/options.ts
@@ -2,7 +2,6 @@
 "use strict";
 
 import path = require("path");
-import helpers = require("./../common/helpers");
 import osenv = require("osenv");
 var yargs: any = require("yargs");
 
@@ -16,18 +15,34 @@ var knownOpts: any = {
 		"watch": Boolean,
 		"avd": String,
 		"profile-dir": String,
+		// If you pass value with dash, yargs adds it to yargs.argv in two ways:
+		// with dash and without dash, replacing first symbol after it with its toUpper equivalent
+		"profileDir": String,
 	},
 	shorthands = {
 		"v": "verbose",
 		"p": "path"
-	};
+	},
+	parsed = yargs.argv;
 
-var parsed = yargs.argv;
-Object.keys(parsed).forEach((opt) => exports[opt] = parsed[opt]);
-var defaultProfileDir = path.join(osenv.home(), ".appbuilder-cli");
-exports["profile-dir"] = exports["profile-dir"] || defaultProfileDir;
+exports.setProfileDir = (profileDir: string) => {
+	var defaultProfileDir = path.join(osenv.home(), profileDir);
+	var selectedProfileDir: string = parsed["profile-dir"] || parsed["profileDir"] || defaultProfileDir;
+
+	// Add the value to yargs arguments.
+	parsed["profile-dir"] = selectedProfileDir;
+	parsed["profileDir"] = selectedProfileDir;
+
+	// Add the value to exported options.
+	exports["profile-dir"] = selectedProfileDir;
+	exports["profileDir"] = selectedProfileDir;
+}
 
 exports.knownOpts = knownOpts;
 exports.shorthands = shorthands
-declare var exports:any;
+
+Object.keys(parsed).forEach((opt) => exports[opt] = parsed[opt]);
+
+declare var exports: any;
 export = exports;
+


### PR DESCRIPTION
Add profileDir to knownOptions to prevent breaking of process when --profile-dir is passed on command line. The reason for breaking was yargs behavior, that adds values with dash as two keys - one with dash (profile-dir) and another one with removed dash and fist letter after it is replaced with its upper value.
Add setProfileDir function to options. It is used to set the profileDir based on client's default profile dir. The function adds the value to yargs.argv and to the exported options, so any code that requires options or yargs.argv will be able to use profile-dir.

Fixes http://teampulse.telerik.com/view#item/277092
