### PR TITLE
Fix android emulator when more than one device is used

### DIFF
--- a/child-process.ts
+++ b/child-process.ts
@@ -7,10 +7,6 @@ import util = require("util");
 export class ChildProcess implements IChildProcess {
 	constructor(private $logger: ILogger) {}
 
-	private _execFile = Future.wrap((command: string, args: string[], callback: (error: any, stdout: NodeBuffer) => void) => {
-		return child_process.execFile(command, args, callback);
-	});
-
 	public exec(command: string): IFuture<any> {
 		var future = new Future<any>();
 		child_process.exec(command, (error: Error, stdout: NodeBuffer, stderr: NodeBuffer) => {
@@ -28,7 +24,16 @@ export class ChildProcess implements IChildProcess {
 
 	public execFile(command: string, args: string[]): IFuture<any> {
 		this.$logger.debug("execFile: %s %s", command, args.join(" "));
-		return this._execFile(command, args);
+		var future = new Future<any>();
+		var result = child_process.execFile(command, args, (error: any, stdout: NodeBuffer) => {
+			if(error) {
+				future.throw(error);
+			} else {
+				future.return(stdout);
+			}
+		});
+
+		return future;
 	}
 
 	public spawn(command: string, args?: string[], options?: any): any {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -172,7 +172,6 @@ declare module Mobile {
 	}
 
 	interface IEmulatorOptions {
-		image?: string;
 		stderrFilePath?: string;
 		stdoutFilePath?: string;
 		deviceFamily?: string;

--- a/helpers.ts
+++ b/helpers.ts
@@ -5,6 +5,7 @@ import path = require("path");
 import util = require("util");
 import _ = require("underscore"); 
 var uuid = require("node-uuid");
+var options = require("./options");
 
 export function createGUID(useBraces: boolean = true) {
 	var output: string;
@@ -185,4 +186,11 @@ export function isNullOrWhitespace(input: string): boolean {
 	}
 
 	return input.replace(/\s/gi, '').length < 1;
+}
+
+export function printInfoMessageOnSameLine(message: string): void {
+	if(options.log === "info") {
+		var logger: ILogger = $injector.resolve("logger");
+		logger.write(message);
+	}
 }

--- a/options.ts
+++ b/options.ts
@@ -18,6 +18,7 @@ var knownOpts: any = {
 		// If you pass value with dash, yargs adds it to yargs.argv in two ways:
 		// with dash and without dash, replacing first symbol after it with its toUpper equivalent
 		"profileDir": String,
+		"retryCount": String
 	},
 	shorthands = {
 		"v": "verbose",


### PR DESCRIPTION
Remove adb wait-for-device call as it raises error when there's more than one device and/or emulator currently running. Use adb -s <emulatorId> instead of adb -e, so having more than one device currently running will not raise errors. Add printing of "Waiting for initialization......" when logging level is info and adding "." for each retry cycle. Add --retryCount option, so you can define the exact number of retries that will be executed before the emulate operation fails.

Fixes: 
http://teampulse.telerik.com/view#item/277469
https://github.com/NativeScript/nativescript-cli/issues/116
