### PR TITLE
Fix unnecessary adb server restarting

### DIFF
--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -67,7 +67,7 @@ class AndroidEmulatorServices implements Mobile.IEmulatorPlatformServices {
 
 			// often the running adb server does not recognise that the emulator is up and never reports new device. Patch through this obstacle
 			for(var retry = 0; retry < retryCount; retry++) {
-				if(runningEmulators.length > initiallyRunningEmulators.length) {
+				if(runningEmulators.length > initiallyRunningEmulators.length || (runningEmulators.length > 0 && !options.avd)) {
 					break;
 				}
 


### PR DESCRIPTION
In case the user had not specified image (--avd option is not used) when using emulate command, there's no need to retry restarting adb server if there's at least one running emulator. We can use it directly.
