### PR TITLE
Add correct waits in dispatcher

### DIFF
--- a/dispatchers.ts
+++ b/dispatchers.ts
@@ -76,7 +76,8 @@ class FutureDispatcher implements IFutureDispatcher {
 		this.actions = new queue.Queue<any>();
 
 		while(true) {
-			this.actions.dequeue().wait();
+			var action = this.actions.dequeue().wait();
+			action.wait();
 		}
 	}
 


### PR DESCRIPTION
Rollback commit: 3bbc0e3b8fa4b3496f72a473ab9ae99c4f90a214 dequeue method returns future, so it should have wait(). Also the action should have wait(). So we need two waits. This was breaking remote command.

Fixes: http://teampulse.telerik.com/view#item/278119 
