### PR TITLE
Release console when ios-sim cannot start

### DIFF
--- a/errors.ts
+++ b/errors.ts
@@ -91,7 +91,7 @@ export class Errors implements IErrors {
 		var exception: any = new (<any>Exception)();
 		exception.name = opts.name || "Exception";
 		exception.message = util.format.apply(null, args);
-		exception.stack = new Error(exception.message).stack;
+		exception.stack = opts.hideCallStack ? null : new Error(exception.message).stack;
 		exception.errorCode = opts.errorCode || ErrorCodes.UNKNOWN;
 		exception.suppressCommandHelp = opts.suppressCommandHelp;
 


### PR DESCRIPTION
Add call for ios-sim --version in order to determine if Xcode and ios-sim versions are compatible. In case they are not, the command will return error - catch it and break the whole execution. Print the error message from ios-sim --version, but remove its stack first as any throw in child_process.stderr.on(...) prints its callstack automatically. So new option is added to errors - hideCallStack. In case it is true, the stack option is set to null.

Fixes: http://teampulse.telerik.com/view#item/277714
