### PR TITLE
Replace retryCount with timeout

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -194,3 +194,8 @@ export function printInfoMessageOnSameLine(message: string): void {
 		logger.write(message);
 	}
 }
+
+export function getCurrentEpochTime(): number {
+	var dateTime = new Date();
+	return dateTime.getTime();
+}

--- a/options.ts
+++ b/options.ts
@@ -18,7 +18,7 @@ var knownOpts: any = {
 		// If you pass value with dash, yargs adds it to yargs.argv in two ways:
 		// with dash and without dash, replacing first symbol after it with its toUpper equivalent
 		"profileDir": String,
-		"retryCount": String
+		"timeout": String
 	},
 	shorthands = {
 		"v": "verbose",


### PR DESCRIPTION
When starting Android emulator we were using --retryCount option, which is difficult to be explained. It it replaced with --timeout option, which is the allowed time to start the emulator device(wait to boot). The default value is 120 seconds. retryCount option is removed as it is not used anymore.

http://teampulse.telerik.com/view#item/278845
