### PR TITLE
Fix StringCommandParameter

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -12,6 +12,8 @@ $injector.require("dispatcher", "./common/dispatchers");
 $injector.require("commandDispatcher", "./common/dispatchers");
 
 $injector.require("stringParameter", "./common/command-params");
+$injector.require("stringParameterBuilder", "./common/command-params");
+
 $injector.require("commandsService", "./common/services/commands-service");
 
 $injector.require("cancellation", "./common/services/cancellation");

--- a/command-params.ts
+++ b/command-params.ts
@@ -2,7 +2,8 @@
 "use strict";
 
 export class StringCommandParameter implements ICommandParameter {
-	constructor(public mandatory?: boolean, public errorMessage?: string) { }
+	public mandatory = false;
+	public errorMessage: string;
 
 	public validate(validationValue: string): IFuture<boolean> {
 		return (() => {
@@ -19,3 +20,14 @@ export class StringCommandParameter implements ICommandParameter {
 	}
 }
 $injector.register("stringParameter", StringCommandParameter);
+
+export class StringParameterBuilder implements IStringParameterBuilder {
+	public createMandatoryParameter(errorMsg: string) {
+		var commandParameter = new StringCommandParameter();
+		commandParameter.mandatory = true;
+		commandParameter.errorMessage = errorMsg;
+
+		return commandParameter;
+	}
+}
+$injector.register("stringParameterBuilder", StringParameterBuilder);

--- a/definitions/commands.d.ts
+++ b/definitions/commands.d.ts
@@ -21,3 +21,7 @@ interface ICommandParameter {
 	mandatory: boolean;
 	validate(value: string, errorMessage?: string): IFuture<boolean>;
 }
+
+interface IStringParameterBuilder {
+	createMandatoryParameter(errorMsg: string): ICommandParameter;
+}


### PR DESCRIPTION
When injector tries to resolve StringCommandParamater, it raises error as it's unable to use the current constructor. Add StringParameterBuilder class that is used to generate string parameters. Add createMandatoryParameter method to it, so it will generate mandatory parameter with specified error message. Add IStringParameterBuilder interface.
The idea is to use stringParameter from injector resolver when the parameter will not be mandatory and to use the builder when a more complicated logic is needed.
Fixes http://teampulse.telerik.com/view#item/279466
