### PR TITLE
Update commands service error message

### DIFF
--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -107,7 +107,7 @@ export class CommandsService implements ICommandsService {
 			if(mandatoryParams.length > 0) {
 				// If command has more mandatory params than the passed ones, we shouldn't execute it
 				if(mandatoryParams.length > commandArguments.length) {
-					this.$errors.fail("You need to provide all required parameters.");
+					this.$errors.fail("You need to provide all the required parameters.");
 				}
 
 				// If we reach here, the commandArguments are at least as much as mandatoryParams. Now we should verify that we have each of them.


### PR DESCRIPTION
Update the message which is shown when the arguments passed on the command line are less than the mandatory params of the command.
