### PR TITLE
Change setting of profile-dir

### DIFF
--- a/options.ts
+++ b/options.ts
@@ -2,7 +2,6 @@
 "use strict";
 
 import path = require("path");
-import osenv = require("osenv");
 var yargs: any = require("yargs");
 
 var knownOpts: any = {
@@ -26,8 +25,7 @@ var knownOpts: any = {
 	},
 	parsed = yargs.argv;
 
-exports.setProfileDir = (profileDir: string) => {
-	var defaultProfileDir = path.join(osenv.home(), profileDir);
+exports.setProfileDir = (defaultProfileDir: string) => {
 	var selectedProfileDir: string = parsed["profile-dir"] || parsed["profileDir"] || defaultProfileDir;
 
 	// Add the value to yargs arguments.


### PR DESCRIPTION
DefaultValue is passed to the setProfileDir method. Different CLI-s have different defaultProfileDirs. setProfileDir method will use the passed on the command line profile-dir or the default one passed as parameter to the function.
