### PR TITLE
Fix tabtab for -- options

### DIFF
--- a/definitions/options-service.d.ts
+++ b/definitions/options-service.d.ts
@@ -1,0 +1,3 @@
+interface IOptionsService {
+	getKnownOptions(): string[];
+}

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -201,7 +201,9 @@ export class CommandsService implements ICommandsService {
 				}
 
 				if(data.last.startsWith("--")) {
-					return tabtab.log(Object.keys(require("./options").knownOpts), data, "--");
+					// Resolve optionsService here. It is not part of common lib, because we need all knownOptions for each CLI.
+					var optionsService: IOptionsService = $injector.resolve("optionsService");
+					return tabtab.log(optionsService.getKnownOptions(), data, "--");
 				}
 
 				if(_.contains(commandsWithPlatformArgument, data.prev)) {


### PR DESCRIPTION
Add IOptionsService interface with one method - getKnownOptions. This method is used in commands service in order to get full list of supported -- options. As each CLI have its own list of knownOptions and the mobile lib has only some of them, the implementation of the interface has to be outside of the lib. This way we can use autocomplete for all available options, not only for the common ones.
