### PR TITLE
Validate iOS appstore commands

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -42,6 +42,7 @@ $injector.require("signal", "./events/signal");
 $injector.require("deviceFound", "./common/mobile/mobile-core/device-discovery");
 $injector.require("deviceLost", "./common/mobile/mobile-core/device-discovery");
 
+$injector.require("iTunesValidator", "./common/validators/iTunes-validator");
 $injector.require("deviceDiscovery", "./common/mobile/mobile-core/device-discovery");
 $injector.require("iOSDeviceDiscovery", "./common/mobile/mobile-core/device-discovery");
 $injector.require("androidDeviceDiscovery", "./common/mobile/mobile-core/device-discovery");

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -51,6 +51,10 @@ declare module Mobile {
 		platform: string;
 	}
 
+	interface IiTunesValidator {
+		getError(): IFuture<string>;
+	}
+
 	interface IiOSCore {
 		getCoreFoundationLibrary(): any;
 		getMobileDeviceLibrary(): any;

--- a/mobile/mobile-core/device-discovery.ts
+++ b/mobile/mobile-core/device-discovery.ts
@@ -150,47 +150,8 @@ class IOSDeviceDiscoveryStub extends DeviceDiscovery {
 	}
 }
 
-class ITunesValidator {
-	private static NOT_INSTALLED_iTUNES_ERROR_MESSAGE = "iTunes is not installed. Install it on your system and run this command again.";
-
-	constructor(private $fs: IFileSystem) { }
-
-	public getError(): IFuture<string> {
-		return (() => {
-			if(hostInfo.isWindows64()) {
-				if(process.arch === "x64") {
-					return "To be able to run operations on connected iOS devices, install the 32-bit version of Node.js.";
-				}
-			}
-
-			var coreFoundationDir = "";
-			var mobileDeviceDir = "";
-
-			if(hostInfo.isWindows()) {
-				var commonProgramFiles = hostInfo.isWindows64() ?  process.env["CommonProgramFiles(x86)"] : process.env.CommonProgramFiles;
-				coreFoundationDir = path.join(commonProgramFiles, "Apple", "Apple Application Support");
-				mobileDeviceDir = path.join(commonProgramFiles, "Apple", "Mobile Device Support");
-			} else if(hostInfo.isDarwin()) {
-				coreFoundationDir = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
-				mobileDeviceDir = "/System/Library/PrivateFrameworks/MobileDevice.framework/MobileDevice";
-			}
-
-			var existsCoreFoundation = this.$fs.exists(coreFoundationDir).wait();
-			var existsMobileDevice = this.$fs.exists(mobileDeviceDir).wait();
-
-			if(!existsCoreFoundation || !existsMobileDevice) {
-				return ITunesValidator.NOT_INSTALLED_iTUNES_ERROR_MESSAGE;
-			}
-
-			return null;
-
-		}).future<string>()();
-	}
-}
-
-$injector.register("iOSDeviceDiscovery", ($errors: IErrors, $logger: ILogger, $fs: IFileSystem, $injector: IInjector) => {
-	var iTunesValidator = new ITunesValidator($fs);
-	var error = iTunesValidator.getError().wait();
+$injector.register("iOSDeviceDiscovery", ($errors: IErrors, $logger: ILogger, $fs: IFileSystem, $injector: IInjector, $iTunesValidator: Mobile.IiTunesValidator) => {
+	var error = $iTunesValidator.getError().wait();
 	var result: Mobile.IDeviceDiscovery = null;
 
 	if(error) {

--- a/validators/iTunes-validator.ts
+++ b/validators/iTunes-validator.ts
@@ -1,0 +1,45 @@
+///<reference path="../../.d.ts"/>
+
+"use strict";
+
+import path = require("path");
+import hostInfo = require("../host-info");
+
+export class ITunesValidator implements Mobile.IiTunesValidator {
+	private static NOT_INSTALLED_iTUNES_ERROR_MESSAGE = "iTunes is not installed. Install it on your system and run this command again.";
+
+	constructor(private $fs: IFileSystem) { }
+
+	public getError(): IFuture<string> {
+		return (() => {
+			if(hostInfo.isWindows64()) {
+				if(process.arch === "x64") {
+					return "To be able to run operations on connected iOS devices, install the 32-bit version of Node.js.";
+				}
+			}
+
+			var coreFoundationDir = "";
+			var mobileDeviceDir = "";
+
+			if(hostInfo.isWindows()) {
+				var commonProgramFiles = hostInfo.isWindows64() ?  process.env["CommonProgramFiles(x86)"] : process.env.CommonProgramFiles;
+				coreFoundationDir = path.join(commonProgramFiles, "Apple", "Apple Application Support");
+				mobileDeviceDir = path.join(commonProgramFiles, "Apple", "Mobile Device Support");
+			} else if(hostInfo.isDarwin()) {
+				coreFoundationDir = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+				mobileDeviceDir = "/System/Library/PrivateFrameworks/MobileDevice.framework/MobileDevice";
+			}
+
+			var existsCoreFoundation = this.$fs.exists(coreFoundationDir).wait();
+			var existsMobileDevice = this.$fs.exists(mobileDeviceDir).wait();
+
+			if(!existsCoreFoundation || !existsMobileDevice) {
+				return ITunesValidator.NOT_INSTALLED_iTUNES_ERROR_MESSAGE;
+			}
+
+			return null;
+
+		}).future<string>()();
+	}
+}
+$injector.register("iTunesValidator", ITunesValidator);


### PR DESCRIPTION
Add IiTunesValidator interface with a single method - getError. Chang ITunesValidator class to implement this interface and move the class to new file.
The validator is required when you are using x64 bit Node on Windows - in this case we are unable to deploy on iOS device (also unable to use livesync).
