### PR TITLE
Share device and device-log stream commands

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -28,6 +28,8 @@ $injector.require("propertiesParser", "./common/properties-parser");
 
 $injector.requireCommand(["help", "/?"], "./common/commands/help");
 $injector.requireCommand("feature-usage-tracking", "./common/commands/analytics");
+$injector.requireCommand("device|*list", "./common/commands/list-devices");
+$injector.requireCommand("device|log", "./common/commands/device-log-stream");
 
 $injector.require("iOSCore", "./common/mobile/ios/ios-core");
 $injector.require("coreFoundation", "./common/mobile/ios/ios-core");

--- a/commands/device-log-stream.ts
+++ b/commands/device-log-stream.ts
@@ -1,0 +1,30 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import options = require("./../options");
+import helpers = require("./../helpers");
+
+export class OpenDeviceLogStreamCommand implements ICommand {
+	private static NOT_SPECIFIED_DEVICE_ERROR_MESSAGE = "More than one device found. Specify device explicitly.";
+
+	constructor(private $devicesServices: Mobile.IDevicesServices,
+		private $errors: IErrors,
+		private $commandsService: ICommandsService) { }
+
+	allowedParameters: ICommandParameter[] = [];
+
+	public execute(args: string[]): IFuture<void> {
+		return (() => {
+			this.$devicesServices.initialize(undefined, options.device, {skipInferPlatform: true}).wait();
+
+			if (this.$devicesServices.deviceCount > 1) {
+				this.$commandsService.executeCommand("device", []).wait();
+				this.$errors.fail(OpenDeviceLogStreamCommand.NOT_SPECIFIED_DEVICE_ERROR_MESSAGE);
+			}
+
+			var action = (device: Mobile.IDevice) =>  { return (() => device.openDeviceLogStream()).future<void>()(); };
+			this.$devicesServices.execute(action).wait();
+		}).future<void>()();
+	}
+}
+$injector.registerCommand("device|log", OpenDeviceLogStreamCommand);

--- a/commands/list-devices.ts
+++ b/commands/list-devices.ts
@@ -1,0 +1,43 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import util = require("util");
+import options = require("./../options");
+import commandParams = require("../command-params");
+
+export class ListDevicesCommand implements ICommand {
+	constructor(private $devicesServices: Mobile.IDevicesServices,
+		private $logger: ILogger,
+		private $stringParameter: ICommandParameter) { }
+
+	allowedParameters = [this.$stringParameter];
+
+	public execute(args: string[]): IFuture<void> {
+		return (() => {
+			var index = 1;
+			this.$devicesServices.initialize(args[0], null, {skipInferPlatform: true}).wait();
+
+			var action: (device: Mobile.IDevice) => IFuture<void>;
+			if (options.json) {
+				this.$logger.setLevel("ERROR");
+				action = (device) => {
+					return (() => { this.$logger.out(JSON.stringify({
+						identifier: device.getIdentifier(),
+						platform: device.getPlatform(),
+						model: device.getModel(),
+						name: device.getDisplayName(),
+						version: device.getVersion(),
+						vendor: device.getVendor()
+					}))}).future<void>()();
+				};
+			} else {
+				action = (device) => {
+					return (() => { this.$logger.out("%s: '%s'", (index++).toString(), device.getDisplayName(), device.getPlatform(), device.getIdentifier()); }).future<void>()();
+				};
+			}
+
+			this.$devicesServices.execute(action, undefined, {allowNoDevices: true}).wait();
+		}).future<void>()();
+	}
+}
+$injector.registerCommand("device|*list", ListDevicesCommand);


### PR DESCRIPTION
`List-devices` was duplicated in tns-cli and icenium-cli. We need to expose `device log` command in tns-cli.  I moved the device releated commands to common lib instead of duplicate more code.
