### PR TITLE
Improve autocompletion

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -127,7 +127,7 @@ interface IFutureDispatcher	 {
 
 interface ICommandDispatcher {
 	dispatchCommand(): IFuture<void>;
-	completeCommand(commandsWithPlatformArgument: string[], platforms: string[], getPropSchemaAction?: any): IFuture<boolean>;
+	completeCommand(): IFuture<boolean>;
 }
 
 interface ICancellationService extends IDisposable {

--- a/definitions/commands-service.d.ts
+++ b/definitions/commands-service.d.ts
@@ -3,5 +3,5 @@ interface ICommandsService {
 	executeCommand(commandName: string, commandArguments: string[]): IFuture<boolean>;
 	tryExecuteCommand(commandName: string, commandArguments: string[]): IFuture<void>;
 	executeCommandUnchecked(commandName: string, commandArguments: string[]): IFuture<boolean>;
-	completeCommand(commandsWithPlatformArgument: string[], platforms: string[], getPropSchemaAction?: any): IFuture<boolean>;
+	completeCommand(): IFuture<boolean>;
 }

--- a/definitions/commands.d.ts
+++ b/definitions/commands.d.ts
@@ -8,6 +8,7 @@ interface ICommand extends ICommandOptions {
 	// but at least one of them is required. Used in prop|add, prop|set, etc. commands as their logic is complicated and 
 	// default validation in CommandsService is not applicable.
 	canExecute?(args: string[]): IFuture<boolean>;
+	completionData?: string[];
 }
 
 interface ISimilarCommand {

--- a/dispatchers.ts
+++ b/dispatchers.ts
@@ -35,8 +35,8 @@ export class CommandDispatcher implements ICommandDispatcher {
 		}).future<void>()();
 	}
 
-	public completeCommand(commandsWithPlatformArgument: string[], platforms: string[], propSchema?: any): IFuture<boolean> {
-		return this.$commandsService.completeCommand(commandsWithPlatformArgument, platforms, propSchema);
+	public completeCommand(): IFuture<boolean> {
+		return this.$commandsService.completeCommand();
 	}
 
 	private getCommandName(): string {
@@ -90,7 +90,7 @@ class FutureDispatcher implements IFutureDispatcher {
 			var commandDispatcher : ICommandDispatcher = $injector.resolve("commandDispatcher");
 
 			if (process.argv[2] === "completion") {
-				commandDispatcher.completeCommand(["add", "remove", "prepare", "build", "deploy", "emulate", "run"], ["android", "ios"]).wait();
+				commandDispatcher.completeCommand().wait();
 			} else {
 				commandDispatcher.dispatchCommand().wait();
 			}


### PR DESCRIPTION
* Remove hardcoded commands
* Remove getPropSchemaAction
* Add completionData to ICommand interface - This way each command can specify data that will be used for autocompletion. For example build command can specify platforms("android", "ios", "wp8"),
plugin command can specify available plugin names, prop command can specify available property names i etc.

This is helper PR for this story http://teampulse.telerik.com/view#item/280276