### PR TITLE
Add shorthands for help command

### DIFF
--- a/dispatchers.ts
+++ b/dispatchers.ts
@@ -23,8 +23,13 @@ export class CommandDispatcher implements ICommandDispatcher {
 
 			var commandName = this.getCommandName();
 			var commandArguments = this.getCommandArguments();
+			var lastArgument: string = _.last(commandArguments);
 
-			if (options.help) {
+			if(options.help) {
+				commandArguments.unshift(commandName);
+				commandName = "help";
+			} else if(lastArgument === "/?" || lastArgument === "?") {
+				commandArguments.pop();
 				commandArguments.unshift(commandName);
 				commandName = "help";
 			}

--- a/helpers.ts
+++ b/helpers.ts
@@ -87,7 +87,6 @@ export function getParsedOptions(options: any, shorthands: any, clientName: stri
 }
 
 export function validateYargsArguments(parsed: any, knownOpts: any, shorthands: any, clientName?: string): void {
-
 	if(path.basename(process.argv[1]).indexOf(clientName) !== -1) {
 		_.each(_.keys(parsed), (opt) => {
 			var option = shorthands[opt] ? shorthands[opt] : opt;

--- a/options.ts
+++ b/options.ts
@@ -23,11 +23,12 @@ var knownOpts: any = {
 		"appid": String,
 		"geny": String
 	},
-	shorthands = {
+	shorthands: IStringDictionary = {
 		"v": "verbose",
-		"p": "path"
+		"p": "path",
+		"h": "help"
 	},
-	parsed = yargs.argv;
+	parsed: any = yargs.argv;
 
 exports.setProfileDir = (defaultProfileDir: string) => {
 	var selectedProfileDir: string = parsed["profile-dir"] || parsed["profileDir"] || defaultProfileDir;
@@ -45,10 +46,15 @@ exports.knownOpts = knownOpts;
 exports.shorthands = shorthands;
 
 Object.keys(parsed).forEach((opt) => {
+	var key: string = opt;
+	if(shorthands[opt]) {
+		key = shorthands[opt];
+	}
+
 	if (typeof (parsed[opt]) === "number") {
-		exports[opt] = parsed[opt].toString();
+		exports[key] = parsed[opt].toString();
 	} else {
-		exports[opt] = parsed[opt];
+		exports[key] = parsed[opt];
 	}
 });
 


### PR DESCRIPTION
Add some shorthands for help command: -h, ?, /?. Fix usage of shorthands, so when you specify -v for example to really use verbose mode.

http://teampulse.telerik.com/view#item/284030