### PR TITLE
Fix exception in getCommandName

### DIFF
--- a/dispatchers.ts
+++ b/dispatchers.ts
@@ -47,7 +47,7 @@ export class CommandDispatcher implements ICommandDispatcher {
 	private getCommandName(): string {
 		var remaining: string[] = options._;
 		if (remaining.length > 0) {
-			return remaining[0].toLowerCase();
+			return remaining[0].toString().toLowerCase();
 		}
 		return "help";
 	}


### PR DESCRIPTION
Add toString() call before calling toLowerCase() to make sure the value is a string. This prevents exception when passed value is a number.

Fixes http://teampulse.telerik.com/view#item/284099