### PR TITLE
Add fail without printing help

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -108,7 +108,7 @@ interface IOpener {
 interface IErrors {
 	fail(formatStr: string, ...args: any[]): void;
 	fail(opts: {formatStr?: string; errorCode?: number; suppressCommandHelp?: boolean}, ...args: any[]): void;
-
+	failWithoutHelp(message: string, ...args: any[]): void;
 	beginCommand(action: () => IFuture<boolean>, printCommandHelp: () => IFuture<boolean>): IFuture<boolean>;
 	verifyHeap(message: string): void;
 }

--- a/errors.ts
+++ b/errors.ts
@@ -98,7 +98,12 @@ export class Errors implements IErrors {
 		throw exception;
 	}
 
-	beginCommand(action: () => IFuture<boolean>, printCommandHelp: () => IFuture<boolean>): IFuture<boolean> {
+	public failWithoutHelp(message: string, ...args: any[]): void {
+		args.unshift(message);
+		this.fail({ formatStr: util.format.apply(null, args), suppressCommandHelp: true });
+	}
+
+	public beginCommand(action: () => IFuture<boolean>, printCommandHelp: () => IFuture<boolean>): IFuture<boolean> {
 		return (() => {
 			try {
 				return action().wait();


### PR DESCRIPTION
Add failWithoutHelp method to Errors. It should be used when you want to break the execution without printing help.