### PR TITLE
Remove adbFilePath and sevenZipFilePath from staticConfig

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -66,3 +66,4 @@ $injector.require("wp8EmulatorServices", "./common/mobile/wp8/wp8-emulator-servi
 
 $injector.require("autoCompletionService", "./common/services/auto-completion-service");
 $injector.require("opener", "./common/opener");
+$injector.require("resourceConstants", "./common/resource-constants");

--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -12,7 +12,8 @@ export class PostInstallCommand implements ICommand {
 		private $fs: IFileSystem,
 		private $staticConfig: Config.IStaticConfig,
 		private $childProcess: IChildProcess,
-		private $errors: IErrors) {
+		private $errors: IErrors,
+		private $resourceConstants: IResourceConstants) {
 	}
 
 	public disableAnalytics = true;
@@ -27,8 +28,8 @@ export class PostInstallCommand implements ICommand {
 					this.$fs.setCurrentUserAsOwner(options.profileDir, process.env.SUDO_USER).wait();
 				}
 
-				this.$fs.chmod(this.$staticConfig.adbFilePath, "0777").wait();
-				this.$fs.chmod(this.$staticConfig.sevenZipFilePath, "0777").wait();
+				this.$fs.chmod(this.$resourceConstants.ADB_FILE_PATH, "0777").wait();
+				this.$fs.chmod(this.$resourceConstants.SEVEN_ZIP_FILE_PATH, "0777").wait();
 			}
 
 			this.$autoCompletionService.enableAutoCompletion().wait();

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -227,3 +227,8 @@ interface ITypeScriptCompilationService {
 	initialize(typeScriptFiles: string[]): void;
 	compileAllFiles(): IFuture<void>;
 }
+
+interface IResourceConstants {
+	ADB_FILE_PATH: string;
+	SEVEN_ZIP_FILE_PATH: string;
+}

--- a/definitions/config.d.ts
+++ b/definitions/config.d.ts
@@ -9,10 +9,7 @@ declare module Config {
 		START_PACKAGE_ACTIVITY_NAME: string;
 		version: string;
 		helpTextPath: string;
-		adbFilePath: string;
-		sevenZipFilePath: string;
 	}
-
 
 	interface IConfig {
 		AB_SERVER?: string;

--- a/file-system.ts
+++ b/file-system.ts
@@ -63,10 +63,12 @@ export class FileSystem implements IFileSystem {
 			this.createDirectory(destinationDir).wait();
 			var args =  <string[]>(_.flatten(['x', shouldOverwriteFiles ? "-y" : "-aos", '-o' + destinationDir, isCaseSensitive ? '' : '-ssc-', zipFile, fileFilters || []]));
 
-			var $childProcess = this.$injector.resolve("childProcess");
-			var $staticConfig = this.$injector.resolve("staticConfig");
+			var $childProcess = this.$injector.resolve("$childProcess");
+			var $resourceConstants = this.$injector.resolve("$resourceConstants");
 
-			$childProcess.spawnFromEvent($staticConfig.sevenZipFilePath, args, "close", { stdio: "ignore", detached: true }).wait();
+			var unzipProc = $childProcess.spawn($resourceConstants.SEVEN_ZIP_FILE_PATH, _.flatten(['x', shouldOverwriteFiles ? "-y" : "-aos", '-o' + destinationDir, zipFile, fileFilters || []]),
+				{ stdio: "ignore", detached: true });
+			this.futureFromEvent(unzipProc, "close").wait();
 		}).future<void>()();
 	}
 

--- a/mobile/ios/ios-core.ts
+++ b/mobile/ios/ios-core.ts
@@ -657,7 +657,6 @@ class WinSocket implements Mobile.IiOSDeviceSocket {
 				return reply;
 			}
 
-			// TODO: add parsing for binary plists
 			return null;
 		}).future<Mobile.IiOSSocketResponseData>()();
 	}

--- a/mobile/mobile-core/device-discovery.ts
+++ b/mobile/mobile-core/device-discovery.ts
@@ -168,13 +168,13 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery {
 
 	constructor(private $childProcess: IChildProcess,
 		private $injector: IInjector,
-		private $staticConfig: Config.IStaticConfig){
+		private $resourceConstants: IResourceConstants){
 		super();
 	}
 
 	private get Adb() {
-		if(!AndroidDeviceDiscovery.adb) {
-			AndroidDeviceDiscovery.adb = helpers.getPathToAdb($injector).wait();
+		if (!AndroidDeviceDiscovery.adb) {
+			AndroidDeviceDiscovery.adb = this.$resourceConstants.ADB_FILE_PATH;
 		}
 
 		return AndroidDeviceDiscovery.adb;

--- a/project-helper.ts
+++ b/project-helper.ts
@@ -21,7 +21,7 @@ export class ProjectHelper implements IProjectHelper {
 		while (true) {
 			this.$logger.trace("Looking for project in '%s'", projectDir);
 
-			if (this.$fs.exists(path.join(projectDir, this.$staticConfig.PROJECT_FILE_NAME)).wait()) {
+			if (this.$staticConfig.PROJECT_FILE_NAME && this.$fs.exists(path.join(projectDir, this.$staticConfig.PROJECT_FILE_NAME)).wait()) {
 				this.$logger.debug("Project directory is '%s'.", projectDir);
 				this.cachedProjectDir = projectDir;
 				break;

--- a/resource-constants.ts
+++ b/resource-constants.ts
@@ -1,0 +1,11 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import path = require("path");
+import util = require("util");
+
+export class ResourceConstants implements IResourceConstants {
+	public ADB_FILE_PATH = path.join(__dirname, util.format("resources/platform-tools/android/%s/adb", process.platform));
+	public SEVEN_ZIP_FILE_PATH = path.join(__dirname, util.format("resources/platform-tools/unzip/%s/7za", process.platform));
+}
+$injector.register("resourceConstants", ResourceConstants);


### PR DESCRIPTION
We don't  need adbFilePath and sevenZipFilePath to be part of IStaticConfig interface anymore because they are already part of common lib.