### PR TITLE
Add check if 7za can be executed on Linux

### DIFF
--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -1,16 +1,37 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
 
-import options = require("../../common/options");
+import options = require("../options");
+import hostInfo = require("../host-info");
 
 export class PostInstallCommand implements ICommand {
+	private static MISSING_LINUX_32BITS_LIBS_MESSAGE = "It looks like you are using x64 Linux OS, but you are missing some of the required 32bits libraries." +
+		"You can find all system requirements on http://docs.telerik.com/platform/appbuilder/running-appbuilder/running-the-cli/system-requirements-cli#linux-systems";
+
 	constructor(private $autoCompletionService: IAutoCompletionService,
 		private $fs: IFileSystem,
-		private $staticConfig: Config.IStaticConfig) {
+		private $staticConfig: Config.IStaticConfig,
+		private $childProcess: IChildProcess,
+		private $errors: IErrors) {
 	}
 
 	public disableAnalytics = true;
 	public allowedParameters: ICommandParameter[] = [];
+
+	private checkLinux32bitsLibrariesConfiguration(): IFuture<void> {
+		return (() => {
+			try {
+				var proc = this.$childProcess.spawnFromEvent(this.$staticConfig.sevenZipFilePath, ["-h"], "exit", undefined, { throwError: false }).wait();
+
+				if(proc.stderr) {
+					this.$errors.failWithoutHelp(PostInstallCommand.MISSING_LINUX_32BITS_LIBS_MESSAGE);
+				}
+			} catch(e) {
+				var message: string = (e.code === "ENOENT") ? PostInstallCommand.MISSING_LINUX_32BITS_LIBS_MESSAGE : e.message;
+				this.$errors.failWithoutHelp(message);
+			}
+		}).future<void>()();
+	}
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
@@ -26,6 +47,10 @@ export class PostInstallCommand implements ICommand {
 			}
 
 			this.$autoCompletionService.enableAutoCompletion().wait();
+
+			if(hostInfo.isLinux64()) {
+				this.checkLinux32bitsLibrariesConfiguration().wait();
+			}
 		}).future<void>()();
 	}
 }

--- a/host-info.ts
+++ b/host-info.ts
@@ -14,21 +14,13 @@ export function isWindows32() {
 }
 
 export function isDarwin() {
-	return process.platform.toUpperCase() === "DARWIN";
+	return process.platform === "darwin";
 }
 
 export function isLinux() {
 	return process.platform === "linux";
 }
 
-export var hostCapabilities: { [key:string]: IHostCapabilities } = {
-	"win32": { 
-		debugToolsSupported: true
-	},
-	"darwin": {
-		debugToolsSupported: true
-	},
-	"linux": {
-		debugToolsSupported: false
-	}
+export function isLinux64(): boolean {
+	return isLinux() && process.config.variables.host_arch === "x64";
 }

--- a/mobile/android/android-device.ts
+++ b/mobile/android/android-device.ts
@@ -8,7 +8,6 @@ import temp = require("temp");
 import byline = require("byline");
 import helpers = require("../../helpers");
 import os = require("os");
-import hostInfo = require("../../host-info");
 import options = require("./../../options");
 import Fiber = require("fibers");
 

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -8,7 +8,6 @@ import os = require("os");
 import osenv = require("osenv");
 import path = require("path");
 import util = require("util");
-import hostInfo = require("../../../common/host-info");
 import MobileHelper = require("../mobile-helper");
 import options = require("../../options");
 import helpers = require("../../helpers");

--- a/mobile/ios/ios-emulator-services.ts
+++ b/mobile/ios/ios-emulator-services.ts
@@ -3,7 +3,7 @@
 
 import util = require("util");
 import Future = require("fibers/future");
-import hostInfo = require("../../../common/host-info");
+import hostInfo = require("../../host-info");
 import MobileHelper = require("./../mobile-helper");
 import options = require("./../../options");
 

--- a/mobile/mobile-core/device-discovery.ts
+++ b/mobile/mobile-core/device-discovery.ts
@@ -11,7 +11,6 @@ import Signal = require("./../../events/signal");
 import Future = require("fibers/future");
 import child_process = require("child_process");
 import helpers = require("./../../helpers");
-import hostInfo = require("../../host-info");
 var options = require("./../../options");
 
 export class DeviceDiscovery implements Mobile.IDeviceDiscovery {

--- a/mobile/wp8/wp8-emulator-services.ts
+++ b/mobile/wp8/wp8-emulator-services.ts
@@ -2,7 +2,7 @@
 "use strict";
 
 import path = require("path");
-import hostInfo = require("../../../common/host-info");
+import hostInfo = require("../../host-info");
 import MobileHelper = require("./../mobile-helper");
 
 class Wp8EmulatorServices implements Mobile.IEmulatorPlatformServices {


### PR DESCRIPTION
If user is on x64 Linux and 32 bit libraries, describe in our documentation, are not installed, user will not be able to use 7zip. This means - unable to create projects, unable to build etc. So on post-install we check if we are able to execute the 7za file and if ENOENT is return we show the user where he can find system requirements.

Fix host-info paths in some files and remove host-info reference from some other files.

http://teampulse.telerik.com/view#item/285027