### PR TITLE
Convert js callstack to ts

### DIFF
--- a/errors.ts
+++ b/errors.ts
@@ -63,10 +63,10 @@ export function installUncaughtExceptionListener(): void {
 		console.log(callstack || err.toString());
 
 		try {
-			var analyticsService = $injector.resolve("analyticsService");
+		 	var analyticsService = $injector.resolve("analyticsService");
 			analyticsService.trackException(err, callstack);
 		} catch (e) {
-			this.$errors.fail("Error while reporting exception: " + e);
+			$injector.resolve("$logger").error("Error while reporting exception: " + e);
 		}
 
 		process.exit(ErrorCodes.UNKNOWN);


### PR DESCRIPTION
1. we should not fail in the catch clause, because that would stop further executing of this function, and the program would exit with the wrong exit code
2. We cannot use this.$xxx resolve, because this is a free-standing function. The old code would throw.