### PR TITLE
Fix genymotion check

### DIFF
--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -63,7 +63,7 @@ class AndroidEmulatorServices implements Mobile.IEmulatorPlatformServices {
 				}
 			} catch (e) {
 				var message: string = (e.code === "ENOENT") ? AndroidEmulatorServices.MISSING_SDK_MESSAGE : e.message;
-				this.$errors.fail({formatStr: message, suppressCommandHelp: true});
+				this.$errors.failWithoutHelp(message);
 			}
 		}).future<void>()();
 	}
@@ -71,12 +71,13 @@ class AndroidEmulatorServices implements Mobile.IEmulatorPlatformServices {
 	private checkGenymotionConfiguration(): IFuture<void> {
 		return (() => {
 			try {
-				var proc = this.$childProcess.spawnFromEvent("genyshell", ["-h"], "exit", undefined, { throwError: false }).wait();
+				var proc = this.$childProcess.spawnFromEvent("player", [], "exit", undefined, { throwError: false }).wait();
 			} catch(e) {
-				this.$errors.failWithoutHelp(AndroidEmulatorServices.MISSING_GENYMOTION_MESSAGE);
+				var message: string = (e.code === "ENOENT") ? AndroidEmulatorServices.MISSING_SDK_MESSAGE : e.message;
+				this.$errors.failWithoutHelp(message);
 			}
 
-			if(proc.stderr) {
+			if(proc.stderr && !proc.stderr.startsWith("Usage:")) {
 				this.$errors.failWithoutHelp(AndroidEmulatorServices.MISSING_GENYMOTION_MESSAGE);
 			}
 		}).future<void>()();


### PR DESCRIPTION
When you specify --geny option of $ appbuilder emulate android command, we check for genyshell in the PATH environment variable. As on MacOS genyshell and the real program that we need for genymotion (player) are in different directories, we fail with incorrect message.

Fixes http://teampulse.telerik.com/view#item/285302