### PR TITLE
Fix incorrect message for genymotion

### DIFF
--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -73,7 +73,7 @@ class AndroidEmulatorServices implements Mobile.IEmulatorPlatformServices {
 			try {
 				var proc = this.$childProcess.spawnFromEvent("player", [], "exit", undefined, { throwError: false }).wait();
 			} catch(e) {
-				var message: string = (e.code === "ENOENT") ? AndroidEmulatorServices.MISSING_SDK_MESSAGE : e.message;
+				var message: string = (e.code === "ENOENT") ? AndroidEmulatorServices.MISSING_GENYMOTION_MESSAGE : e.message;
 				this.$errors.failWithoutHelp(message);
 			}
 


### PR DESCRIPTION
If Genymotion is not configured properly, the error message is not correct. Using correct constant.