### PR TITLE
Update Lodash definitions, createTable helper

### DIFF
--- a/definitions/lodash.d.ts
+++ b/definitions/lodash.d.ts
@@ -5867,7 +5867,7 @@ declare module _ {
         * @see _.keys
         **/
         keys(): LoDashArrayWrapper<string>
-    }
+	}
 
     //_.mapValues
     interface LoDashStatic {
@@ -6122,7 +6122,22 @@ declare module _ {
         * @return Returns an array of property values.
         **/
         values(object: any): any[];
-    }
+	}
+
+	interface LoDashObjectWrapper<T> {
+		/**
+		* @see _.values
+		**/
+		values(): LoDashArrayWrapper<any>
+	}
+
+	interface LoDashArrayWrapper<T> {
+		/**
+		* @see _.values
+		**/
+		values(): LoDashArrayWrapper<any>
+	}
+
 
     /*************
      * Utilities *

--- a/helpers.ts
+++ b/helpers.ts
@@ -8,6 +8,7 @@ var uuid = require("node-uuid");
 var options = require("./options");
 import Future = require("fibers/future");
 import Fiber = require("fibers");
+var Table = require("cli-table");
 
 export function createGUID(useBraces: boolean = true) {
 	var output: string;
@@ -227,4 +228,14 @@ export function getPathToAdb(injector: IInjector): IFuture<string> {
 
 		return "adb";
 	}).future<string>()();
+}
+
+export function createTable(headers: string[], data: string[][]): any {
+	var table = new Table({
+		head: headers,
+		chars: { 'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': '' }
+	});
+
+	_.forEach(data, row => table.push(row));
+	return table;
 }


### PR DESCRIPTION
Update Lodash definitions to allow chaining of .values method. Add createTable helper method which creates cli-table from passed headers and data.

Fixes are required for this issue: http://teampulse.telerik.com/view#item/285533