### PR TITLE
Remove default value for START_PACKAGE_ACTIVITY

### DIFF
--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -10,7 +10,7 @@ export class StaticConfigBase implements Config.IStaticConfig {
 	public ANALYTICS_API_KEY: string = null;
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME: string = null;
 	public TRACK_FEATURE_USAGE_SETTING_NAME: string = null;
-	public START_PACKAGE_ACTIVITY_NAME: string = null;
+	public START_PACKAGE_ACTIVITY_NAME: string;
 	public version: string = null;
 	public get helpTextPath(): string {
 		return null;


### PR DESCRIPTION
The default value doesn't allow us to use constructions like public get START_PACKAGE_ACTIVITY_NAME(): string { ... } in each CLI's. We need such construction in appbuilder-cli to support different start package activity names, based on the project type.