### PR TITLE
Remove bad try-catch

### DIFF
--- a/mobile/ios/ios-device.ts
+++ b/mobile/ios/ios-device.ts
@@ -294,11 +294,7 @@ export class IOSDevice implements Mobile.IIOSDevice {
 					}
 				};
 
-				try {
-			    	this.tryToExecuteFunction<void>(func);
-				} catch(e) {
-
-				}
+				this.tryToExecuteFunction<void>(func);
 			}
 		}).future<void>()();
 	}


### PR DESCRIPTION
The code inside it calls this.$errors.fail and expects the program execution to stop.
Due to our implementation, the catch will prevent this from working and the program will continue executing in a bad state.