### PR TITLE
Remove unneeded chmod on user's machine on package install

### DIFF
--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -26,9 +26,6 @@ export class PostInstallCommand implements ICommand {
 				if (process.env.SUDO_USER) {
 					this.$fs.setCurrentUserAsOwner(options.profileDir, process.env.SUDO_USER).wait();
 				}
-
-				this.$fs.chmod(this.$staticConfig.adbFilePath, "0777").wait();
-				this.$fs.chmod(this.$staticConfig.sevenZipFilePath, "0777").wait();
 			}
 
 			this.$autoCompletionService.enableAutoCompletion().wait();


### PR DESCRIPTION
The package.tgz contains proper unix file attributes so we do not need to explicitly set them any more.