### PR TITLE
Support multilevel hierarchical commands

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -66,3 +66,5 @@ $injector.require("wp8EmulatorServices", "./common/mobile/wp8/wp8-emulator-servi
 
 $injector.require("autoCompletionService", "./common/services/auto-completion-service");
 $injector.require("opener", "./common/opener");
+$injector.require("dynamicHelpService", "./common/services/dynamic-help-service");
+$injector.require("microTemplateService", "./common/services/micro-templating-service");

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -228,3 +228,18 @@ interface ITypeScriptCompilationService {
 	initialize(typeScriptFiles: string[]): void;
 	compileAllFiles(): IFuture<void>;
 }
+
+interface IDynamicHelpService {
+	isProjectType(...args: string[]): IFuture<boolean>;
+	isPlatform(...args: string[]): boolean;
+	getLocalVariables(): IFuture<IDictionary<any>>;
+}
+
+interface IDynamicHelpProvider {
+	isProjectType(args: string[]): IFuture<boolean>;
+	getLocalVariables(): IFuture<IDictionary<any>>;
+}
+
+interface IMicroTemplateService {
+	parseContent(data: string): string;
+}

--- a/definitions/yok.d.ts
+++ b/definitions/yok.d.ts
@@ -15,6 +15,7 @@ interface IInjector extends IDisposable {
 	isDefaultCommand(commandName: string): boolean;
 	isValidHierarchicalCommand(commandName: string, commandArguments: string[]): boolean;
 	getChildrenCommandsNames(commandName: string): string[];
+	buildHierarchicalCommand(parentCommandName: string, commandLineArguments: string[]): any;
 }
 
 declare var $injector: IInjector;

--- a/services/dynamic-help-service.ts
+++ b/services/dynamic-help-service.ts
@@ -1,0 +1,28 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import os = require("os");
+
+export class DynamicHelpService implements IDynamicHelpService {
+	constructor(private $dynamicHelpProvider: IDynamicHelpProvider) { }
+	public isProjectType(...args: string[]): IFuture<boolean> {
+		return this.$dynamicHelpProvider.isProjectType(args);
+	}
+
+	public isPlatform(...args: string[]): boolean {
+		var platform = os.platform().toLowerCase();
+		return _.any(args, arg => arg.toLowerCase() === platform);
+	}
+
+	public getLocalVariables(): IFuture<IDictionary<any>> {
+		return ((): IDictionary<any> => {
+			var localVariables = this.$dynamicHelpProvider.getLocalVariables().wait();
+			localVariables["isLinux"] = this.isPlatform("linux");
+			localVariables["isWindows"] = this.isPlatform("win32");
+			localVariables["isMacOS"] = this.isPlatform("darwin");
+
+			return localVariables;
+		}).future<IDictionary<any>>()();
+	}
+}
+$injector.register("dynamicHelpService", DynamicHelpService);

--- a/services/micro-templating-service.ts
+++ b/services/micro-templating-service.ts
@@ -1,0 +1,24 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import util = require("util");
+
+export class MicroTemplateService implements IMicroTemplateService {
+	private dynamicCallRegex: RegExp;
+
+	constructor(private $dynamicHelpService: IDynamicHelpService,
+		private $injector: IInjector) {
+		// Injector's dynamicCallRegex doesn't have 'g' option, which we need here.
+		// Use ( ) in order to use $1 to get whole expression later
+		this.dynamicCallRegex = new RegExp(util.format("(%s)", this.$injector.dynamicCallRegex.source), "g");
+	}
+
+	public parseContent(data: string): string {
+		var localVariables = this.$dynamicHelpService.getLocalVariables().wait();
+		var compiledTemplate = _.template(data.replace(this.dynamicCallRegex, "this.$injector.dynamicCall(\"$1\").wait()"));
+		// When debugging parsing, uncomment the line below:
+		// console.log(compiledTemplate.source);
+		return compiledTemplate.apply(this, [localVariables]);
+	}
+}
+$injector.register("microTemplateService", MicroTemplateService);


### PR DESCRIPTION
Add support for multilevel hierarchical commands. This way we can use commands like $ appbuilder appmanager upload android declared as "appmanager|upload|android".
Add support for passing multiple arguments to dynamic calls, by changing regular expressions.
Add DynamicHelpService which is used to check different conditions when printing our help.
Use _.isBoolean where possible. Add dynamicHelpProvider which should be implemented by each CLI.
Use lodash _.template as it uses microTemplate internally and pass the help through it. This way we can write javascript directly in our help.txt.
Replace of all entries in the help content (when executing), which match our dynamicCallRegex with this.$injector.dynamicCall($1).wait()
This way you can call dynamic methods, by just using:
\<%= #{cordovaProject.projectTemplatesString} %\>
Add localVariables that allow easy call for default scenarios (isLinux, isMacOS, is Windows, isCordova, isNativeScript, isMobileWebsite).
In order to use it, just call:
\<% if (isCordova) %\>

http://teampulse.telerik.com/view#item/283188