### PR TITLE
Change $logger.error color to red

### DIFF
--- a/logger.ts
+++ b/logger.ts
@@ -42,7 +42,10 @@ export class Logger implements ILogger {
 	}
 
 	error(...args: string[]): void {
-		this.log4jsLogger.error.apply(this.log4jsLogger, args);
+		var message = util.format.apply(null, args);
+		var colorizedMessage = message.red;
+
+		this.log4jsLogger.error.apply(this.log4jsLogger, [colorizedMessage]);
 	}
 
 	warn(...args: string[]): void {


### PR DESCRIPTION
Note: This shade of red is a lot different than the shade of red displayed by $errors.fail
Tested in cmd and bash under windows