### PR TITLE
Fix starting of genymotion emulator

### DIFF
--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -70,14 +70,15 @@ class AndroidEmulatorServices implements Mobile.IEmulatorPlatformServices {
 
 	private checkGenymotionConfiguration(): IFuture<void> {
 		return (() => {
+			var proc: any;
 			try {
-				var proc = this.$childProcess.spawnFromEvent("player", [], "exit", undefined, { throwError: false }).wait();
+				proc = this.$childProcess.spawnFromEvent("player", [], "exit", undefined, { throwError: false }).wait();
 			} catch(e) {
 				var message: string = (e.code === "ENOENT") ? AndroidEmulatorServices.MISSING_GENYMOTION_MESSAGE : e.message;
 				this.$errors.failWithoutHelp(message);
 			}
 
-			if(proc.stderr && !proc.stderr.startsWith("Usage:")) {
+			if(proc.stderr && !_.startsWith(proc.stderr, "Usage:")) {
 				this.$errors.failWithoutHelp(AndroidEmulatorServices.MISSING_GENYMOTION_MESSAGE);
 			}
 		}).future<void>()();


### PR DESCRIPTION
Use lodash's startsWith method as the extension method startsWith (it was part of extensions.ts) had been removed.