### PR TITLE
Add method to check if analytics tracking is enabled

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -189,6 +189,7 @@ interface IAnalyticsService {
 	setAnalyticsStatus(enabled: boolean): IFuture<void>;
 	disableAnalytics(): IFuture<void>;
 	getStatusMessage(): IFuture<string>;
+	isEnabled(): IFuture<boolean>;
 }
 
 interface IPrompter extends IDisposable {

--- a/services/analytics-service.ts
+++ b/services/analytics-service.ts
@@ -180,6 +180,13 @@ export class AnalyticsService implements IAnalyticsService {
 		}).future<void>()();
 	}
 
+	public isEnabled(): IFuture<boolean> {
+		return (() => {
+			var analyticsStatus = this.getAnalyticsStatus().wait();
+			return analyticsStatus === AnalyticsStatus.enabled;
+		}).future<boolean>()();
+	}
+
 	private isDisabled(): IFuture<boolean> {
 		return (() => {
 			var analyticsStatus = this.getAnalyticsStatus().wait();


### PR DESCRIPTION
Add isEnabled method which returns true only when analytics tracking is enabled. We need the value in order to pass it to simulator in appbuilder-cli.

http://teampulse.telerik.com/view#item/286925