### PR TITLE
Fix hierarchical commands

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -32,6 +32,9 @@ $injector.requireCommand("feature-usage-tracking", "./common/commands/analytics"
 $injector.requireCommand("dev-post-install", "./common/commands/post-install");
 
 $injector.requireCommand("device|*list", "./common/commands/device/list-devices");
+$injector.requireCommand("device|android", "./common/commands/device/list-devices");
+$injector.requireCommand("device|ios", "./common/commands/device/list-devices");
+
 $injector.requireCommand("device|log", "./common/commands/device/device-log-stream");
 $injector.requireCommand("device|run", "./common/commands/device/run-application");
 $injector.requireCommand("device|list-applications", "./common/commands/device/list-applications");

--- a/commands/device/list-devices.ts
+++ b/commands/device/list-devices.ts
@@ -4,6 +4,7 @@
 import util = require("util");
 import options = require("./../../options");
 import commandParams = require("../../command-params");
+import MobileHelper = require("../../mobile/mobile-helper");
 
 export class ListDevicesCommand implements ICommand {
 	constructor(private $devicesServices: Mobile.IDevicesServices,
@@ -41,3 +42,33 @@ export class ListDevicesCommand implements ICommand {
 	}
 }
 $injector.registerCommand("device|*list", ListDevicesCommand);
+
+class ListAndroidDevicesCommand implements ICommand {
+	constructor(private $injector: IInjector) { }
+
+	allowedParameters: ICommandParameter[] = [];
+
+	public execute(args: string[]): IFuture<void> {
+		return (() => {
+			var listDevicesCommand: ICommand = this.$injector.resolve(ListDevicesCommand);
+			var platform = MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android]
+			listDevicesCommand.execute([platform]).wait();
+		}).future<void>()();
+	}
+}
+$injector.registerCommand("device|android", ListAndroidDevicesCommand);
+
+class ListiOSDevicesCommand implements ICommand {
+	constructor(private $injector: IInjector) { }
+
+	allowedParameters: ICommandParameter[] = [];
+
+	public execute(args: string[]): IFuture<void> {
+		return (() => {
+			var listDevicesCommand: ICommand = this.$injector.resolve(ListDevicesCommand);
+			var platform = MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.iOS]
+			listDevicesCommand.execute([platform]).wait();
+		}).future<void>()();
+	}
+}
+$injector.registerCommand("device|ios", ListiOSDevicesCommand);

--- a/yok.ts
+++ b/yok.ts
@@ -205,13 +205,18 @@ export class Yok implements IInjector {
 
 						if(args.length > 0) {
 							var hierarchicalCommand = this.buildHierarchicalCommand(name, args);
-							var isValidCommand = this.isValidCommand(hierarchicalCommand.commandName);
-							if(isValidCommand) {
+							if(hierarchicalCommand) {
 								commandName = hierarchicalCommand.commandName;
 								commandArguments = hierarchicalCommand.remainingArguments;
 							} else {
-								commandArguments = args;
-								commandName = "help";
+								commandName = defaultCommand ? this.getHierarchicalCommandName(name, defaultCommand) : "help";
+								// If we'll execute the default command, but it's full name had been written by the user
+								// for example "appbuilder cloud list", we have to remove the "list" option from the arguments that we'll pass to the command.
+								if(_.contains(this.hierarchicalCommands[name], "*" + args[0])) {
+									commandArguments = _.rest(args);
+								} else {
+									commandArguments = args;
+								}
 							}
 						} else {
 							//Execute only default command without arguments


### PR DESCRIPTION
Fix code which should execute default hierarchical command which accepts arguments.
Split device commands in order to use different context for each of them,