### PR TITLE
Replace  appbuilder strings with CLIENT_NAME

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -71,3 +71,5 @@ $injector.require("autoCompletionService", "./common/services/auto-completion-se
 $injector.require("opener", "./common/opener");
 $injector.require("dynamicHelpService", "./common/services/dynamic-help-service");
 $injector.require("microTemplateService", "./common/services/micro-templating-service");
+$injector.require("mobileHelper", "./common/mobile/mobile-helper");
+$injector.require("devicePlatformsConstants", "./common/mobile/device-platforms-constants");

--- a/commands/device/list-devices.ts
+++ b/commands/device/list-devices.ts
@@ -4,7 +4,6 @@
 import util = require("util");
 import options = require("./../../options");
 import commandParams = require("../../command-params");
-import MobileHelper = require("../../mobile/mobile-helper");
 
 export class ListDevicesCommand implements ICommand {
 	constructor(private $devicesServices: Mobile.IDevicesServices,
@@ -44,14 +43,15 @@ export class ListDevicesCommand implements ICommand {
 $injector.registerCommand("device|*list", ListDevicesCommand);
 
 class ListAndroidDevicesCommand implements ICommand {
-	constructor(private $injector: IInjector) { }
+	constructor(private $injector: IInjector,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	allowedParameters: ICommandParameter[] = [];
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
 			var listDevicesCommand: ICommand = this.$injector.resolve(ListDevicesCommand);
-			var platform = MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android]
+			var platform = this.$devicePlatformsConstants.Android;
 			listDevicesCommand.execute([platform]).wait();
 		}).future<void>()();
 	}
@@ -59,14 +59,15 @@ class ListAndroidDevicesCommand implements ICommand {
 $injector.registerCommand("device|android", ListAndroidDevicesCommand);
 
 class ListiOSDevicesCommand implements ICommand {
-	constructor(private $injector: IInjector) { }
+	constructor(private $injector: IInjector,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	allowedParameters: ICommandParameter[] = [];
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
 			var listDevicesCommand: ICommand = this.$injector.resolve(ListDevicesCommand);
-			var platform = MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.iOS]
+			var platform = this.$devicePlatformsConstants.iOS;
 			listDevicesCommand.execute([platform]).wait();
 		}).future<void>()();
 	}

--- a/commands/device/run-application.ts
+++ b/commands/device/run-application.ts
@@ -8,7 +8,8 @@ export class RunApplicationOnDeviceCommand implements ICommand {
 
 	constructor(private $devicesServices: Mobile.IDevicesServices,
 		private $errors: IErrors,
-		private $stringParameter: ICommandParameter) { }
+		private $stringParameter: ICommandParameter,
+		private $staticConfig: IStaticConfig) { }
 
 	allowedParameters: ICommandParameter[] = [this.$stringParameter];
 
@@ -17,7 +18,7 @@ export class RunApplicationOnDeviceCommand implements ICommand {
 			this.$devicesServices.initialize({ deviceId: options.device, skipInferPlatform: true }).wait();
 
 			if (this.$devicesServices.deviceCount > 1) {
-				this.$errors.fail("More than one device found. Specify device explicitly with --device option.To discover device ID, use $appbuilder device command.");
+				this.$errors.fail("More than one device found. Specify device explicitly with --device option.To discover device ID, use $%s device command.", this.$staticConfig.CLIENT_NAME.toLowerCase());
 			}
 
 			var action = (device: Mobile.IDevice) =>  { return (() => device.runApplication(args[0]).wait()).future<void>()(); };

--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -3,10 +3,11 @@
 
 import options = require("../options");
 import hostInfo = require("../host-info");
+import util = require("util");
 
 export class PostInstallCommand implements ICommand {
 	private static SEVEN_ZIP_ERROR_MESSAGE = "It looks like there's a problem with your system configuration. " +
-		"You can find all system requirements on http://docs.telerik.com/platform/appbuilder/running-appbuilder/running-the-cli/system-requirements-cli";
+		"You can find all system requirements on %s"; 
 
 	constructor(private $autoCompletionService: IAutoCompletionService,
 		private $fs: IFileSystem,
@@ -35,14 +36,15 @@ export class PostInstallCommand implements ICommand {
 
 	private checkSevenZip(): IFuture<void> {
 		return (() => {
+			var sevenZipErrorMessage = util.format(PostInstallCommand.SEVEN_ZIP_ERROR_MESSAGE, this.$staticConfig.SYS_REQUIREMENTS_LINK);
 			try {
 				var proc = this.$childProcess.spawnFromEvent(this.$staticConfig.sevenZipFilePath, ["-h"], "exit", undefined, { throwError: false }).wait();
 
 				if(proc.stderr) {
-					this.$errors.failWithoutHelp(PostInstallCommand.SEVEN_ZIP_ERROR_MESSAGE);
+					this.$errors.failWithoutHelp(sevenZipErrorMessage);
 				}
 			} catch(e) {
-				var message: string = (e.code === "ENOENT") ? PostInstallCommand.SEVEN_ZIP_ERROR_MESSAGE : e.message;
+				var message: string = (e.code === "ENOENT") ? sevenZipErrorMessage : e.message;
 				this.$errors.failWithoutHelp(message);
 			}
 		}).future<void>()();

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -203,7 +203,9 @@ interface IPrompter extends IDisposable {
 
 interface IAnalyticsSettingsService {
 	canDoRequest(): IFuture<boolean>;
-	getUserId():  IFuture<string>;
+	getUserId(): IFuture<string>;
+	getClientName(): string;
+	getPrivacyPolicyLink(): string;
 }
 
 interface IHostCapabilities {

--- a/definitions/config.d.ts
+++ b/definitions/config.d.ts
@@ -7,6 +7,7 @@ declare module Config {
 		ANALYTICS_INSTALLATION_ID_SETTING_NAME: string;
 		TRACK_FEATURE_USAGE_SETTING_NAME: string;
 		START_PACKAGE_ACTIVITY_NAME: string;
+		SYS_REQUIREMENTS_LINK: string;
 		version: string;
 		helpTextPath: string;
 		adbFilePath: string;

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -228,4 +228,27 @@ declare module Mobile {
 		stdoutFilePath?: string;
 		appId?: string;
 	}
+
+	interface IPlatformsCapabilities {
+		getPlatformNames(): string[];
+		getAllCapabilities(): IDictionary<Mobile.IPlatformCapabilities>;
+	}
+
+	interface IMobileHelper {
+		platformNames: string[];
+		isAndroidPlatform(platform: string): boolean;
+		isiOSPlatform(platform: string): boolean;
+		isWP8Platform(platform: string): boolean;
+		normalizePlatformName(platform: string): string;
+		isPlatformSupported(platform: string): boolean;
+		validatePlatformName(platform: string): string;
+		getPlatformCapabilities(platform: string): Mobile.IPlatformCapabilities;
+		generateLocalToDevicePathData(localPath: string, devicePath: string, relativeToProjectBasePath: string): Mobile.ILocalToDevicePathData;
+	}
+
+	interface IDevicePlatformsConstants {
+		iOS: string;
+		Android: string;
+		WP8: string;
+	}
 }

--- a/helpers.ts
+++ b/helpers.ts
@@ -117,7 +117,7 @@ export function getPathToAdb(injector: IInjector): IFuture<string> {
 			var logger: ILogger = injector.resolve("logger");
 			var staticConfig: IStaticConfig = injector.resolve("staticConfig");
 
-			var warningMessage = util.format("Unable to find adb in PATH. Default one from %s resources will be used.", staticConfig.CLIENT_NAME);
+			var warningMessage = util.format("Unable to find adb in PATH. Default one from %s resources will be used.", staticConfig.CLIENT_NAME.toLowerCase());
 			var proc = childProcess.spawnFromEvent("adb", ["version"], "exit", undefined, { throwError: false }).wait();
 
 			if(proc.stderr) {

--- a/http-client.ts
+++ b/http-client.ts
@@ -69,7 +69,8 @@ export class HttpClient implements Server.IHttpClient {
 			if (!headers["User-Agent"]) {
 				if (!this.defaultUserAgent) {
 					//TODO: the user agent client name is also passed explicitly during login and should be kept in sync
-					this.defaultUserAgent = util.format("AppBuilderCLI/%s (Node.js %s; %s; %s)",
+					this.defaultUserAgent = util.format("%sCLI/%s (Node.js %s; %s; %s)",
+						this.$staticConfig.CLIENT_NAME,
 						this.$staticConfig.version,
 						process.versions.node, process.platform, process.arch);
 					this.$logger.debug("User-Agent: %s", this.defaultUserAgent);

--- a/mobile/android/android-device.ts
+++ b/mobile/android/android-device.ts
@@ -1,6 +1,5 @@
 ///<reference path="../../../.d.ts"/>
 "use strict";
-import MobileHelper = require("./../mobile-helper");
 import util = require("util");
 import Future = require("fibers/future");
 import path = require("path");
@@ -42,10 +41,10 @@ export class AndroidDevice implements Mobile.IDevice {
 	private static LIVESYNC_BROADCAST_NAME = "com.telerik.LiveSync";
 	private static CHECK_LIVESYNC_INTENT_NAME = "com.telerik.IsLiveSyncSupported"
 
-    private static ENV_DEBUG_IN_FILENAME = "envDebug.in";
-    private static ENV_DEBUG_OUT_FILENAME = "envDebug.out";
-    private static PACKAGE_EXTERNAL_DIR_TEMPLATE = "/sdcard/Android/data/%s/files/";
-    private static DEVICE_TMP_DIR_FORMAT_V2 = "/data/local/tmp/12590FAA-5EDD-4B12-856D-F52A0A1599F2/%s";
+	private static ENV_DEBUG_IN_FILENAME = "envDebug.in";
+	private static ENV_DEBUG_OUT_FILENAME = "envDebug.out";
+	private static PACKAGE_EXTERNAL_DIR_TEMPLATE = "/sdcard/Android/data/%s/files/";
+	private static DEVICE_TMP_DIR_FORMAT_V2 = "/data/local/tmp/12590FAA-5EDD-4B12-856D-F52A0A1599F2/%s";
 	private static DEVICE_TMP_DIR_FORMAT_V3 = "/mnt/sdcard/Android/data/%s/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2";
 	private static COMMANDS_FILE = "telerik.livesync.commands";
 	private static DEVICE_PATH_SEPARATOR = "/";
@@ -55,16 +54,17 @@ export class AndroidDevice implements Mobile.IDevice {
 	private version: string;
 	private vendor: string;
 	private _tmpRoots: IStringDictionary = {};
-    private _installedApplications: string[];
-    private defaultNodeInspectorUrl = "http://127.0.0.1:8080/debug";
+	private _installedApplications: string[];
+	private defaultNodeInspectorUrl = "http://127.0.0.1:8080/debug";
 
 	constructor(private identifier: string, private adb: string,
 		private $logger: ILogger,
 		private $fs: IFileSystem,
 		private $childProcess: IChildProcess,
 		private $errors: IErrors,
-        private $staticConfig: Config.IStaticConfig,
-        private $opener: IOpener) {
+		private $staticConfig: Config.IStaticConfig,
+		private $opener: IOpener,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
 		var details: IAndroidDeviceDetails = this.getDeviceDetails().wait();
 		this.model = details.model;
 		this.name = details.name;
@@ -91,7 +91,7 @@ export class AndroidDevice implements Mobile.IDevice {
 	}
 
 	public getPlatform(): string {
-		return MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android];
+		return this.$devicePlatformsConstants.Android;
 	}
 
 	public getIdentifier(): string {

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -8,7 +8,6 @@ import os = require("os");
 import osenv = require("osenv");
 import path = require("path");
 import util = require("util");
-import MobileHelper = require("../mobile-helper");
 import options = require("../../options");
 import helpers = require("../../helpers");
 var net = require('net');
@@ -39,7 +38,8 @@ class AndroidEmulatorServices implements Mobile.IEmulatorPlatformServices {
 		private $errors: IErrors,
 		private $childProcess: IChildProcess,
 		private $fs: IFileSystem,
-		private $staticConfig: Config.IStaticConfig) {
+		private $staticConfig: Config.IStaticConfig,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
 		iconv.extendNodeEncodings();
 		this.adbFilePath = helpers.getPathToAdb($injector).wait();
 	}
@@ -86,7 +86,7 @@ class AndroidEmulatorServices implements Mobile.IEmulatorPlatformServices {
 
 	public checkAvailability(): IFuture<void> {
 		return (() => {
-			var platform = MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android];
+			var platform = this.$devicePlatformsConstants.Android;
 			if(!this.$emulatorSettingsService.canStart(platform).wait()) {
 				this.$errors.fail("The current project does not target Android and cannot be run in the Android emulator.");
 			}

--- a/mobile/device-platforms-constants.ts
+++ b/mobile/device-platforms-constants.ts
@@ -1,0 +1,9 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+export class DevicePlatformsConstants implements Mobile.IDevicePlatformsConstants {
+	public iOS = "iOS";
+	public Android = "Android";
+	public WP8 = "WP8";
+}
+$injector.register("devicePlatformsConstants", DevicePlatformsConstants);

--- a/mobile/ios/ios-device.ts
+++ b/mobile/ios/ios-device.ts
@@ -10,7 +10,6 @@ import util = require("util");
 
 import iosCore = require("./ios-core");
 import iOSProxyServices = require("./ios-proxy-services");
-import MobileHelper = require("./../mobile-helper");
 import helpers = require("./../../helpers");
 import hostInfo = require("./../../host-info");
 import options = require("./../../options");
@@ -32,7 +31,9 @@ export class IOSDevice implements Mobile.IIOSDevice {
 		private $fs: IFileSystem,
 		private $injector: IInjector,
 		private $logger: ILogger,
-		private $mobileDevice: Mobile.IMobileDevice) {
+		private $mobileDevice: Mobile.IMobileDevice,
+		private $staticConfig: IStaticConfig,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
 		this.mountImageCallbackPtr = CoreTypes.am_device_mount_image_callback.toPointer(IOSDevice.mountImageCallback);
 	}
 
@@ -45,7 +46,7 @@ export class IOSDevice implements Mobile.IIOSDevice {
 	}
 
 	public getPlatform(): string {
-		return MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.iOS];
+		return this.$devicePlatformsConstants.iOS;
 	}
 
 	public getIdentifier(): string {
@@ -372,7 +373,7 @@ export class IOSDevice implements Mobile.IIOSDevice {
 	public runApplication(applicationId: string): IFuture<void> {
 		return (() => {
 			if(hostInfo.isWindows()) {
-				this.$errors.fail("$appbuilder device run command is not supported on Windows for iOS devices.");
+				this.$errors.fail("$%s device run command is not supported on Windows for iOS devices.", this.$staticConfig.CLIENT_NAME.toLowerCase());
 			}
 
 			var applications = this.lookupApplications();

--- a/mobile/ios/ios-emulator-services.ts
+++ b/mobile/ios/ios-emulator-services.ts
@@ -4,14 +4,15 @@
 import util = require("util");
 import Future = require("fibers/future");
 import hostInfo = require("../../host-info");
-import MobileHelper = require("./../mobile-helper");
 import options = require("./../../options");
 
 class IosEmulatorServices implements Mobile.IEmulatorPlatformServices {
 	constructor(private $logger: ILogger,
 		private $emulatorSettingsService: Mobile.IEmulatorSettingsService,
 		private $errors: IErrors,
-		private $childProcess: IChildProcess) { }
+		private $childProcess: IChildProcess,
+		private $mobileHelper: Mobile.IMobileHelper,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	public checkDependencies(): IFuture<void> {
 		return (() => {
@@ -24,7 +25,7 @@ class IosEmulatorServices implements Mobile.IEmulatorPlatformServices {
 				this.$errors.fail("iOS Simulator is available only on Mac OS X.");
 			}
 
-			var platform = MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.iOS];
+			var platform = this.$devicePlatformsConstants.iOS;
 			if(dependsOnProject && !this.$emulatorSettingsService.canStart(platform).wait()) {
 				this.$errors.fail("The current project does not target iOS and cannot be run in the iOS Simulator.");
 			}

--- a/mobile/mobile-core/device-discovery.ts
+++ b/mobile/mobile-core/device-discovery.ts
@@ -149,7 +149,7 @@ class IOSDeviceDiscoveryStub extends DeviceDiscovery {
 		if(this.error) {
 			this.$logger.warn(this.error);
 		} else if(hostInfo.isLinux()) {
-			this.$logger.warn("In this version of the %s command-line interface, you cannot use connected iOS devices.", this.$staticConfig.CLIENT_NAME);
+			this.$logger.warn("In this version of the %s command-line interface, you cannot use connected iOS devices.", this.$staticConfig.CLIENT_NAME.toLowerCase());
 		}
 		
 		return Future.fromResult();

--- a/mobile/mobile-helper.ts
+++ b/mobile/mobile-helper.ts
@@ -3,85 +3,82 @@
 
 import helpers = require("../helpers");
 
-export enum DevicePlatforms {
-	iOS,
-	Android,
-	WP8
-}
-
-export var platformCapabilities: {[key: string]: Mobile.IPlatformCapabilities } = {
-	iOS: {
-		wirelessDeploy: true,
-		cableDeploy: true,
-		companion: true,
-		hostPlatformsForDeploy: ["win32", "darwin"]
-	},
-	Android: {
-		wirelessDeploy: true,
-		cableDeploy: true,
-		companion: true,
-		hostPlatformsForDeploy: ["win32", "darwin", "linux"]
-	},
-	WP8: {
-		wirelessDeploy: true,
-		cableDeploy: false,
-		companion: true,
-		hostPlatformsForDeploy: ["win32"]
-	}
-};
-
-export var PlatformNames = Object.keys(platformCapabilities);
-
 export class LocalToDevicePathData implements Mobile.ILocalToDevicePathData {
-	constructor(private localPath: string, private devicePath: string, private relativeToProjectBasePath: string) {}
+	constructor(private localPath: string, private devicePath: string, private relativeToProjectBasePath: string) { }
 
 	getLocalPath(): string { return this.localPath; }
 	getDevicePath(): string { return this.devicePath; }
 	getRelativeToProjectBasePath(): string { return this.relativeToProjectBasePath; }
 }
 
-export function isAndroidPlatform(platform: string): boolean {
-	return DevicePlatforms[DevicePlatforms.Android].toLowerCase() === platform.toLowerCase();
-}
-
-export function isiOSPlatform(platform:string): boolean {
-	return DevicePlatforms[DevicePlatforms.iOS].toLowerCase() === platform.toLowerCase();
-}
-
-export function isWP8Platform(platform: string): boolean {
-	return DevicePlatforms[DevicePlatforms.WP8].toLowerCase() === platform.toLowerCase();
-}
-
-export function normalizePlatformName(platform: string): string {
-	if (isAndroidPlatform(platform)) {
-		return "Android";
-	} else if (isiOSPlatform(platform)) {
-		return "iOS";
-	} else if (isWP8Platform(platform)) {
-		return "WP8";
+export class MobileHelper implements Mobile.IMobileHelper {
+	public generateLocalToDevicePathData(localPath: string, devicePath: string, relativeToProjectBasePath: string): Mobile.ILocalToDevicePathData {
+		return new LocalToDevicePathData(localPath, devicePath, relativeToProjectBasePath);
 	}
 
-	return undefined;
-}
+	private platformNamesCache: string[];
 
-export function isPlatformSupported(platform: string): boolean {
-	var platformName = normalizePlatformName(platform);
-	return _.contains(platformCapabilities[platformName].hostPlatformsForDeploy, process.platform);
-}
+	constructor(private $mobilePlatformsCapabilities: Mobile.IPlatformsCapabilities,
+		private $errors: IErrors,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
-export function generateWP8GUID(): string {
-	return helpers.createGUID();
-}
+	public get platformNames(): string[]{
+		this.platformNamesCache = this.platformNamesCache ||
+			_.map(this.$mobilePlatformsCapabilities.getPlatformNames(), platform => this.normalizePlatformName(platform));
 
-export function validatePlatformName(platform: string, $errors: IErrors): string {
-	if (!platform) {
-		$errors.fail("No device platform specified.");
+		return this.platformNamesCache;
 	}
 
-	var normalizedPlatform = normalizePlatformName(platform);
-	if (!normalizedPlatform) {
-		$errors.fail("'%s' is not a valid device platform. Valid platforms are %s.",
-			platform, helpers.formatListOfNames(Object.keys(platformCapabilities)));
+	public getPlatformCapabilities(platform: string): Mobile.IPlatformCapabilities {
+		var platformNames = this.$mobilePlatformsCapabilities.getPlatformNames();
+		var validPlatformName = this.validatePlatformName(platform);
+		if(!_.any(platformNames, platformName => platformName === validPlatformName)) {
+			this.$errors.failWithoutHelp("'%s' is not a valid device platform. Valid platforms are %s.", platform, platformNames);
+		}
+
+		return this.$mobilePlatformsCapabilities.getAllCapabilities()[validPlatformName];
 	}
-	return normalizedPlatform;
+
+	public isAndroidPlatform(platform: string): boolean {
+		return this.$devicePlatformsConstants.Android.toLowerCase() === platform.toLowerCase();
+	}
+
+	public isiOSPlatform(platform: string): boolean {
+		return this.$devicePlatformsConstants.iOS.toLowerCase() === platform.toLowerCase();
+	}
+
+	public isWP8Platform(platform: string): boolean {
+		return this.$devicePlatformsConstants.WP8.toLowerCase() === platform.toLowerCase();
+	}
+
+	public normalizePlatformName(platform: string): string {
+		if(this.isAndroidPlatform(platform)) {
+			return "Android";
+		} else if(this.isiOSPlatform(platform)) {
+			return "iOS";
+		} else if(this.isWP8Platform(platform)) {
+			return "WP8";
+		}
+
+		return undefined;
+	}
+
+	public isPlatformSupported(platform: string): boolean {
+		return _.contains(this.getPlatformCapabilities(platform).hostPlatformsForDeploy, process.platform);
+	}
+
+	public validatePlatformName(platform: string): string {
+		if(!platform) {
+			this.$errors.fail("No device platform specified.");
+		}
+
+		var normalizedPlatform = this.normalizePlatformName(platform);
+		if(!normalizedPlatform) {
+			this.$errors.fail("'%s' is not a valid device platform. Valid platforms are %s.",
+				platform, helpers.formatListOfNames(this.$mobilePlatformsCapabilities.getPlatformNames()));
+		}
+		return normalizedPlatform;
+	}
+
 }
+$injector.register("mobileHelper", MobileHelper);

--- a/mobile/wp8/wp8-emulator-services.ts
+++ b/mobile/wp8/wp8-emulator-services.ts
@@ -3,13 +3,13 @@
 
 import path = require("path");
 import hostInfo = require("../../host-info");
-import MobileHelper = require("./../mobile-helper");
 
 class Wp8EmulatorServices implements Mobile.IEmulatorPlatformServices {
 	constructor(private $logger: ILogger,
 		private $emulatorSettingsService: Mobile.IEmulatorSettingsService,
 		private $errors: IErrors,
-		private $childProcess: IChildProcess) {}
+		private $childProcess: IChildProcess,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	public checkDependencies(): IFuture<void> {
 		return (() => {
@@ -22,7 +22,7 @@ class Wp8EmulatorServices implements Mobile.IEmulatorPlatformServices {
 				this.$errors.fail("Windows Phone Emulator is available only on Windows 8 or later.");
 			}
 
-			var platform = MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.WP8];
+			var platform = this.$devicePlatformsConstants.WP8;
 			if (!this.$emulatorSettingsService.canStart(platform).wait()) {
 				this.$errors.fail("The current project does not target Windows Phone 8 and cannot be run in the Windows Phone emulator.");
 			}

--- a/services/analytics-service.ts
+++ b/services/analytics-service.ts
@@ -26,10 +26,10 @@ export class AnalyticsService implements IAnalyticsService {
 
 				if(this.isNotConfirmed().wait() && helpers.isInteractive() && !_.contains(this.excluded, featureName)) {
 					this.$logger.out("Do you want to help us improve " +
-						"Telerik".white.bold + " " + this.$staticConfig.CLIENT_NAME.cyan.bold
+						this.$analyticsSettingsService.getClientName() + 
 						+ " by automatically sending anonymous usage statistics? We will not use this information to identify or contact you."
 						+ " You can read our official Privacy Policy at");
-					var message = "http://www.telerik.com/company/privacy-policy";
+					var message = this.$analyticsSettingsService.getPrivacyPolicyLink();
 
 					var trackFeatureUsage = this.$prompter.confirm(message, () => "y").wait();
 					this.setAnalyticsStatus(trackFeatureUsage).wait();

--- a/services/auto-completion-service.ts
+++ b/services/auto-completion-service.ts
@@ -45,7 +45,7 @@ export class AutoCompletionService implements IAutoCompletionService {
 			var doUpdate = true;
 			if (this.$fs.exists(filePath).wait()) {
 				var contents = this.$fs.readText(filePath).wait();
-				var regExp = new RegExp(util.format("%s\\s+completion\\s+--\\s+", this.$staticConfig.CLIENT_NAME));
+				var regExp = new RegExp(util.format("%s\\s+completion\\s+--\\s+", this.$staticConfig.CLIENT_NAME.toLowerCase()));
 				var matchCondition = contents.match(regExp);
 				if(this.$staticConfig.CLIENT_NAME_ALIAS) {
 					matchCondition = matchCondition || contents.match(new RegExp(util.format("%s\\s+completion\\s+--\\s+", this.$staticConfig.CLIENT_NAME_ALIAS.toLowerCase())));

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -97,11 +97,11 @@ export class CommandsService implements ICommandsService {
 					return true;
 				}
 
-				this.$errors.fail("Unable to execute command '%s'. Use '$ %s %s --help' for help.", beautifiedName, this.$staticConfig.CLIENT_NAME, beautifiedName);
+				this.$errors.fail("Unable to execute command '%s'. Use '$ %s %s --help' for help.", beautifiedName, this.$staticConfig.CLIENT_NAME.toLowerCase(), beautifiedName);
 				return false;
 			}
 
-			this.$logger.fatal("Unknown command '%s'. Use '%s help' for help.", beautifiedName, this.$staticConfig.CLIENT_NAME);
+			this.$logger.fatal("Unknown command '%s'. Use '%s help' for help.", beautifiedName, this.$staticConfig.CLIENT_NAME.toLowerCase());
 			this.tryMatchCommand(commandName);
 
 			return false;

--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -11,6 +11,7 @@ export class StaticConfigBase implements Config.IStaticConfig {
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME: string = null;
 	public TRACK_FEATURE_USAGE_SETTING_NAME: string = null;
 	public START_PACKAGE_ACTIVITY_NAME: string;
+	public SYS_REQUIREMENTS_LINK: string;
 	public version: string = null;
 	public get helpTextPath(): string {
 		return null;


### PR DESCRIPTION
Common lib is used by several CLIs - appbuilder-cli, nativescript-cli, etc. 

- There are several places where appbuilder is used, while it should be staticConfig.CLIENT_NAME. Fix all of these.
- Replace MobileHelper's exported functions in a new class - MobileHelper. This way we can resolve it from injector and it can easily use staticConfig's CLIENT_NAME. 
- Remove DevicePlatforms enum and add DevicePlatformsConstants class which can be used instead of the enum. 
- Add SYS_REQUIREMENTS_LINK to StaticConfig in order to have different links for each CLI. 
- Add getClientName and getPrivacyPolicyLink methods to IAnalyticsSettingsService.

http://teampulse.telerik.com/view#item/287728