### PR TITLE
Fix validation of device platform names

### DIFF
--- a/mobile/mobile-helper.ts
+++ b/mobile/mobile-helper.ts
@@ -73,9 +73,9 @@ export class MobileHelper implements Mobile.IMobileHelper {
 		}
 
 		var normalizedPlatform = this.normalizePlatformName(platform);
-		if(!normalizedPlatform) {
+		if(!normalizedPlatform || !_.contains(this.platformNames, normalizedPlatform)) {
 			this.$errors.fail("'%s' is not a valid device platform. Valid platforms are %s.",
-				platform, helpers.formatListOfNames(this.$mobilePlatformsCapabilities.getPlatformNames()));
+				platform, helpers.formatListOfNames(this.platformNames));
 		}
 		return normalizedPlatform;
 	}


### PR DESCRIPTION
In case the CLI doesn't support a mobile platform, for example WP8, but it is valid mobile platform according to normalizePlatformName(WP8 for example), we should break the execution.