### PR TITLE
Enable proxy using for http requests

### DIFF
--- a/config-base.ts
+++ b/config-base.ts
@@ -1,0 +1,18 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import path = require("path");
+import util = require("util");
+
+export class ConfigBase implements IConfiguration {
+	constructor(protected $fs: IFileSystem) { }
+
+	protected loadConfig(name: string): IFuture<any> {
+		var configFileName = this.getConfigPath(name);
+		return this.$fs.readJson(configFileName);
+	}
+
+	protected getConfigPath(filename: string): string {
+		return path.join(__dirname, "../../config/", filename + ".json");
+	}
+}

--- a/definitions/config.d.ts
+++ b/definitions/config.d.ts
@@ -13,14 +13,14 @@ declare module Config {
 		sevenZipFilePath: string;
 	}
 
-
 	interface IConfig {
 		AB_SERVER?: string;
 		AB_SERVER_PROTO?: string;
 		DEBUG?: boolean;
-		FIDDLER_HOSTNAME?: string;
+		PROXY_HOSTNAME?: string;
+		USE_PROXY?: boolean;
+		PROXY_PORT?: number;
 		CI_LOGGER?: boolean;
-		PROXY_TO_FIDDLER?: boolean;
 		TYPESCRIPT_COMPILER_OPTIONS?: any;
 	}
 }

--- a/http-client.ts
+++ b/http-client.ts
@@ -44,17 +44,18 @@ export class HttpClient implements Server.IHttpClient {
 			var pipeTo = options.pipeTo;
 			delete options.pipeTo;
 
-			var proto = this.$config.PROXY_TO_FIDDLER ? "http" : requestProto;
+			var proto = this.$config.USE_PROXY ? "http" : requestProto;
 			var http = require(proto);
 
 			options.headers = options.headers || {};
 			var headers = options.headers;
 
-			if (this.$config.PROXY_TO_FIDDLER) {
+			if(this.$config.USE_PROXY) {
 				options.path = requestProto + "://" + options.host + options.path;
 				headers.Host = options.host;
-				options.host = this.$config.FIDDLER_HOSTNAME;
-				options.port = 8888;
+				options.host = this.$config.PROXY_HOSTNAME;
+				options.port = this.$config.PROXY_PORT;
+				this.$logger.trace("Using proxy with host: %s, port: %d, path is: %s", options.host, options.port, options.path);
 			}
 
 			if (!headers.Accept || headers.Accept.indexOf("application/json") < 0) {


### PR DESCRIPTION
Rename the following config options:
 - FIDDLER_HOSTNAME to PROXY_HOSTNAME
 - PROXY_TO_FIDDLER to USE_PROXY

Add PROXY_PORT option to config with default value 8888. Add ConfigBase class which should be used as a base for CLI specific configs.

Required for https://github.com/NativeScript/nativescript-cli/issues/297 and https://github.com/NativeScript/nativescript-cli/issues/302