### PR TITLE
Fix ConfigBase parent

### DIFF
--- a/config-base.ts
+++ b/config-base.ts
@@ -4,7 +4,7 @@
 import path = require("path");
 import util = require("util");
 
-export class ConfigBase implements IConfiguration {
+export class ConfigBase implements Config.IConfig {
 	constructor(protected $fs: IFileSystem) { }
 
 	protected loadConfig(name: string): IFuture<any> {


### PR DESCRIPTION
ConfigBase must implement Config.IConfig, not IConfiguration. IConfiguration is specific for each CLI.