### PR TITLE
Get back availableDevices option

### DIFF
--- a/options.ts
+++ b/options.ts
@@ -22,6 +22,7 @@ var knownOpts: any = {
 		"profile-dir": String,
 		"timeout": String,
 		"device": String,
+		"availableDevices": Boolean,
 		"appid": String,
 		"geny": String,
 		"debug-brk": Boolean,


### PR DESCRIPTION
Get back the availableDevices option that had been removed by mistake.