### PR TITLE
Show HTML Help

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -74,3 +74,4 @@ $injector.require("dynamicHelpService", "./common/services/dynamic-help-service"
 $injector.require("microTemplateService", "./common/services/micro-templating-service");
 $injector.require("mobileHelper", "./common/mobile/mobile-helper");
 $injector.require("devicePlatformsConstants", "./common/mobile/device-platforms-constants");
+$injector.require("htmlHelpService", "./common/services/html-help-service");

--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -14,7 +14,8 @@ export class PostInstallCommand implements ICommand {
 		private $staticConfig: Config.IStaticConfig,
 		private $childProcess: IChildProcess,
 		private $errors: IErrors,
-		private $commandsService: ICommandsService) {
+		private $commandsService: ICommandsService,
+		private $htmlHelpService: IHtmlHelpService) {
 	}
 
 	public disableAnalytics = true;
@@ -32,6 +33,7 @@ export class PostInstallCommand implements ICommand {
 
 			this.checkSevenZip().wait();
 			this.$commandsService.tryExecuteCommand("autocomplete", []).wait();
+			this.$htmlHelpService.generateHtmlPages().wait();
 		}).future<void>()();
 	}
 

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -43,6 +43,7 @@ interface IFileSystem {
 	readText(filename: string, encoding?: string): IFuture<string>;
 	readJson(filename: string, encoding?: string): IFuture<any>;
 	writeFile(filename: string, data: any, encoding?: string): IFuture<void>;
+	appendFile(filename: string, data: any, encoding?: string): IFuture<void>;
 	writeJson(filename: string, data: any, space?: string, encoding?: string): IFuture<void>;
 	copyFile(sourceFileName: string, destinationFileName: string): IFuture<void>;
 	getUniqueFileName(baseName: string): IFuture<string>;
@@ -235,14 +236,20 @@ interface ITypeScriptCompilationService {
 interface IDynamicHelpService {
 	isProjectType(...args: string[]): IFuture<boolean>;
 	isPlatform(...args: string[]): boolean;
-	getLocalVariables(): IFuture<IDictionary<any>>;
+	getLocalVariables(options: { isHtml: boolean }): IFuture<IDictionary<any>>;
 }
 
 interface IDynamicHelpProvider {
 	isProjectType(args: string[]): IFuture<boolean>;
-	getLocalVariables(): IFuture<IDictionary<any>>;
+	getLocalVariables(options: { isHtml: boolean }): IFuture<IDictionary<any>>;
 }
 
 interface IMicroTemplateService {
-	parseContent(data: string): string;
+	parseContent(data: string, options: {isHtml: boolean }): string;
+}
+
+interface IHtmlHelpService {
+	generateHtmlPages(): IFuture<void>;
+	getCommandLineHelpForCommand(commandName: string): IFuture<string>;
+	openHelpForCommandInBrowser(commandName: string): IFuture<void>;
 }

--- a/definitions/config.d.ts
+++ b/definitions/config.d.ts
@@ -12,6 +12,9 @@ declare module Config {
 		helpTextPath: string;
 		adbFilePath: string;
 		sevenZipFilePath: string;
+		MAN_PAGES_DIR: string;
+		HTML_PAGES_DIR: string;
+		HTML_HELPERS_DIR: string;
 	}
 
 	interface IConfig {

--- a/definitions/lodash.d.ts
+++ b/definitions/lodash.d.ts
@@ -6144,9 +6144,29 @@ declare module _ {
 	 ***********/
 
 	interface LoDashStatic {
-		endsWith(string?:string, target?:string, position?:number): boolean;
-		startsWith(string?:string, target?:string, position?:number): boolean;
-	}
+        camelCase(str?: string): string;
+        capitalize(str?: string): string;
+        deburr(str?: string): string;
+        endsWith(str?: string, target?: string, position?: number): boolean;
+        escape(str?: string): string;
+        escapeRegExp(str?: string): string;
+        kebabCase(str?: string): string;
+        pad(str?: string, length?: number, chars?: string): string;
+        padLeft(str?: string, length?: number, chars?: string): string;
+        padRight(str?: string, length?: number, chars?: string): string;
+        repeat(str?: string, n?: number): string;
+        snakeCase(str?: string): string;
+        startCase(str?: string): string;
+        startsWith(str?: string, target?: string, position?: number): boolean;
+        trim(str?: string, chars?: string): string;
+        trimLeft(str?: string, chars?: string): string;
+        trimRight(str?: string, chars?: string): string;
+        trunc(str?: string, len?: number): string;
+        trunc(str?: string, options?: { length?: number; omission?: string; separator?: string }): string;
+        trunc(str?: string, options?: { length?: number; omission?: string; separator?: RegExp }): string;
+        words(str?: string, pattern?: string): string[];
+        words(str?: string, pattern?: RegExp): string[];
+    }
 
     /*************
      * Utilities *

--- a/definitions/marked.d.ts
+++ b/definitions/marked.d.ts
@@ -1,0 +1,126 @@
+// Type definitions for Marked
+// Project: https://github.com/chjj/marked
+// Definitions by: William Orr <https://github.com/worr>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+
+interface MarkedStatic {
+	/**
+		* Compiles markdown to HTML.
+		*
+		* @param src String of markdown source to be compiled
+		* @param callback Function called when the markdownString has been fully parsed when using async highlighting
+		* @return String of compiled HTML
+	*/
+	(src: string, callback?: Function): string;
+
+	/**
+		* Compiles markdown to HTML.
+		*
+		* @param src String of markdown source to be compiled
+		* @param options Hash of options
+		* @param callback Function called when the markdownString has been fully parsed when using async highlighting
+		* @return String of compiled HTML
+		*/
+	(src: string, options?: MarkedOptions, callback?: Function): string;
+
+	/**
+		* @param src String of markdown source to be compiled
+		* @param options Hash of options
+		*/
+	lexer(src: string, options?: MarkedOptions): any[];
+
+	/**
+		* Compiles markdown to HTML.
+		*
+		* @param src String of markdown source to be compiled
+		* @param callback Function called when the markdownString has been fully parsed when using async highlighting
+		* @return String of compiled HTML
+		*/
+	parse(src: string, callback: Function): string;
+
+	/**
+		* Compiles markdown to HTML.
+		*
+		* @param src String of markdown source to be compiled
+		* @param options Hash of options
+		* @param callback Function called when the markdownString has been fully parsed when using async highlighting
+		* @return String of compiled HTML
+		*/
+	parse(src: string, options?: MarkedOptions, callback?: Function): string;
+
+	/**
+		* @param options Hash of options
+		*/
+	parser(src: any[], options?: MarkedOptions): string;
+
+	/**
+		* Sets the default options.
+		*
+		* @param options Hash of options
+		*/
+	setOptions(options: MarkedOptions): void;
+}
+
+interface MarkedOptions {
+	/**
+		* Enable GitHub flavored markdown.
+		*/
+	gfm?: boolean;
+
+	/**
+		* Enable GFM tables. This option requires the gfm option to be true.
+		*/
+	tables?: boolean;
+
+	/**
+		* Enable GFM line breaks. This option requires the gfm option to be true.
+		*/
+	breaks?: boolean;
+
+	/**
+		* Conform to obscure parts of markdown.pl as much as possible. Don't fix any of the original markdown bugs or poor behavior.
+		*/
+	pedantic?: boolean;
+
+	/**
+		* Sanitize the output. Ignore any HTML that has been input.
+		*/
+	sanitize?: boolean;
+
+	/**
+		* Use smarter list behavior than the original markdown. May eventually be default with the old behavior moved into pedantic.
+		*/
+	smartLists?: boolean;
+
+	/**
+		* Shows an HTML error message when rendering fails.
+		*/
+	silent?: boolean;
+
+	/**
+		* A function to highlight code blocks. The function takes three arguments: code, lang, and callback.
+		*/
+	highlight? (code: string, lang: string, callback?: Function): string;
+
+	/**
+		* Set the prefix for code block classes.
+		*/
+	langPrefix?: string;
+
+	/**
+		* Use "smart" typograhic punctuation for things like quotes and dashes.
+		*/
+	smartypants?: boolean;
+
+	/**
+	 * An object containing functions to render tokens to HTML.
+	 */
+	renderer?: any
+}
+
+declare module "marked" {
+	export = marked;
+}
+
+declare var marked: MarkedStatic;

--- a/file-system.ts
+++ b/file-system.ts
@@ -215,6 +215,18 @@ export class FileSystem implements IFileSystem {
 		}).future<void>()();
 	}
 
+	public appendFile(filename: string, data: any, encoding?: string): IFuture<void> {
+		var future = new Future<void>();
+		fs.appendFile(filename, data, { encoding: encoding },(err: Error) => {
+			if(err) {
+				future.throw(err);
+			} else {
+				future.return();
+			}
+		});
+		return future;
+	}
+
 	public writeJson(filename: string, data: any, space: string = "\t", encoding?: string): IFuture<void> {
 		return this.writeFile(filename, JSON.stringify(data, null, space), encoding);
 	}

--- a/mobile/constants.ts
+++ b/mobile/constants.ts
@@ -7,4 +7,4 @@ export class ProvisionType {
 	static Enterprise = "Enterprise";
 }
 
-export var ERROR_NO_DEVICES = "Cannot find connected devices. Reconnect any connected devices, verify that your system recognizes them, and run this command again";
+export var ERROR_NO_DEVICES = "Cannot find connected devices. Reconnect any connected devices, verify that your system recognizes them, and run this command again.";

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -57,10 +57,15 @@ export class CommandsService implements ICommandsService {
 		}).future<boolean>()();
 	}
 
+	private printHelp(commandName: string): IFuture<boolean> {
+		options.help = true;
+		return this.executeCommandUnchecked("help", [this.beautifyCommandName(commandName)]);
+	}
+
 	private executeCommandAction(commandName: string, commandArguments: string[], action: (commandName: string, commandArguments: string[]) => IFuture<boolean>): IFuture<boolean> {
 		return this.$errors.beginCommand(
 			() => action.apply(this, [commandName, commandArguments]),
-			() => this.executeCommandUnchecked("help", [this.beautifyCommandName(commandName)]));
+			() => this.printHelp(commandName));
 	}
 
 	public tryExecuteCommand(commandName: string, commandArguments: string[]): IFuture<void> {
@@ -72,7 +77,7 @@ export class CommandsService implements ICommandsService {
 				var command = this.$injector.resolveCommand(commandName);
 				if(command) {
 					// If command cannot be executed we should print its help.
-					this.executeCommandUnchecked("help", [this.beautifyCommandName(commandName)]).wait();
+					this.printHelp(commandName).wait();
 				}
 			}
 		}).future<void>()();

--- a/services/dynamic-help-service.ts
+++ b/services/dynamic-help-service.ts
@@ -5,6 +5,7 @@ import os = require("os");
 
 export class DynamicHelpService implements IDynamicHelpService {
 	constructor(private $dynamicHelpProvider: IDynamicHelpProvider) { }
+
 	public isProjectType(...args: string[]): IFuture<boolean> {
 		return this.$dynamicHelpProvider.isProjectType(args);
 	}
@@ -14,12 +15,16 @@ export class DynamicHelpService implements IDynamicHelpService {
 		return _.any(args, arg => arg.toLowerCase() === platform);
 	}
 
-	public getLocalVariables(): IFuture<IDictionary<any>> {
+	public getLocalVariables(options: { isHtml: boolean }): IFuture<IDictionary<any>> {
 		return ((): IDictionary<any> => {
-			var localVariables = this.$dynamicHelpProvider.getLocalVariables().wait();
-			localVariables["isLinux"] = this.isPlatform("linux");
-			localVariables["isWindows"] = this.isPlatform("win32");
-			localVariables["isMacOS"] = this.isPlatform("darwin");
+			var isHtml = options.isHtml;
+			//in html help we want to show all help. Only CONSOLE specific help(wrapped in if(isConsole) ) must be omitted
+			var localVariables = this.$dynamicHelpProvider.getLocalVariables(options).wait();
+			localVariables["isLinux"] = isHtml || this.isPlatform("linux");
+			localVariables["isWindows"] = isHtml || this.isPlatform("win32");
+			localVariables["isMacOS"] = isHtml || this.isPlatform("darwin");
+			localVariables["isConsole"] = !isHtml;
+			localVariables["isHtml"] = isHtml;
 
 			return localVariables;
 		}).future<IDictionary<any>>()();

--- a/services/html-help-service.ts
+++ b/services/html-help-service.ts
@@ -1,0 +1,158 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import util = require("util");
+import Future = require("fibers/future");
+import path = require("path");
+import options = require("options");
+import marked = require("marked");
+var TerminalRenderer = require('marked-terminal');
+var chalk = require("chalk");
+
+export class HtmlHelpService implements IHtmlHelpService {
+	private static MARKDOWN_FILE_EXTENSION = ".md";
+	private static HTML_FILE_EXTENSION = ".html";
+	private static MAN_PAGE_NAME_PLACEHOLDER = "@MAN_PAGE_NAME@";
+	private static HTML_COMMAND_HELP_PLACEHOLDER = "@HTML_COMMAND_HELP@";
+	private static RELATIVE_PATH_TO_STYLES_CSS_PLACEHOLDER = "@RELATIVE_PATH_TO_STYLES_CSS@";
+
+	private pathToManPages: string;
+	private pathToHtmlPages: string;
+	private get pathToStylesCss(): string {
+		return path.join(this.$staticConfig.HTML_HELPERS_DIR, "styles.css");
+	}
+
+	private get pathToBasicPage(): string {
+		return path.join(this.$staticConfig.HTML_HELPERS_DIR, "basic-page.html");
+	}
+
+	constructor(private $logger: ILogger,
+		private $injector: IInjector,
+		private $errors: IErrors,
+		private $fs: IFileSystem,
+		private $staticConfig: Config.IStaticConfig,
+		private $microTemplateService: IMicroTemplateService,
+		private $opener: IOpener) {
+		this.pathToHtmlPages = this.$staticConfig.HTML_PAGES_DIR;
+		this.pathToManPages = this.$staticConfig.MAN_PAGES_DIR;
+	}
+
+	public generateHtmlPages(): IFuture<void> {
+		return (() => {
+			var mdFiles = this.$fs.enumerateFilesInDirectorySync(this.pathToManPages);
+			var basicHtmlPage = this.$fs.readFile(this.pathToBasicPage).wait().toString();
+			var futures = _.map(mdFiles, markdownFile => this.createHtmlPage(basicHtmlPage, markdownFile));
+			Future.wait(futures);
+			this.$logger.trace("Finished generating HTML files.");
+		}).future<void>()();
+	}
+
+	private createHtmlPage(basicHtmlPage: string, pathToMdFile: string): IFuture<void> {
+		return (() => {
+			var mdFileName = path.basename(pathToMdFile);
+			var htmlFileName = mdFileName.replace(HtmlHelpService.MARKDOWN_FILE_EXTENSION, HtmlHelpService.HTML_FILE_EXTENSION);
+			this.$logger.trace("Generating '%s' help topic.", htmlFileName);
+
+			var helpText = this.$fs.readText(pathToMdFile).wait();
+			var outputText = this.$microTemplateService.parseContent(helpText, { isHtml: true });
+			var htmlText = marked(outputText);
+
+			var filePath = pathToMdFile
+				.replace(path.basename(this.pathToManPages), path.basename(this.pathToHtmlPages))
+				.replace(mdFileName, htmlFileName);
+			this.$logger.trace("HTML file path for '%s' man page is: '%s'.", mdFileName, filePath);
+
+			var outputHtml = basicHtmlPage
+				.replace(HtmlHelpService.MAN_PAGE_NAME_PLACEHOLDER, mdFileName.replace(HtmlHelpService.MARKDOWN_FILE_EXTENSION, ""))
+				.replace(HtmlHelpService.HTML_COMMAND_HELP_PLACEHOLDER, htmlText)
+				.replace(HtmlHelpService.RELATIVE_PATH_TO_STYLES_CSS_PLACEHOLDER, path.relative(path.dirname(filePath), this.pathToStylesCss));
+
+			this.$fs.writeFile(filePath, outputHtml).wait();
+			this.$logger.trace("Finished writing file '%s'.", filePath);
+		}).future<void>()();
+	}
+
+	public openHelpForCommandInBrowser(commandName: string): IFuture<void> {
+		return ((): void => {
+			var htmlPage = this.convertCommandNameToFileName(commandName) + HtmlHelpService.HTML_FILE_EXTENSION;
+			this.$logger.trace("Opening help for command '%s'. FileName is '%s'.", commandName, htmlPage);
+			if(!this.tryOpeningSelectedPage(htmlPage)) {
+				// HTML pages may have been skipped on post-install, lets generate them.
+				this.$logger.trace("Required HTML file '%s' is missing. Let's try generating HTML files and see if we'll find it.", htmlPage);
+				this.generateHtmlPages().wait();
+				if(!this.tryOpeningSelectedPage(htmlPage)) {
+					this.$errors.failWithoutHelp("Unable to find help for '%s'", commandName);
+				}
+			}
+		}).future<void>()();
+	}
+
+	private convertCommandNameToFileName(commandName: string): string {
+		var defaultCommandMatch = commandName.match(/(\w+?)\|\*/);
+		if(defaultCommandMatch) {
+			this.$logger.trace("Default command found. Replace current command name '%s' with '%s'.", commandName, defaultCommandMatch[1]);
+			commandName = defaultCommandMatch[1];
+		}
+
+		var availableCommands = this.$injector.getRegisteredCommandsNames(false).sort();
+		this.$logger.trace("List of registered commands: %s", availableCommands.join(", "));
+		if(commandName && !_.contains(availableCommands, commandName)) {
+			this.$errors.failWithoutHelp("Unknown command '%s'. Try '$ %s help' for a full list of supported commands.", commandName, this.$staticConfig.CLIENT_NAME.toLowerCase());
+		}
+
+		return commandName.replace(/\|/g, "-") || "index";
+	}
+	
+	private tryOpeningSelectedPage(htmlPage: string): boolean {
+		var fileList = this.$fs.enumerateFilesInDirectorySync(this.pathToHtmlPages);
+		this.$logger.trace("File list: " + fileList);
+		var pageToOpen = _.find(fileList, file => path.basename(file) === htmlPage);
+		
+		if(pageToOpen) {
+			this.$logger.trace("Found page to open: '%s'", pageToOpen);
+			this.$opener.open(pageToOpen);
+			return true;
+		} 
+		
+		this.$logger.trace("Unable to find file: '%s'", htmlPage);
+		return false;
+	}
+
+	private readMdFileForCommand(commandName: string): IFuture<string> {
+		return ((): string => {
+			var mdFileName = this.convertCommandNameToFileName(commandName) + HtmlHelpService.MARKDOWN_FILE_EXTENSION;
+			this.$logger.trace("Reading help for command '%s'. FileName is '%s'.", commandName, mdFileName);
+
+			var markdownFile = _.find(this.$fs.enumerateFilesInDirectorySync(this.pathToManPages), file => path.basename(file) === mdFileName);
+			if(markdownFile) {
+				return this.$fs.readText(markdownFile).wait();
+			} 
+
+			this.$errors.failWithoutHelp("Unknown command '%s'. Try '$ %s help' for a full list of supported commands.", mdFileName.replace(".md", ""), this.$staticConfig.CLIENT_NAME.toLowerCase());
+		}).future<string>()();
+	}
+
+	public getCommandLineHelpForCommand(commandName: string): IFuture<string> {
+		return ((): string => {
+			var helpText = this.readMdFileForCommand(commandName).wait();
+			var outputText = this.$microTemplateService.parseContent(helpText, { isHtml: false });
+			var opts = {
+				unescape: true,
+				link: chalk.red
+				// TODO: Use tableOptions when marked-terminal officialy supports them.
+				// tableOptions: { colWidths: [20,50] }
+			};
+
+			marked.setOptions({ renderer: new TerminalRenderer(opts) });
+			var parsedMarkdown = marked(outputText);
+			// Fix issue inside marked-terminal when table contains < >.
+			// Check https://github.com/mikaelbr/marked-terminal/issues/12 for more details.
+			// Do not remove spaces before < and after > - they are required for correct rendering of cli-table
+			// as the width of columns is calculated with 4 symbols (&lt;), so we should replace values with correct ones with same length
+			return parsedMarkdown
+				.replace(/\&lt;/g, "   <")
+				.replace(/\&gt;/g, ">   ");
+		}).future<string>()();
+	}
+}
+$injector.register("htmlHelpService", HtmlHelpService);

--- a/services/micro-templating-service.ts
+++ b/services/micro-templating-service.ts
@@ -13,8 +13,8 @@ export class MicroTemplateService implements IMicroTemplateService {
 		this.dynamicCallRegex = new RegExp(util.format("(%s)", this.$injector.dynamicCallRegex.source), "g");
 	}
 
-	public parseContent(data: string): string {
-		var localVariables = this.$dynamicHelpService.getLocalVariables().wait();
+	public parseContent(data: string, options: { isHtml: boolean }): string {
+		var localVariables = this.$dynamicHelpService.getLocalVariables(options).wait();
 		var compiledTemplate = _.template(data.replace(this.dynamicCallRegex, "this.$injector.dynamicCall(\"$1\").wait()"));
 		// When debugging parsing, uncomment the line below:
 		// console.log(compiledTemplate.source);

--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -24,4 +24,16 @@ export class StaticConfigBase implements Config.IStaticConfig {
 	public get adbFilePath(): string {
 		return path.join(__dirname, util.format("resources/platform-tools/android/%s/adb", process.platform));
 	}
+
+	public get MAN_PAGES_DIR(): string {
+		return path.join(__dirname, "../../", "docs", "man_pages");
+	}
+
+	public get HTML_PAGES_DIR(): string {
+		return path.join(__dirname, "../../", "docs", "html");
+	}
+
+	public get HTML_HELPERS_DIR(): string {
+		return path.join(__dirname, "../../", "docs", "helpers");
+	}
 }

--- a/yok.ts
+++ b/yok.ts
@@ -123,6 +123,9 @@ export class Yok implements IInjector {
 
 			if(commands.length > 1 && !this.modules[this.createCommandName(commands[0])]) {
 				this.require(this.createCommandName(commands[0]), file);
+				if(commands[1] && !commandName.match(/\|\*/)) {
+					this.require(this.createCommandName(commandName), file);
+				}
 			} else {
 				this.require(this.createCommandName(commandName), file);
 			}


### PR DESCRIPTION
## Use case:
CLIs should be able to show HTML help when using ```<cli name> help <command name>```
When using ```<cli name> <command name> --help``` console help should be shown.
When an error is raised in command, only console help is shown.

## Implementation
* ```HelpCommand``` is modified to show console help when ```options.help``` is specified and html help when it is not.
* Add ```HtmlHelpService``` which handles both console and html help by parsing markdown help files.
* Each commands help is placed in a separate file. The files are markdown and they are used for both html and console help.
* Html pages are generated from markdown on post-install. As post-install command could fail before generating html pages, when html help should be shown, we check if command name is valid and if the command exists, but its html help is missing, we generate all html pages.
* Modify ```CommandsService``` to show console help by specifying options.help before calling ```HelpCommand```
* Modify ```DynamicHelpService``` and ```DynamicHelpProvider``` to accept isHtml option. When ```isHtml``` is specified, all localVariables will be set to true. This way html help will show full help, no matter of the conditions.
* Add ```basic_page.html``` page and used three placeholders in it. The page is used to generate all html files, by replacing the placeholders with commands name, help content and path to css file.
* Add ```styles.css``` file which contains styles used in html pages.
* Add definitions for marked module.
* Add ```appendFile``` method to ```FileSystem```
* Fix issue in yok, which was not requiring the first hierarchical command if it was not default one (if the hierarchical command doesn't have default command to execute) - this was leading to incorrect behavior when checking if command is valid.

http://teampulse.telerik.com/view#item/259417