### PR TITLE
Fix analytics prompt

### DIFF
--- a/services/analytics-service.ts
+++ b/services/analytics-service.ts
@@ -25,8 +25,8 @@ export class AnalyticsService implements IAnalyticsService {
 			if(this.$analyticsSettingsService.canDoRequest().wait()) {
 
 				if(this.isNotConfirmed().wait() && helpers.isInteractive() && !_.contains(this.excluded, featureName)) {
-					this.$logger.out("Do you want to help us improve " +
-						this.$analyticsSettingsService.getClientName() + 
+					this.$logger.out("Do you want to help us improve "
+						+ this.$analyticsSettingsService.getClientName()
 						+ " by automatically sending anonymous usage statistics? We will not use this information to identify or contact you."
 						+ " You can read our official Privacy Policy at");
 					var message = this.$analyticsSettingsService.getPrivacyPolicyLink();


### PR DESCRIPTION
Currently analytics prompt is showing:
"Do you want to help us improve Telerik AppBuilderNaN You can read our official Privacy Policy at"

Instead it must show: "Do you want to help us improve Telerik AppBuilder by automatically sending anonymous usage statistics? We will not use this information to identify or contact you. You can read our official Privacy Policy at..."

The problem is with __two consecutive + signs__ used when message is generated.