### PR TITLE
Fix marked-terminal parsing

### DIFF
--- a/services/html-help-service.ts
+++ b/services/html-help-service.ts
@@ -139,19 +139,10 @@ export class HtmlHelpService implements IHtmlHelpService {
 			var opts = {
 				unescape: true,
 				link: chalk.red
-				// TODO: Use tableOptions when marked-terminal officialy supports them.
-				// tableOptions: { colWidths: [20,50] }
 			};
 
 			marked.setOptions({ renderer: new TerminalRenderer(opts) });
-			var parsedMarkdown = marked(outputText);
-			// Fix issue inside marked-terminal when table contains < >.
-			// Check https://github.com/mikaelbr/marked-terminal/issues/12 for more details.
-			// Do not remove spaces before < and after > - they are required for correct rendering of cli-table
-			// as the width of columns is calculated with 4 symbols (&lt;), so we should replace values with correct ones with same length
-			return parsedMarkdown
-				.replace(/\&lt;/g, "   <")
-				.replace(/\&gt;/g, ">   ");
+			return marked(outputText);
 		}).future<string>()();
 	}
 }


### PR DESCRIPTION
Remove the hack when parsing markdown text that has to be show on the console. The problem was with code in table, but it had been fixed in version 1.3.0 of marked-terminal.

Part of http://teampulse.telerik.com/view#item/259417