### PR TITLE
Improve warnings and prompts at install

### DIFF
--- a/commands/completion-prompt.ts
+++ b/commands/completion-prompt.ts
@@ -15,8 +15,8 @@ export class CompletionPromptCommand implements ICommand {
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
 			if (helpers.isInteractive()) {
-				this.$logger.out("If you are using bash or zsh, you can enable command line auto completion.");
-				var message = "Enable it now?";
+				this.$logger.out("If you are using bash or zsh, you can enable command-line completion.");
+				var message = "Do you want to enable it now?";
 
 				var autoCompetionStatus = this.$prompter.confirm(message, () => "y").wait();
 

--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -4,6 +4,8 @@
 import options = require("../options");
 import hostInfo = require("../host-info");
 import util = require("util");
+import os = require("os");
+import HostInfo = require("host-info");
 
 export class PostInstallCommand implements ICommand {
 	private static SEVEN_ZIP_ERROR_MESSAGE = "It looks like there's a problem with your system configuration. " +
@@ -47,33 +49,78 @@ export class PostInstallCommand implements ICommand {
 		}).future<void>()();
 	}
 
+	private printPackageManagerTip() {
+		if (hostInfo.isWindows()) {
+			this.$logger.out("TIP: To avoid setting up the necessary environment variables, you can use the chocolatey package manager to install the Android SDK and its dependencies." + os.EOL);
+		} else if (hostInfo.isDarwin()) {
+			this.$logger.out("TIP: To avoid setting up the necessary environment variables, you can use the Homebrew package manager to install the Android SDK and its dependencies." + os.EOL);
+		}
+	}
+
 	private printNSWarnings(sysInfo: ISysInfoData) {
 		if (!sysInfo.adbVer) {
-			this.$logger.warn("Cannot find adb in the path. The built-in one will be used, which may be incompatible with the latest Android SDK or Genymotion. Adjust system path to include adb from the latest Android SDK.");
+			this.$logger.warn("WARNING: adb from the Android SDK is not installed or is not configured properly.");
+			this.$logger.out("For Android-related operations, the AppBuilder CLI will use a built-in version of adb." + os.EOL
+			+ "To avoid possible issues with the native Android emulator, Genymotion or connected" + os.EOL
+			+ "Android devices, verify that you have installed the latest Android SDK and" + os.EOL
+			+ "its dependencies as described in http://developer.android.com/sdk/index.html#Requirements" + os.EOL);
+
+			this.printPackageManagerTip();
 		}
 		if (!sysInfo.antVer) {
-			this.$logger.warn("Cannot find ant. You cannot build Android projects. Download and install ant as described in the Android SDK documentation.");
+			this.$logger.warn("WARNING: Apache Ant is not installed or is not configured properly.");
+			this.$logger.out("You will not be able to build your projects for Android." + os.EOL
+			+ "To be able to build for Android, download and install Apache Ant and" + os.EOL
+			+ "its dependencies as described in http://ant.apache.org/manual/index.html" + os.EOL);
+
+			this.printPackageManagerTip();
 		}
-		if (!sysInfo.javaVer) {
-			this.$logger.warn("Cannot find java. You cannot build Android projects and use Android Emulator. Install java as described in the Android SDK documentation.");
+		if (!sysInfo.androidInstalled) {
+			this.$logger.warn("WARNING: The Android SDK is not installed or is not configured properly.");
+			this.$logger.out("You will not be able to build your projects for Android and run them in the native emulator." + os.EOL
+				+ "To be able to build for Android and run apps in the native emulator, verify that you have" + os.EOL
+				+ "installed the latest Android SDK and its dependencies as described in http://developer.android.com/sdk/index.html#Requirements" + os.EOL
+			);
+
+			this.printPackageManagerTip();
 		}
 		if (hostInfo.isDarwin() && !sysInfo.xcodeVer) {
-			this.$logger.warn("Cannot find Xcode. You cannot build iOS projects and use the iOS Simulator. Install Xcode from the App Store.");
+			this.$logger.warn("WARNING: Xcode is not installed or is not configured properly.");
+			this.$logger.out("You will not be able to build your projects for iOS or run them in the iOS Simulator." + os.EOL
+			+ "To be able to build for iOS and run apps in the native emulator, verify that you have installed Xcode." + os.EOL);
 		}
 		if (!sysInfo.itunesInstalled) {
-			this.$logger.warn("iTunes is not installed. Commands for working with iOS devices will not work. Download and install iTunes from http://www.apple.com");
+			this.$logger.warn("WARNING: iTunes is not installed.");
+			this.$logger.out("You will not be able to work with iOS devices via cable connection." + os.EOL
+			+ "To be able to work with connected iOS devices," + os.EOL
+			+ "download and install iTunes from http://www.apple.com" + os.EOL);
 		}
 	}
 
 	private printAppBuilderWarnings(sysInfo: ISysInfoData) {
 		if (!sysInfo.adbVer) {
-			this.$logger.warn("Cannot find adb in the path. The built-in one will be used, which may be incompatible with the latest Android SDK or Genymotion. Adjust system path to include adb from the latest Android SDK.");
+			this.$logger.warn("WARNING: adb from the Android SDK is not installed or is not configured properly. ");
+			this.$logger.out("For Android-related operations, the AppBuilder CLI will use a built-in version of adb." + os.EOL
+			+ "To avoid possible issues with the native Android emulator, Genymotion or connected" + os.EOL
+			+ "Android devices, verify that you have installed the latest Android SDK and" + os.EOL
+			+ "its dependencies as described in http://developer.android.com/sdk/index.html#Requirements" + os.EOL);
+
+			this.printPackageManagerTip();
 		}
-		if (!sysInfo.javaVer) {
-			this.$logger.warn("Cannot find java. You cannot use Android Emulator. Install java as described in the Android SDK documentation.");
+		if (!sysInfo.androidInstalled) {
+			this.$logger.warn("WARNING: The Android SDK is not installed or is not configured properly.");
+			this.$logger.out("You will not be able to run your apps in the native emulator. To be able to run apps" + os.EOL
+				+ "in the native Android emulator, verify that you have installed the latest Android SDK " + os.EOL
+				+ "and its dependencies as described in http://developer.android.com/sdk/index.html#Requirements" + os.EOL
+			);
+
+			this.printPackageManagerTip()
 		}
 		if (!sysInfo.itunesInstalled) {
-			this.$logger.warn("iTunes is not installed. Commands for working with iOS devices will not work. Download and install iTunes from http://www.apple.com");
+			this.$logger.warn("WARNING: iTunes is not installed.");
+			this.$logger.out("You will not be able to work with iOS devices via cable connection." + os.EOL
+			+ "To be able to work with connected iOS devices," + os.EOL
+			+ "download and install iTunes from http://www.apple.com" + os.EOL);
 		}
 	}
 

--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -60,7 +60,7 @@ export class PostInstallCommand implements ICommand {
 	private printNSWarnings(sysInfo: ISysInfoData) {
 		if (!sysInfo.adbVer) {
 			this.$logger.warn("WARNING: adb from the Android SDK is not installed or is not configured properly.");
-			this.$logger.out("For Android-related operations, the AppBuilder CLI will use a built-in version of adb." + os.EOL
+			this.$logger.out("For Android-related operations, the NativeScript CLI will use a built-in version of adb." + os.EOL
 			+ "To avoid possible issues with the native Android emulator, Genymotion or connected" + os.EOL
 			+ "Android devices, verify that you have installed the latest Android SDK and" + os.EOL
 			+ "its dependencies as described in http://developer.android.com/sdk/index.html#Requirements" + os.EOL);

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -281,8 +281,6 @@ interface ISysInfoData {
 	nodeGypVer: string;
 
 	// dependencies
-	/** Version string of java as returned by `java -version` */
-	javaVer: string;
 	/** version string of ant, as returned by `ant -version` */
 	antVer: string;
 	/** Xcode version string as returned by `xcodebuild -version`. Valid only on Mac */
@@ -291,6 +289,8 @@ interface ISysInfoData {
 	adbVer: string;
 	/** Whether iTunes is installed on the machine */
 	itunesInstalled: boolean;
+	/** Whether `android` executable can be run */
+	androidInstalled: boolean;
 }
 
 interface ISysInfo {

--- a/sysinfo.ts
+++ b/sysinfo.ts
@@ -34,11 +34,8 @@ export class SysInfo implements ISysInfo {
 			res.npmVer = procOutput ? procOutput.split("\n")[0] : null;
 
 			// dependencies
-			try {
-				res.javaVer = this.$childProcess.spawnFromEvent("java", ["-version"], "exit").wait().stderr.split(os.EOL)[2];
-			} catch(e) {
-				res.javaVer = null;
-			} // if we got an error, assume not working
+			// Java detection is disabled for now. Leaving the code in case we decide to use it later
+			// res.javaVer = this.$childProcess.spawnFromEvent("java", ["-version"], "exit").wait().stderr.split(os.EOL)[2];
 
 			procOutput = this.exec("ant -version");
 			res.antVer = procOutput ? procOutput.split(os.EOL)[0] : null;
@@ -49,6 +46,9 @@ export class SysInfo implements ISysInfo {
 
 			procOutput = this.exec("adb version");
 			res.adbVer = procOutput ? procOutput.split(os.EOL)[0] : null;
+
+			procOutput = this.exec("android -h").toString();
+			res.androidInstalled = procOutput ? _.contains(procOutput, "android") : false;
 
 			this.sysInfoCache = res;
 		}

--- a/sysinfo.ts
+++ b/sysinfo.ts
@@ -47,7 +47,7 @@ export class SysInfo implements ISysInfo {
 			procOutput = this.exec("adb version");
 			res.adbVer = procOutput ? procOutput.split(os.EOL)[0] : null;
 
-			procOutput = this.exec("android -h").toString();
+			procOutput = this.exec("android -h");
 			res.androidInstalled = procOutput ? _.contains(procOutput, "android") : false;
 
 			this.sysInfoCache = res;


### PR DESCRIPTION
- Changed the prompt for enabling auto completion to proper English
- Changed warnings: only the first line is colored, the text is expanded, there are platform-specific hints
- Stop searching for java, instead search for android