### PR TITLE
Fix installation and uninstall of CLI

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -76,3 +76,4 @@ $injector.require("microTemplateService", "./common/services/micro-templating-se
 $injector.require("mobileHelper", "./common/mobile/mobile-helper");
 $injector.require("devicePlatformsConstants", "./common/mobile/device-platforms-constants");
 $injector.require("htmlHelpService", "./common/services/html-help-service");
+$injector.requireCommand("dev-preuninstall", "./common/commands/preuninstall");

--- a/commands/preuninstall.ts
+++ b/commands/preuninstall.ts
@@ -1,0 +1,37 @@
+﻿///<reference path="../../.d.ts"/>
+"use strict";
+
+import options = require("../options");
+import path = require("path");
+import util = require("util");
+
+export class PreUninstallCommand implements ICommand {
+	private static ADB_RELATIVE_PATH = "../resources/platform-tools/android/%s/adb";
+
+	constructor(private $fs: IFileSystem,
+		private $childProcess: IChildProcess,
+		private $logger: ILogger) { }
+	public disableAnalytics = true;
+
+	public allowedParameters: ICommandParameter[] = [];
+
+	public execute(args: string[]): IFuture<void> {
+		return (() => {
+			var relativeAdbPath = util.format(PreUninstallCommand.ADB_RELATIVE_PATH, process.platform);
+			var adbPath = path.join(__dirname, relativeAdbPath);
+
+			var killAdbServerCommand = util.format("\"%s\" kill-server", adbPath);
+			this.$logger.warn("Trying to kill adb server. Some running andorid related operations may fail.");
+
+			try {
+				this.$childProcess.exec(killAdbServerCommand).wait();
+			} catch(err) {
+				this.$logger.trace(err);
+				this.$logger.warn("Unable to kill adb server.");
+			}
+
+			this.$fs.deleteFile(path.join(options["profile-dir"], "KillSwitches", "cli")).wait();
+		}).future<void>()();
+	}
+}
+$injector.registerCommand("dev-preuninstall", PreUninstallCommand);

--- a/services/cancellation.ts
+++ b/services/cancellation.ts
@@ -61,7 +61,7 @@ export class CancellationService implements ICancellationService {
 	}
 
 	private static get killSwitchDir(): string {
-		return path.join(os.tmpdir(), process.env.SUDO_USER || process.env.USER || process.env.USERNAME,  "KillSwitches");
+		return path.join(options.profileDir,  "KillSwitches");
 	}
 
 	private static makeKillSwitchFileName(name: string): string {


### PR DESCRIPTION
Add dev-preuninstall command which is used to execute preuninstall actions. It should be referenced from each CLI in its preuninstall script. Fix KillSwitches dir to be under our profile-dir directory.