### PR TITLE
Fix console help when arguments are not passed

### DIFF
--- a/dispatchers.ts
+++ b/dispatchers.ts
@@ -56,7 +56,9 @@ export class CommandDispatcher implements ICommandDispatcher {
 		if (remaining.length > 0) {
 			return remaining[0].toString().toLowerCase();
 		}
-		return "help";
+		// if only <CLI_NAME> is specified on console, show console help
+		options.help = true;
+		return "";
 	}
 
 	// yargs convert parameters that are numbers to numbers, which we do not expect. undo its hard work.

--- a/services/html-help-service.ts
+++ b/services/html-help-service.ts
@@ -4,7 +4,6 @@
 import util = require("util");
 import Future = require("fibers/future");
 import path = require("path");
-import options = require("options");
 import marked = require("marked");
 var TerminalRenderer = require('marked-terminal');
 var chalk = require("chalk");


### PR DESCRIPTION
When you write `$ appbuilder` or `$ tns` we automatically open index.html in your default html editor. Change this behavior to show index.md in the console (full list of commands). The behavior now is:
`$ <cli_name>` - shows full list of commands in the console
`$ <cli_name> help` - shows full list of commands in the browser
`$ <cli_name> -h` - same as `$ <cli_name>` - shows full list of commands in the console
`$ <cli_name> help -h` - shows help for "help" command in the console
`$ <cli_name> help help` - shows help for "help" command in the browser