### PR TITLE
Fix errors print in debug

### DIFF
--- a/errors.ts
+++ b/errors.ts
@@ -117,7 +117,6 @@ export class Errors implements IErrors {
 			try {
 				return action().wait();
 			} catch(ex) {
-				console.log("this.printCallStack = " + this.printCallStack);
 				console.log(this.printCallStack
 					? resolveCallStack(ex)
 					: "\x1B[31;1m" + ex.message + "\x1B[0m");

--- a/errors.ts
+++ b/errors.ts
@@ -9,8 +9,8 @@ import helpers = require("./helpers");
 function Exception() {}
 Exception.prototype = new Error();
 
-function resolveCallStack(stack: string): string {
-	var stackLines: string[]= stack.split("\n");
+function resolveCallStack(error: Error): string {
+	var stackLines: string[]= error.stack.split("\n");
 	var parsed = _.map(stackLines, (line: string): any => {
 		var match = line.match(/^\s*at ([^(]*) \((.*?):([0-9]+):([0-9]+)\)$/);
 		if (match) {
@@ -54,14 +54,20 @@ function resolveCallStack(stack: string): string {
 		return util.format("    at %s (%s:%s:%s)", functionName, source, sourcePos.line, sourcePos.column);
 	});
 
-	return remapped.join("\n");
+	var outputMessage = remapped.join("\n");
+	if(outputMessage.indexOf(error.message) === -1) {
+		// when fibers throw error in node 0.12.x, the stack does NOT contain the message
+		outputMessage = outputMessage.replace(/Error/, "Error: " + error.message);
+	}
+
+	return outputMessage;
 }
 
 export function installUncaughtExceptionListener(): void {
 	process.on("uncaughtException", (err: Error) => {
 		var callstack = err.stack;
 		if (callstack) {
-			callstack = resolveCallStack(callstack);
+			callstack = resolveCallStack(err);
 		}
 		console.log(callstack || err.toString());
 
@@ -110,9 +116,10 @@ export class Errors implements IErrors {
 		return (() => {
 			try {
 				return action().wait();
-			} catch (ex) {
+			} catch(ex) {
+				console.log("this.printCallStack = " + this.printCallStack);
 				console.log(this.printCallStack
-					? resolveCallStack(ex.stack)
+					? resolveCallStack(ex)
 					: "\x1B[31;1m" + ex.message + "\x1B[0m");
 
 				if (!ex.suppressCommandHelp) {
@@ -130,7 +137,7 @@ export class Errors implements IErrors {
 			return action();
 		} catch (ex) {
 			console.log(this.printCallStack
-				? resolveCallStack(ex.stack)
+				? resolveCallStack(ex)
 				: "\x1B[31;1m" + ex.message + "\x1B[0m");
 
 			process.exit(_.isNumber(ex.errorCode) ? ex.errorCode : ErrorCodes.UNKNOWN);


### PR DESCRIPTION
In case you are using Node 0.12.x and in config.json "debug" is set to true, the real error message is not printed to the output. When we are in debug mode, we print only the callstack and in Node 0.10.x , when fibers throw exception, the top row of the callstack is the error message. With Node 0.12.x, when error is thrown from fibers, the message is not part of the callstack for some reason. Workaround this behavior by checking the callstack and add the message in case it is missing.

> NOTE: The commits are cherry-picked from master