### PR TITLE
Add getString method to the prompter

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -183,8 +183,6 @@ interface IDictionary<T> {
 	[key: string]: T
 }
 
-interface IStringDictionary extends IDictionary<string> { }
-
 interface IAnalyticsService {
 	checkConsent(featureName: string): IFuture<void>;
 	trackFeature(featureName: string): IFuture<void>;
@@ -198,6 +196,8 @@ interface IAnalyticsService {
 interface IPrompter extends IDisposable {
 	get(schema: IPromptSchema[]): IFuture<any>;
 	getPassword(prompt: string, options?: {allowEmpty?: boolean}): IFuture<string>;
+	getString(prompt: string): IFuture<string>;
+	promptForChoice(promptMessage: string, choices: any[]): IFuture<string>;
 	confirm(prompt: string, defaultAction?: () => boolean): IFuture<boolean>;
 }
 

--- a/prompter.ts
+++ b/prompter.ts
@@ -68,6 +68,33 @@ export class Prompter implements IPrompter {
 		}).future<string>()();
 	}
 
+	public getString(prompt: string): IFuture<string> {
+		return (() => {
+			var schema: IPromptSchema = {
+				message: prompt,
+				type: "input",
+				name: "inputString"
+			};
+
+			var result = this.get([schema]).wait();
+			return result.inputString;
+		}).future<string>()();
+	}
+
+	public promptForChoice(promptMessage: string, choices: any[]): IFuture<string> {
+		return (() => {
+			var schema: IPromptSchema = {
+				message: promptMessage,
+				type: "list",
+				name: "userAnswer",
+				choices: choices
+			};
+
+			var result = this.get([schema]).wait();
+			return result.userAnswer;
+		}).future<string>()();
+	}
+
 	public confirm(prompt: string, defaultAction?: () => boolean): IFuture<boolean> {
 		return ((): boolean => {
 			var schema = {


### PR DESCRIPTION
In most cases one only needs to prompt the user for a single input.
I exposed a getString method similar to getPassword for facilitation.

promptForChoice on the other hand asks the user to choose from a list of options.