### PR TITLE
Fix ILogger definitions

### DIFF
--- a/definitions/logger.d.ts
+++ b/definitions/logger.d.ts
@@ -1,14 +1,14 @@
 interface ILogger {
 	setLevel(level: string): void;
 	getLevel(): string;
-	fatal(formatStr: any, ...args: string[]): void;
-	error(formatStr: any, ...args: string[]): void;
-	warn(formatStr: any, ...args: string[]): void;
-	info(formatStr: any, ...args: string[]): void;
-	debug(formatStr: any, ...args: string[]): void;
-	trace(formatStr: any, ...args: string[]): void;
+	fatal(formatStr?: any, ...args: string[]): void;
+	error(formatStr?: any, ...args: string[]): void;
+	warn(formatStr?: any, ...args: string[]): void;
+	info(formatStr?: any, ...args: string[]): void;
+	debug(formatStr?: any, ...args: string[]): void;
+	trace(formatStr?: any, ...args: string[]): void;
 
-	out(formatStr: any, ...args: string[]): void;
+	out(formatStr?: any, ...args: string[]): void;
 	write(...args: string[]): void;
 
 	prepare(item: any): string;


### PR DESCRIPTION
Allow logger functions to be called without parameters