### PR TITLE
Move KillSwitches dir to tmp

### DIFF
--- a/services/cancellation.ts
+++ b/services/cancellation.ts
@@ -61,7 +61,7 @@ export class CancellationService implements ICancellationService {
 	}
 
 	private static get killSwitchDir(): string {
-		return path.join(options.profileDir,  "KillSwitches");
+		return path.join(os.tmpdir(), process.env.SUDO_USER || process.env.USER || process.env.USERNAME, "KillSwitches");
 	}
 
 	private static makeKillSwitchFileName(name: string): string {


### PR DESCRIPTION
Move KillSwitches dir to os.temp directory as when CLI is installed with sudo, we need correct privileges.

Cherry-picked from release-appbuilder branch