### PR TITLE
Show command line help for hierarchical commands

### DIFF
--- a/yok.ts
+++ b/yok.ts
@@ -227,6 +227,10 @@ export class Yok implements IInjector {
 								commandName = this.getHierarchicalCommandName(name, defaultCommand);
 							} else {
 								commandName = "help";
+
+								// Show command-line help
+								var options = require("./options");
+								options.help = true;
 							}
 						}
 


### PR DESCRIPTION
If hierarchical command does NOT have default command, for example `appbuilder build`, trying to execute it should print console help. Instead this leads to opening html help.
Set option.help to true in this case. Require the options in the action itself in order to prevent cyclic errors when yok and options are required.

Fixes http://teampulse.telerik.com/view#item/290168