### PR TITLE
Fix markdown links in console

### DIFF
--- a/services/html-help-service.ts
+++ b/services/html-help-service.ts
@@ -16,7 +16,7 @@ export class HtmlHelpService implements IHtmlHelpService {
 	private static RELATIVE_PATH_TO_STYLES_CSS_REGEX = /@RELATIVE_PATH_TO_STYLES_CSS@/g;
 	private static RELATIVE_PATH_TO_IMAGES_REGEX = /@RELATIVE_PATH_TO_IMAGES@/g;
 	private static RELATIVE_PATH_TO_INDEX_REGEX = /@RELATIVE_PATH_TO_INDEX@/g;
-	private static MARKDROWN_LINK_REGEX = /\[([\s\S]+?)\]\([\s\S]*?\)/g;
+	private static MARKDOWN_LINK_REGEX = /\[([\w -`<>]+?)\]\([\s\S]*?\)/g;
 
 	private pathToManPages: string;
 	private pathToHtmlPages: string;
@@ -152,7 +152,7 @@ export class HtmlHelpService implements IHtmlHelpService {
 			var helpText = this.readMdFileForCommand(commandName).wait();
 			var outputText = this.$microTemplateService.parseContent(helpText, { isHtml: false })
 				.replace(/&nbsp;/g, " ")
-				.replace(HtmlHelpService.MARKDROWN_LINK_REGEX, "$1");
+				.replace(HtmlHelpService.MARKDOWN_LINK_REGEX, "$1");
 
 			var opts = {
 				unescape: true,


### PR DESCRIPTION
Links in markdown files should be stripped in console help. Fix the incorrect regex, so now the correct text between [ and ] will be shown.
Fixes: http://teampulse.telerik.com/view#item/290105