### PR TITLE
Fix tabtab logging

### DIFF
--- a/definitions/options-service.d.ts
+++ b/definitions/options-service.d.ts
@@ -1,3 +1,0 @@
-interface IOptionsService {
-	getKnownOptions(): string[];
-}

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -230,14 +230,16 @@ export class CommandsService implements ICommandsService {
 
 				var childrenCommands = this.$injector.getChildrenCommandsNames(commandName);
 
-				if(data.words === 1) {
-					return tabtab.log(this.allCommands(false), data);
+				if(data.last && _.startsWith(data.last, "--")) {
+					return tabtab.log(_.keys(options.knownOpts), data, "--");
 				}
 
-				if(data.last.startsWith("--")) {
-					// Resolve optionsService here. It is not part of common lib, because we need all knownOptions for each CLI.
-					var optionsService: IOptionsService = this.$injector.resolve("optionsService");
-					return tabtab.log(optionsService.getKnownOptions(), data, "--");
+				if(data.last && _.startsWith(data.last, "-")) {
+					return tabtab.log(_.keys(options.shorthands), data, "-");
+				}
+
+				if(data.words === 1) {
+					return tabtab.log(this.allCommands(false), data);
 				}
 
 				if(data.words >= 3) { // Hierarchical command


### PR DESCRIPTION
Use correct `_.startsWith` method, the used one was throwing exception. Move the logic for showing `-- options` to be at the beginning of the method, so you can write `$ appbuilder --` and to see all available options. Add logic to show shortcut options. Remove IOptionsService interface as the OptionsService was required for our old logic. Now, when external options are extending knownOpts of common lib's options, we do not need this service.
Fixes http://teampulse.telerik.com/view#item/288643