### PR TITLE
Show application output by default

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -46,6 +46,10 @@ declare module Mobile {
 		start(deviceIdentifier: string, adbPath: string): any;
 	}
 
+	interface ILogcatPrinter {
+		print(line: string): void;
+	}
+
 	interface IDebugOnDeviceSetup {
 		frontEndPath?: string;
 	}

--- a/mobile/android/android-device.ts
+++ b/mobile/android/android-device.ts
@@ -174,7 +174,7 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 			var startPackageCommand = this.composeCommand("shell am start -a android.intent.action.MAIN -n %s/%s -c android.intent.category.LAUNCHER", packageName, this.$staticConfig.START_PACKAGE_ACTIVITY_NAME);
 			this.$childProcess.exec(startPackageCommand).wait();
 
-			if (options.printAppOutput) {
+			if (!options.justlaunch) {
 				this.openDeviceLogStream();
 			}
 		}).future<void>()();

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -113,7 +113,7 @@ class AndroidEmulatorServices implements Mobile.IEmulatorPlatformServices {
 				{ stdio: "ignore", detached: true });
 			this.$fs.futureFromEvent(childProcess, "close").wait();
 
-			if (options.printAppOutput) {
+			if (!options.justlaunch) {
 				this.$logcatHelper.start(emulatorId, this.adbFilePath);
 			}
 		}).future<void>()();

--- a/mobile/android/logcat-helper.ts
+++ b/mobile/android/logcat-helper.ts
@@ -1,16 +1,17 @@
 ///<reference path="../../../.d.ts"/>
 "use strict";
 import byline = require("byline");
+import util = require("util");
 
 export class LogcatHelper implements Mobile.ILogcatHelper {
-	private lineRegex = /.\/(.+?)\s*\(\s*(\d+?)\): (.*)/;
-
 	constructor(private $childProcess: IChildProcess,
-		    private $logger: ILogger) {
+		    private $logcatPrinter: Mobile.ILogcatPrinter,
+			private $logger: ILogger){
 
 	}
 
 	public start(deviceIdentifier: string, adbPath: string): any {
+		this.$childProcess.exec(util.format("%s -s %s logcat -c", adbPath, deviceIdentifier)).wait();
 		var adbLogcat = this.$childProcess.spawn(adbPath, ["-s", deviceIdentifier, "logcat"]);
 		var lineStream = byline(adbLogcat.stdout);
 
@@ -26,33 +27,10 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 
 		lineStream.on('data', (line: NodeBuffer) => {
 			var lineText = line.toString();
-			var log = this.getConsoleLogFromLine(lineText);
-			if(log) {
-				if(log.tag) {
-					this.$logger.out("%s: %s", log.tag, log.message);
-				} else {
-					this.$logger.out(log.message);
-				}
-			}
+			this.$logcatPrinter.print(lineText);
 		});
 
 		return adbLogcat;
-	}
-
-	private getConsoleLogFromLine(lineText: String): any {
-		var acceptedTags = ["chromium", "Web Console", "JS"];
-
-		//sample line is "I/Web Console(    4438): Received Event: deviceready at file:///storage/emulated/0/Icenium/com.telerik.TestApp/js/index.js:48"
-		var match = lineText.match(this.lineRegex);
-		if(match) {
-			if(acceptedTags.indexOf(match[1]) !== -1) {
-				return {tag: match[1], message: match[3]};
-			}
-		} else if(_.any(acceptedTags, (tag: string) => { return lineText.indexOf(tag) !== -1; })) {
-			return {message: match[3]};
-		}
-
-		return null;
 	}
 }
 $injector.register("logcatHelper", LogcatHelper);

--- a/mobile/android/logcat-helper.ts
+++ b/mobile/android/logcat-helper.ts
@@ -11,7 +11,7 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 	}
 
 	public start(deviceIdentifier: string, adbPath: string): any {
-		this.$childProcess.exec(util.format("%s -s %s logcat -c", adbPath, deviceIdentifier)).wait();
+		this.$childProcess.exec(util.format("%s -s %s logcat -c", adbPath, deviceIdentifier)).wait(); // remove cached logs
 		var adbLogcat = this.$childProcess.spawn(adbPath, ["-s", deviceIdentifier, "logcat"]);
 		var lineStream = byline(adbLogcat.stdout);
 

--- a/mobile/ios/ios-core.ts
+++ b/mobile/ios/ios-core.ts
@@ -1095,7 +1095,7 @@ export class GDBServer implements Mobile.IGDBServer {
 		if(hostInfo.isWindows()) {
 			this.send("vCont;c");
 		} else {
-			if (options.printAppOutput) {
+			if (!options.justlaunch) {
 				this.socket.pipe(new GDBStandardOutputAdapter()).pipe(process.stdout);
 				this.socket.pipe(new GDBSignalWatcher());
 				this.send("vCont;c");

--- a/mobile/ios/ios-emulator-services.ts
+++ b/mobile/ios/ios-emulator-services.ts
@@ -66,7 +66,7 @@ class IosEmulatorServices implements Mobile.IEmulatorPlatformServices {
 			"--timeout", options.timeout
 		];
 
-		if(options.printAppOutput) {
+		if(!options.justlaunch) {
 			opts.push("--logging");
 		} else {
 			if(emulatorOptions) {

--- a/mobile/ios/ios-proxy-services.ts
+++ b/mobile/ios/ios-proxy-services.ts
@@ -383,7 +383,6 @@ export class HouseArrestClient implements Mobile.IHouseArrestClient {
 
 export class IOSSyslog {
 	private plistService: Mobile.IiOSDeviceSocket;
-	private matchRegex = new RegExp(".*?((Cordova.{3}|AppBuilder)\\[\\d+\\] <Warning>: )", 'i');
 
 	constructor(private device: Mobile.IIOSDevice,
 		private $logger: ILogger,
@@ -392,12 +391,16 @@ export class IOSSyslog {
 	}
 
 	public read(): void {
+		var shouldLog = false;
+		setTimeout(() => shouldLog = true, 2500);
+
 		var printData = (data: NodeBuffer) => {
-			var output = ref.readCString(data, 0);
-			if(this.matchRegex.test(output)) {
-				this.$logger.out(output);
+			if(shouldLog) {
+				var output = ref.readCString(data, 0);
+				this.$logger.write(output);
 			}
 		};
+
 
 		this.plistService.readSystemLog(printData);
 	}

--- a/options.ts
+++ b/options.ts
@@ -31,7 +31,7 @@ var knownOpts: any = {
 	"start": Boolean,
 	"stop": Boolean,
 	"ddi": String, // the path to developer  disk image
-	"print-app-output": Boolean
+	"justlaunch": Boolean
 };
 var shorthands: IStringDictionary = {
 	"v": "verbose",


### PR DESCRIPTION
Until now the application output was printed only if the --printAppOutput option was specified. This PR changes this behavior and the application output is printed by default. The new option - justlaunch is introduced and if it is specified the application output is not printed. 

Also this PR removes the filtration of android logcat for projects created with nativescript-cli.