### PR TITLE
Prevent doubling of typescript definitions

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -231,7 +231,7 @@ interface IHook {
 }
 
 interface ITypeScriptCompilationService {
-	initialize(typeScriptFiles: string[]): void;
+	initialize(typeScriptFiles: string[], definitionFiles?: string[]): void;
 	compileAllFiles(): IFuture<void>;
 }
 


### PR DESCRIPTION
CLI has its own typescript definition files, which are used when we build typescript projects. Make sure to exclude them in case the project directory already has files with such name. This is the scenario with NativeScript TypeScript projects, which have android17.d.ts files in the templates and we are adding them again on build.

Fixes http://teampulse.telerik.com/view#item/290964
