### PR TITLE
Fix hierarchical commands' case-sensitivity

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -126,7 +126,7 @@ interface ICommandOptions {
 	enableHooks?: boolean;
 }
 
-declare enum ErrorCodes {
+declare const enum ErrorCodes {
 	UNKNOWN = 127,
 	INVALID_ARGUMENT = 128
 }

--- a/yok.ts
+++ b/yok.ts
@@ -176,6 +176,7 @@ export class Yok implements IInjector {
 		let remainingArguments = commandLineArguments;
 		let foundSubCommand = false;
 		_.each(commandLineArguments, arg => {
+			arg = arg.toLowerCase();
 			subCommandName = subCommandName ? this.getHierarchicalCommandName(subCommandName, arg) : arg;
 			remainingArguments = _.rest(remainingArguments);
 			if(_.any(subCommands,(sc) => sc === subCommandName)) {


### PR DESCRIPTION
In addition declare ErrorCodes enum as const
to conform with TypeScript 1.5
Fixes http://teampulse.telerik.com/view#item/291385