### PR TITLE
Use Cancellation service only on Windows

### DIFF
--- a/commands/preuninstall.ts
+++ b/commands/preuninstall.ts
@@ -10,7 +10,8 @@ export class PreUninstallCommand implements ICommand {
 
 	constructor(private $fs: IFileSystem,
 		private $childProcess: IChildProcess,
-		private $logger: ILogger) { }
+		private $logger: ILogger,
+		private $cancellationService: ICancellationService) { }
 	public disableAnalytics = true;
 
 	public allowedParameters: ICommandParameter[] = [];


### PR DESCRIPTION
Due to different security models on Windows and *ix, this code cannot be made to work reliably on all OSes. Because it exists only because Windows keeps executable code locked, the right thing to do is to execute it only on Windows.