### PR TITLE
Enable command autocompletion when local installation is used

### DIFF
--- a/commands/preuninstall.ts
+++ b/commands/preuninstall.ts
@@ -10,8 +10,7 @@ export class PreUninstallCommand implements ICommand {
 
 	constructor(private $fs: IFileSystem,
 		private $childProcess: IChildProcess,
-		private $logger: ILogger,
-		private $cancellationService: ICancellationService) { }
+		private $logger: ILogger) { }
 	public disableAnalytics = true;
 
 	public allowedParameters: ICommandParameter[] = [];

--- a/services/auto-completion-service.ts
+++ b/services/auto-completion-service.ts
@@ -235,8 +235,10 @@ export class AutoCompletionService implements IAutoCompletionService {
 				}
 
 				if(doUpdate) {
-					this.$childProcess.exec(this.$staticConfig.CLIENT_NAME.toLowerCase() + " completion >> " + filePath).wait();
-					this.$fs.chmod(filePath, "0777").wait();
+					let clientExecutableFileName = this.$staticConfig.CLIENT_NAME_ALIAS || this.$staticConfig.CLIENT_NAME;
+					let pathToExecutableFile = path.join(__dirname, `../../../bin/${clientExecutableFileName}.js`);
+					this.$childProcess.exec(`${process.argv[0]} ${pathToExecutableFile} completion >> ${filePath}`).wait();
+					this.$fs.chmod(filePath, "0644").wait();
 				}
 			} catch(err) {
 				this.$logger.out("Failed to update %s. Auto-completion may not work. ", filePath);


### PR DESCRIPTION
When you do not specify -g flag, we could still enable autocompletion, but currently this process fails as we are executing globally installed CLI (for example tns completion >> ...). Use the javascript from bin directory instead.
Fix dev-preuninstall command, which was failing due to incorrect service called in it (cancellationService is not called at all, so I removed it. In fact we have $cancellation, not $cancellationService).