### PR TITLE
Fix autocompletion on Linux

### DIFF
--- a/services/auto-completion-service.ts
+++ b/services/auto-completion-service.ts
@@ -235,7 +235,7 @@ export class AutoCompletionService implements IAutoCompletionService {
 				}
 
 				if(doUpdate) {
-					let clientExecutableFileName = this.$staticConfig.CLIENT_NAME_ALIAS || this.$staticConfig.CLIENT_NAME;
+					let clientExecutableFileName = (this.$staticConfig.CLIENT_NAME_ALIAS || this.$staticConfig.CLIENT_NAME).toLowerCase()
 					let pathToExecutableFile = path.join(__dirname, `../../../bin/${clientExecutableFileName}.js`);
 					this.$childProcess.exec(`${process.argv[0]} ${pathToExecutableFile} completion >> ${filePath}`).wait();
 					this.$fs.chmod(filePath, "0644").wait();


### PR DESCRIPTION
Linux has case-sensitive file system and autocompletion is unable to find correct appbuilder.js/nativescript.js file as it is searching for AppBuilder.js/NativeScript.js