### PR TITLE
Handle bad file descriptors in iOSDevice.connectToPort

### DIFF
--- a/mobile/ios/ios-device.ts
+++ b/mobile/ios/ios-device.ts
@@ -459,7 +459,16 @@ export class IOSDevice implements Mobile.IIOSDevice {
 			this.$mobileDevice.uSBMuxConnectByPort(connectionId, this.htons(port), socketRef);
 			let socketValue = socketRef.deref();
 
-			return new net.Socket({ fd: socketValue });
+			let socket: net.Socket;
+			if (socketValue < 0) {
+				socket = new net.Socket();
+				process.nextTick(() => socket.emit("error", new Error("USBMuxConnectByPort returned bad file descriptor")));
+			} else {
+				socket = new net.Socket({ fd: socketValue });
+				process.nextTick(() => socket.emit("connect"));
+			}
+
+			return socket;
 		}
 
 		return null;


### PR DESCRIPTION
Whenever `USBMuxConnectByPort` fails to connect to a port on a device, either because the device is no longer there, or the connection is refused, it returns a negative value file descriptor. This upsets Node's `net.Socket` constructor that accepts a file descriptor and causes an assertion failure.

This patch handles bad file descriptors by creating a pristine `net.Socket` and emitting the `error` event on it.