### PR TITLE
Allow parallel executions of many CLIs

### DIFF
--- a/services/cancellation.ts
+++ b/services/cancellation.ts
@@ -19,12 +19,13 @@ class CancellationService implements ICancellationService {
 	public begin(name: string): IFuture<void> {
 		return (() => {
 			let triggerFile = CancellationService.makeKillSwitchFileName(name);
-
-			let stream = this.$fs.createWriteStream(triggerFile);
-			let streamEnd = this.$fs.futureFromEvent(stream, "finish");
-			stream.end();
-			streamEnd.wait();
-			this.$fs.chmod(triggerFile, "0777").wait();
+			if(!this.$fs.exists(triggerFile).wait()) { 
+				let stream = this.$fs.createWriteStream(triggerFile);
+				let streamEnd = this.$fs.futureFromEvent(stream, "finish");
+				stream.end();
+				streamEnd.wait();
+				this.$fs.chmod(triggerFile, "0777").wait();
+			}
 
 			this.$logger.trace("Starting watch on killswitch %s", triggerFile);
 


### PR DESCRIPTION
Currently when you try to use CLI in more than one terminal simultaneously, only the last process keeps working, while the other ones stop immediately when the next process starts. This is due to our code, which recreates the "cli" watch file. Add check if the file exists and do not recreate it in such case.

Fixes http://teampulse.telerik.com/view#item/292941