### PR TITLE
Add Object type to Options

### DIFF
--- a/options.ts
+++ b/options.ts
@@ -9,7 +9,8 @@ export enum OptionType {
 	String,
 	Boolean,
 	Number,
-	Array
+	Array,
+	Object
 }
 
 export class OptionsBase {
@@ -111,17 +112,16 @@ export class OptionsBase {
 			let optionName = this.getCorrectOptionName(originalOptionName);
 
 			if (!_.contains(this.optionsWhiteList, optionName)) {
-				
 				if (!this.isOptionSupported(optionName)) {
 					this.$errors.failWithoutHelp("The option '%s' is not supported. To see command's options, use '$ %s help %s'. To see all commands use '$ %s help'.", originalOptionName, this.$staticConfig.CLIENT_NAME.toLowerCase(), process.argv[2], this.$staticConfig.CLIENT_NAME.toLowerCase());
 				} 
-				
+
 				let optionType = this.getOptionType(optionName);
 				let optionValue = parsed[optionName];
 				let parsedOptionType = typeof (optionValue);
-				
+
 				if (_.isArray(optionValue) && optionType !== OptionType.Array) {
-					this.$errors.failWithoutHelp("You have set the %s option multiple times. Check the correct command syntax below and try again.", originalOptionName);
+					this.$errors.fail("You have set the %s option multiple times. Check the correct command syntax below and try again.", originalOptionName);
 				} else if (this.doesOptionRequireValue(optionType, parsedOptionType)) {
 					this.$errors.failWithoutHelp("The option '%s' requires a value.", originalOptionName);
 				} else if (optionType === OptionType.String && helpers.isNullOrWhitespace(optionValue)) {


### PR DESCRIPTION
Yargs creates objects for options passed with dots, for example --var.debug.a 2 will create the object
```JavaScript
{
    "debug": 2
}
```
Add the Object type as available for our options and replace failWithoutHelp with fail as the message says "Check the help below", but there's no help when `failWithoutHelp` is used.

Part of http://teampulse.telerik.com/view#item/292387