### PR TITLE
Add general track method

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -189,6 +189,7 @@ interface IAnalyticsService {
 	disableAnalytics(): IFuture<void>;
 	getStatusMessage(): IFuture<string>;
 	isEnabled(): IFuture<boolean>;
+	track(featureName: string, featureValue: string): IFuture<void>;
 }
 
 interface IPrompter extends IDisposable {

--- a/services/analytics-service.ts
+++ b/services/analytics-service.ts
@@ -42,15 +42,19 @@ export class AnalyticsService implements IAnalyticsService {
 	}
 
 	public trackFeature(featureName: string): IFuture<void> {
+		let category = this.$options.client ||
+						(helpers.isInteractive() ? "CLI" : "Non-interactive");
+		return this.track(category, featureName);
+	}
+
+	public track(featureName: string, featureValue: string): IFuture<void> {
 		return (() => {
+			this.$logger.trace(`Trying to track feature '${featureName}' with value '${featureValue}'.`);
 			if(this.$analyticsSettingsService.canDoRequest().wait()) {
 				try {
 					this.start().wait();
 					if(this._eqatecMonitor) {
-						
-						let category = this.$options.client ||
-							(helpers.isInteractive() ? "CLI" : "Non-interactive");
-						this._eqatecMonitor.trackFeature(category + "." + featureName);
+						this._eqatecMonitor.trackFeature(`${featureName}.${featureValue}`);
 					}
 				} catch(e) {
 					this.$logger.trace("Analytics exception: '%s'", e.toString());


### PR DESCRIPTION
When feature tracking is enabled, we need an easy way to track new features that will go in separate section on the feature page. Add such track method. When you want to track new information, just pass the feature name and its value to track method.