### PR TITLE
Fix analytics feature tracking

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -356,6 +356,7 @@ interface ICommonOptions {
 	skipRefresh: boolean;
 	app: string;
 	file: string;
+	analyticsClient: string;
 }
 
 interface IYargArgv extends IDictionary<any> {

--- a/options.ts
+++ b/options.ts
@@ -85,7 +85,8 @@ export class OptionsBase {
 			"stop": { type: OptionType.Boolean },
 			"ddi": { type: OptionType.String }, // the path to developer  disk image
 			"justlaunch": { type: OptionType.Boolean },
-			"file": { type: OptionType.String }
+			"file": { type: OptionType.String },
+			"analyticsClient": {type: OptionType.String}
 		}
 	}
 

--- a/services/analytics-service.ts
+++ b/services/analytics-service.ts
@@ -42,7 +42,7 @@ export class AnalyticsService implements IAnalyticsService {
 	}
 
 	public trackFeature(featureName: string): IFuture<void> {
-		let category = this.$options.client ||
+		let category = this.$options.analyticsClient || 
 						(helpers.isInteractive() ? "CLI" : "Non-interactive");
 		return this.track(category, featureName);
 	}


### PR DESCRIPTION
Feature tracking is checking incorrect option - client.  As this option has different meaning in our CLIs, add new option - analyticsClient and use it instead of client when tracking features.