### PR TITLE
Chain options before getting argv

### DIFF
--- a/options.ts
+++ b/options.ts
@@ -25,8 +25,7 @@ export class OptionsBase {
 			
 		_.extend(this.options, this.commonOptions);
 
-		yargs.options(this.options);
-		this.argv = yargs.argv;
+		this.argv = yargs.options(this.options).argv;
 		
 		// Check if some of the given options is alias and add its original name to argv
 		_.each(_.keys(this.argv), item => {


### PR DESCRIPTION
This is the [right way](https://www.npmjs.com/package/yargs#options-key-opt) to use the `.options()` function of yargs.