### PR TITLE
Add dashedOptions for each command

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -328,7 +328,7 @@ interface Error {
 
 interface ICommonOptions {
 	argv: IYargArgv;
-	validateOptions(): void;
+	validateOptions(commandSpecificDashedOptions?: IDictionary<IDashedOption>): void;
 	options: IDictionary<any>;
 	shorthands: string[];
 
@@ -362,6 +362,65 @@ interface ICommonOptions {
 interface IYargArgv extends IDictionary<any> {
 	_: string[];
 	$0: string;
+}
+
+/**
+ * Describes dashed option (starting with --) passed on the command line.
+ * @interface
+ */
+interface IDashedOption {
+	/**
+	 * Type of the option. It can be string, boolean, Array, etc.
+	 */
+	type: string;
+	/**
+	 * Shorthand option passed on the command line with `-` sign, for example `-v`
+	 */
+	alias?: any;
+	/**
+	 * Defines if the options is mandatory or the number of mandatory arguments.
+	 */
+	demand?: any;
+	/**
+	 * @see demand
+	 */
+	required?: any;
+	/**
+	 * @see demand
+	 */
+	require?: any;
+	/**
+	 * Sets default value of the -- option if it is NOT passed on the command line.
+	 */
+	default?: any;
+	/**
+	 * Interpret the value as boolean, even if value is passed for it.
+	 */
+	boolean?: any;
+	/**
+	 * Interpret the value as string, especially useful when you have to preserve numbers leading zeroes.
+	 */
+	string?: any;
+	/**
+	 * Returns the count of the dashed options passed on the command line.
+	 */
+	count?: any;
+	/**
+	 * Describes the usage of option.
+	 */
+	describe?: any;
+	/**
+	 * No information about this option. Keep it here for backwards compatibility, but use describe instead.
+	 */
+	description?: any;
+	/**
+	 * @see describe
+	 */
+	desc?: any;
+	/**
+	 * Specifies either a single option key (string), or an array of options that must be followed by option values.
+	 */
+	requiresArg?: any;
 }
 
 /**

--- a/definitions/commands.d.ts
+++ b/definitions/commands.d.ts
@@ -1,3 +1,4 @@
+
 interface ICommand extends ICommandOptions {
 	execute(args: string[]): IFuture<void>;
 	allowedParameters: ICommandParameter[];
@@ -11,6 +12,7 @@ interface ICommand extends ICommandOptions {
 	// default validation in CommandsService is not applicable.
 	canExecute?(args: string[]): IFuture<boolean>;
 	completionData?: string[];
+	dashedOptions?: IDictionary<IDashedOption>;
 }
 
 interface IDynamicCommand extends ICommand { }

--- a/definitions/yargs.d.ts
+++ b/definitions/yargs.d.ts
@@ -45,13 +45,13 @@ declare module "yargs" {
 			describe(key: string, description: string): Argv;
 			describe(descriptions: { [key: string]: string }): Argv;
 
-			option(key: string, options: IOption): Argv;
-			option(options: { [key: string]: IOption }): Argv;
-			options(key: string, options: IOption): Argv;
-			options(options: { [key: string]: IOption }): Argv;
+			option(key: string, options: IDashedOption): Argv;
+			option(options: { [key: string]: IDashedOption }): Argv;
+			options(key: string, options: IDashedOption): Argv;
+			options(options: { [key: string]: IDashedOption }): Argv;
 
-			usage(message: string, options?: { [key: string]: IOption }): Argv;
-			usage(options?: { [key: string]: IOption }): Argv;
+			usage(message: string, options?: { [key: string]: IDashedOption }): Argv;
+			usage(options?: { [key: string]: IDashedOption }): Argv;
 
 			example(command: string, description: string): Argv;
 
@@ -92,22 +92,6 @@ declare module "yargs" {
 			count(keys: string[]): Argv;
 
 			fail(func: (msg: string) => any): void;
-		}
-
-		interface IOption {
-			type?: any;
-			alias?: any;
-			demand?: any;
-			required?: any;
-			require?: any;
-			default?: any;
-			boolean?: any;
-			string?: any;
-			count?: any;
-			describe?: any;
-			description?: any;
-			desc?: any;
-			requiresArg?: any;
 		}
 	}
 

--- a/options.ts
+++ b/options.ts
@@ -5,52 +5,37 @@ import util = require("util");
 import helpers = require("./helpers");
 import yargs = require("yargs");
 
-export enum OptionType {
-	String,
-	Boolean,
-	Number,
-	Array,
-	Object
+export class OptionType {
+	public static String = "string";
+	public static Boolean = "boolean";
+	public static Number = "number";
+	public static Array = "array";
+	public static Object = "object";
 }
 
 export class OptionsBase {
 	private optionsWhiteList = ["ui", "recursive", "reporter", "require", "timeout", "_", "$0"]; // These options shouldn't be validated
 	private _parsed: any[];
 	public argv: IYargArgv;
+	private static GLOBAL_OPTIONS: IDictionary<IDashedOption> = {
+		"log": { type: OptionType.String },
+		"verbose": { type: OptionType.Boolean, alias: "v" },
+		"version": { type: OptionType.Boolean },
+		"help": { type: OptionType.Boolean, alias: "h" },
+		"profileDir": { type: OptionType.String },
+		"analyticsClient": {type: OptionType.String},
+		"path": { type: OptionType.String, alias: "p" }
+	};
 
-	constructor(public options: IDictionary<yargs.IOption>,
+	constructor(public options: IDictionary<IDashedOption>,
 		public defaultProfileDir: string,
 		private $errors: IErrors,
 		private $staticConfig: IStaticConfig) {
 			
-		_.extend(this.options, this.commonOptions);
-
-		this.argv = yargs.options(this.options).argv;
-		
-		// Check if some of the given options is alias and add its original name to argv
-		_.each(_.keys(this.argv), item => {
-			_.each(this.optionNames, optionName => {
-				if(this.options[optionName].alias === item) {
-					this.argv[optionName] = this.argv[item];
-				} 
-			});
-		});
-		
-		this.argv["profileDir"] = this.argv["profileDir"] || this.defaultProfileDir;		
-
-		_.each(this.optionNames, optionName => {
-			Object.defineProperty(OptionsBase.prototype, optionName, {
-				configurable: true,
-				get: function () {
-					return this.getOptionValue(optionName);
-				},
-				set: function(value: any) {
-					this.argv[optionName] = value;
-				}
-			});
-		});
+		_.extend(this.options, this.commonOptions, OptionsBase.GLOBAL_OPTIONS);
+		this.setArgv();
 	}
-	
+
 	public get shorthands(): string[] {
 		var result: string[] = [];
 		_.each(_.keys(this.options), optionName => {
@@ -61,17 +46,11 @@ export class OptionsBase {
 		return result;
 	}
 
-	private get commonOptions(): IDictionary<yargs.IOption> {
+	private get commonOptions(): IDictionary<IDashedOption> {
 		return {
-			"log": { type: OptionType.String },
-			"verbose": { type: OptionType.Boolean, alias: "v" },
-			"path": { type: OptionType.String, alias: "p" },
-			"version": { type: OptionType.Boolean },
-			"help": { type: OptionType.Boolean, alias: "h" },
 			"json": { type: OptionType.Boolean },
 			"watch": { type: OptionType.Boolean },
 			"avd": { type: OptionType.String },
-			"profileDir": { type: OptionType.String },
 			"timeout": { type: OptionType.String },
 			"device": { type: OptionType.String },
 			"availableDevices": { type: OptionType.Boolean },
@@ -84,8 +63,7 @@ export class OptionsBase {
 			"stop": { type: OptionType.Boolean },
 			"ddi": { type: OptionType.String }, // the path to developer  disk image
 			"justlaunch": { type: OptionType.Boolean },
-			"file": { type: OptionType.String },
-			"analyticsClient": {type: OptionType.String}
+			"file": { type: OptionType.String }
 		}
 	}
 
@@ -95,39 +73,42 @@ export class OptionsBase {
 
 	private getOptionValue(optionName: string): any {
 		optionName = this.getCorrectOptionName(optionName);
-		let result = typeof this.argv[optionName] === "number" ? this.argv[optionName].toString() : this.argv[optionName];
-		
-		let optionType = this.getOptionType(optionName);
-		if(optionType === OptionType.Array && typeof result === "string") {
-			return [result];
-		} 
-		
-		return result;
+		return this.argv[optionName];
 	}
 
-	public validateOptions(): void {
+	public validateOptions(commandSpecificDashedOptions?: IDictionary<IDashedOption>): void {
+		if(commandSpecificDashedOptions) {
+			this.options = OptionsBase.GLOBAL_OPTIONS;
+			_.extend(this.options, commandSpecificDashedOptions);
+			this.setArgv();
+		}
+
 		let parsed = Object.create(null);
-		_.each(_.keys(this.argv), optionName => parsed[optionName] = this.getOptionValue(optionName));
-		_.each(_.keys(parsed), (originalOptionName:string) => {
+		// DO NOT REMOVE { } as when they are missing and some of the option values is false, the each stops as it thinks we have set "return false".
+		_.each(_.keys(this.argv), optionName => {
+			parsed[optionName] = this.getOptionValue(optionName);
+		});
+
+		_.each(parsed, (value:any, originalOptionName:string) => {
+			// when this.options are passed to yargs, it returns all of them and the ones that are not part of process.argv are set to undefined.
+			if(value === undefined) {
+				return;
+			}
+
 			let optionName = this.getCorrectOptionName(originalOptionName);
 
 			if (!_.contains(this.optionsWhiteList, optionName)) {
 				if (!this.isOptionSupported(optionName)) {
-					this.$errors.failWithoutHelp("The option '%s' is not supported. To see command's options, use '$ %s help %s'. To see all commands use '$ %s help'.", originalOptionName, this.$staticConfig.CLIENT_NAME.toLowerCase(), process.argv[2], this.$staticConfig.CLIENT_NAME.toLowerCase());
+					this.$errors.failWithoutHelp(`The option '${originalOptionName}' is not supported. To see command's options, use '$ ${this.$staticConfig.CLIENT_NAME.toLowerCase()} help ${process.argv[2]}'. To see all commands use '$ ${this.$staticConfig.CLIENT_NAME.toLowerCase()} help'.`);
 				} 
-
 				let optionType = this.getOptionType(optionName);
 				let optionValue = parsed[optionName];
-				let parsedOptionType = typeof (optionValue);
-
 				if (_.isArray(optionValue) && optionType !== OptionType.Array) {
 					this.$errors.fail("You have set the %s option multiple times. Check the correct command syntax below and try again.", originalOptionName);
-				} else if (this.doesOptionRequireValue(optionType, parsedOptionType)) {
-					this.$errors.failWithoutHelp("The option '%s' requires a value.", originalOptionName);
 				} else if (optionType === OptionType.String && helpers.isNullOrWhitespace(optionValue)) {
 					this.$errors.failWithoutHelp("The option '%s' requires non-empty value.", originalOptionName);
-				} else if (optionType === OptionType.Boolean && parsedOptionType !== 'boolean') {
-					this.$errors.failWithoutHelp("The option '%s' does not accept values.", originalOptionName);
+				} else if(optionType === OptionType.Array && optionValue.length === 0) {
+					this.$errors.failWithoutHelp(`The option '${originalOptionName}' requires one or more values, separated by a space.`);
 				}
 			}
 		});
@@ -138,11 +119,11 @@ export class OptionsBase {
 		return _.contains(this.optionNames, secondaryOptionName) ? secondaryOptionName : optionName;
 	}
 	
-	private getOptionType(optionName: string) {
-		var option = this.options[optionName] || this.tryGetOptionByAliasName(optionName);
-		 return option ? option.type : ""
+	private getOptionType(optionName: string): string {
+		let option = this.options[optionName] || this.tryGetOptionByAliasName(optionName);
+		return option ? option.type : ""
 	}
-	
+
 	private tryGetOptionByAliasName(aliasName: string) {
 		let option = _.find(this.options, opt => opt.alias === aliasName);
 		return option;
@@ -157,15 +138,11 @@ export class OptionsBase {
 		return true;
 	}
 
-	private doesOptionRequireValue(optionType: OptionType, parsedOptionType: string): boolean {
-		return optionType !== OptionType.Boolean && parsedOptionType === 'boolean';
-	}
-
-// If you pass value with dash, yargs adds it to yargs.argv in two ways:
-// with dash and without dash, replacing first symbol after it with its toUpper equivalent
-// ex, "$ <cli name> emulate android --profile-dir" will add profile-dir to yargs.argv as profile-dir and profileDir
-// IMPORTANT: In your code, it is better to use the value without dashes (profileDir in the example).
-// This way your code will work in case "$ <cli name> emulate android --profile-dir" or "$ <cli name> emulate android --profileDir" is used by user.
+	// If you pass value with dash, yargs adds it to yargs.argv in two ways:
+	// with dash and without dash, replacing first symbol after it with its toUpper equivalent
+	// ex, "$ <cli name> emulate android --profile-dir" will add profile-dir to yargs.argv as profile-dir and profileDir
+	// IMPORTANT: In your code, it is better to use the value without dashes (profileDir in the example).
+	// This way your code will work in case "$ <cli name> emulate android --profile-dir" or "$ <cli name> emulate android --profileDir" is used by user.
 	private getSecondaryOptionName(optionName: string): string {
 		let matchUpperCaseLetters = optionName.match(/(.+?)([-])([a-zA-Z])(.*)/);
 		if(matchUpperCaseLetters) {
@@ -177,4 +154,26 @@ export class OptionsBase {
 
 		return optionName;
 	}
+
+	private setArgv(): void {
+		this.argv = yargs(process.argv.slice(2)).options(this.options).argv;
+		this.adjustDashedOptions();
+	}
+
+	private adjustDashedOptions(): void {
+		this.argv["profileDir"] = this.argv["profileDir"] || this.defaultProfileDir;		
+
+		_.each(this.optionNames, optionName => {
+			Object.defineProperty(OptionsBase.prototype, optionName, {
+				configurable: true,
+				get: function () {
+					return this.getOptionValue(optionName);
+				},
+				set: function(value: any) {
+					this.argv[optionName] = value;
+				}
+			});
+		});
+	}
+
 }

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -80,14 +80,15 @@ export class CommandsService implements ICommandsService {
 	public tryExecuteCommand(commandName: string, commandArguments: string[]): IFuture<void> {
 		return (() => {
 			let action = (commandName: string, commandArguments: string[]) => {
-				this.$options.validateOptions();
+				let command = this.$injector.resolveCommand(commandName);
+				this.$options.validateOptions(command ? command.dashedOptions : null);
 				
 				if(!this.areDynamicSubcommandsRegistered) {
 					this.$commandsServiceProvider.registerDynamicSubCommands();
 					this.areDynamicSubcommandsRegistered = true;
 				}
 				return this.canExecuteCommand(commandName, commandArguments);
-			}
+			};
 			if(this.executeCommandAction(commandName, commandArguments, action).wait()) {
 				this.executeCommandAction(commandName, commandArguments, this.executeCommandUnchecked).wait();
 			} else {


### PR DESCRIPTION
Each command can use specific dashed options (`-- avd <name>` for example is valid for one command, but not for other). Add dashedOptions parameter to ICommand interface and make sure to use it for validation when it exists. In case there's no dashedOptions paramter, use the common options.

Use correct types for yargs - "string", "boolean", etc. instead of 0, 1, 2 which were the result of our enum. Replace the enum with class and remove code, which we do not need anymore as yargs is doing its work as expected.
After yargs is updated to latest version, some fixes have to be applied - now when `yargs.options(opts).argv` is passed, it returns all members of `opts`, but the ones that are not part of process.argv have value undefined.
