### PR TITLE
Error-reporting command

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -27,7 +27,8 @@ $injector.require("projectHelper", "./common/project-helper");
 $injector.require("propertiesParser", "./common/properties-parser");
 
 $injector.requireCommand(["help", "/?"], "./common/commands/help");
-$injector.requireCommand("feature-usage-tracking", "./common/commands/analytics");
+$injector.requireCommand("usage-reporting", "./common/commands/analytics");
+$injector.requireCommand("error-reporting", "./common/commands/analytics");
 
 $injector.requireCommand("dev-post-install", "./common/commands/post-install");
 $injector.requireCommand("autocomplete|*default", "./common/commands/autocompletion");

--- a/commands/help.ts
+++ b/commands/help.ts
@@ -14,6 +14,8 @@ export class HelpCommand implements ICommand {
 		private $options: IOptions) { }
 
 	public enableHooks = false;
+	public disableAnalytics = true;
+
 	public canExecute(args: string[]): IFuture<boolean> {
 		return Future.fromResult(true);
 	}

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -184,13 +184,12 @@ interface IDictionary<T> {
 }
 
 interface IAnalyticsService {
-	checkConsent(featureName: string): IFuture<void>;
+	checkConsent(): IFuture<void>;
 	trackFeature(featureName: string): IFuture<void>;
 	trackException(exception: any, message: string): IFuture<void>;
-	setAnalyticsStatus(enabled: boolean): IFuture<void>;
-	disableAnalytics(): IFuture<void>;
-	getStatusMessage(): IFuture<string>;
-	isEnabled(): IFuture<boolean>;
+	setStatus(settingName: string, enabled: boolean): IFuture<void>;
+	getStatusMessage(settingName: string, jsonFormat: boolean, readableSettingName: string): IFuture<string>;
+	isEnabled(settingName: string): IFuture<boolean>;
 	track(featureName: string, featureValue: string): IFuture<void>;
 }
 

--- a/definitions/config.d.ts
+++ b/definitions/config.d.ts
@@ -7,6 +7,7 @@ declare module Config {
 		ANALYTICS_API_KEY: string;
 		ANALYTICS_INSTALLATION_ID_SETTING_NAME: string;
 		TRACK_FEATURE_USAGE_SETTING_NAME: string;
+		ERROR_REPORT_SETTING_NAME: string;
 		START_PACKAGE_ACTIVITY_NAME: string;
 		SYS_REQUIREMENTS_LINK: string;
 		version: string;

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -41,7 +41,7 @@ export class CommandsService implements ICommandsService {
 			if(command) {
 				if(!this.$staticConfig.disableAnalytics && !command.disableAnalytics) {
 					let analyticsService = this.$injector.resolve("analyticsService"); // This should be resolved here due to cyclic dependency
-					analyticsService.checkConsent(commandName).wait();
+					analyticsService.checkConsent().wait();
 					analyticsService.trackFeature(commandName).wait();
 				}
 				if(!this.$staticConfig.disableHooks && (command.enableHooks === undefined || command.enableHooks === true)) {

--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -10,6 +10,7 @@ export class StaticConfigBase implements Config.IStaticConfig {
 	public ANALYTICS_API_KEY: string = null;
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME: string = null;
 	public TRACK_FEATURE_USAGE_SETTING_NAME: string = null;
+	public ERROR_REPORT_SETTING_NAME: string = null;
 	public START_PACKAGE_ACTIVITY_NAME: string;
 	public SYS_REQUIREMENTS_LINK: string;
 	public version: string = null;


### PR DESCRIPTION
Add error-reporting command that should be used in a similar manner as feature-usage-tracking command. The difference is that during installation, the exceptions tracking will be enabled without prompt (keep current behavior that we are tracking exceptions). It can be disabled later by using `$ appbuilder error-reporting disable`.
Refactor analytics-service in order to "hide" some methods from the interface and to simplify adding of new analytics commands and variables. 

**Rename feature-usage-tracking to usage-reporting**