### PR TITLE
Use package.json's buildVersion property

### DIFF
--- a/definitions/config.d.ts
+++ b/definitions/config.d.ts
@@ -19,6 +19,7 @@ declare module Config {
 		HTML_PAGES_DIR: string;
 		HTML_COMMON_HELPERS_DIR: string;
 		HTML_CLI_HELPERS_DIR: string;
+		pathToPackageJson: string;
 	}
 
 	interface IConfig {

--- a/dispatchers.ts
+++ b/dispatchers.ts
@@ -13,13 +13,13 @@ export class CommandDispatcher implements ICommandDispatcher {
 		private $commandsService: ICommandsService,
 		private $staticConfig: Config.IStaticConfig,
 		private $sysInfo: ISysInfo,
-		private $options: IOptions) { }
+		private $options: IOptions,
+		private $fs: IFileSystem) { }
 
 	public dispatchCommand(): IFuture<void> {
 		return(() => {
 			if (this.$options.version) {
-				this.$logger.out(this.$staticConfig.version);
-				return;
+				return this.printVersion();
 			}
 
 			if (this.$logger.getLevel() === "TRACE") {
@@ -65,6 +65,16 @@ export class CommandDispatcher implements ICommandDispatcher {
 	private getCommandArguments(): string[] {
 		let remaining: string[] = this.$options.argv._.slice(1);
 		return _.map(remaining, (item) => (typeof item === "number") ? item.toString() : item);
+	}
+
+	private printVersion(): void {
+		let version = this.$staticConfig.version;
+
+		let json = require(this.$staticConfig.pathToPackageJson);
+		if(json && json.buildVersion) {
+			version = `${version}-${json.buildVersion}`;
+		}
+		this.$logger.out(version);
 	}
 }
 $injector.register("commandDispatcher", CommandDispatcher);

--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -34,4 +34,5 @@ export class StaticConfigBase implements Config.IStaticConfig {
 	}
 
 	public HTML_CLI_HELPERS_DIR: string;
+	public pathToPackageJson: string;
 }


### PR DESCRIPTION
In case the package.json has buildVersion property, concatenate it with the version from staticConfig and show it to user when `$ appbuilder --version` is invoked.
Add PATH_TO_PACKAGE_JSON to staticConfig in order to allow each CLI to specify where is its package.json.