### PR TITLE
Fix analytics issues

### DIFF
--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -9,9 +9,9 @@ class AnalyticsCommand implements ICommand {
 		private $staticConfig: IStaticConfig,
 		private settingName: string,
 		private humanReadableSettingName: string) { }
-		
-	public disableAnalytics = true;
+
 	public allowedParameters = [new AnalyticsCommandParameter(this.$errors)];
+	public disableAnalyticsConsentCheck = true;
 
 	public execute(args: string[]): IFuture<void> {
 		return(() => {

--- a/commands/help.ts
+++ b/commands/help.ts
@@ -14,8 +14,7 @@ export class HelpCommand implements ICommand {
 		private $options: IOptions) { }
 
 	public enableHooks = false;
-	public disableAnalytics = true;
-
+	public disableAnalyticsConsentCheck = true;
 	public canExecute(args: string[]): IFuture<boolean> {
 		return Future.fromResult(true);
 	}

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -121,6 +121,7 @@ interface IErrors {
 interface ICommandOptions {
 	disableAnalytics?: boolean;
 	enableHooks?: boolean;
+	disableAnalyticsConsentCheck?: boolean;
 }
 
 declare const enum ErrorCodes {

--- a/services/analytics-service.ts
+++ b/services/analytics-service.ts
@@ -238,14 +238,16 @@ export class AnalyticsService implements IAnalyticsService {
 	
 	private initAnalyticsStatuses(): IFuture<void> {
 		return (() => {
-			if(!this.isAnalyticsStatusesInitialized) {
-				this.$logger.trace("Initializing analytics statuses.");
-				let settingsNames = [this.$staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, this.$staticConfig.ERROR_REPORT_SETTING_NAME];
-				settingsNames.forEach(settingName => this.getStatus(settingName).wait());
-				this.isAnalyticsStatusesInitialized = true;
+			if(this.$analyticsSettingsService.canDoRequest().wait()) {
+				if(!this.isAnalyticsStatusesInitialized) {
+					this.$logger.trace("Initializing analytics statuses.");
+					let settingsNames = [this.$staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, this.$staticConfig.ERROR_REPORT_SETTING_NAME];
+					settingsNames.forEach(settingName => this.getStatus(settingName).wait());
+					this.isAnalyticsStatusesInitialized = true;
+				}
+				this.$logger.trace("Analytics statuses: ");
+				this.$logger.trace(this.analyticsStatuses);
 			}
-			this.$logger.trace("Analytics statuses: ");
-			this.$logger.trace(this.analyticsStatuses);
 		}).future<void>()();
 	}
 }

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -41,7 +41,9 @@ export class CommandsService implements ICommandsService {
 			if(command) {
 				if(!this.$staticConfig.disableAnalytics && !command.disableAnalytics) {
 					let analyticsService = this.$injector.resolve("analyticsService"); // This should be resolved here due to cyclic dependency
-					analyticsService.checkConsent().wait();
+					if(!command.disableAnalyticsConsentCheck) {
+						analyticsService.checkConsent().wait();
+					}
 					analyticsService.trackFeature(commandName).wait();
 				}
 				if(!this.$staticConfig.disableHooks && (command.enableHooks === undefined || command.enableHooks === true)) {


### PR DESCRIPTION
- Fix behavior that is trying to login the user when tracking command - in fact we should first check if the user is logged in and if not, do not try to login.
- Make sure commands are tracked, but for some of them we should not ask the user for confirmation of usage reporting (for example help command). So add new command property - `disableAnalyticsConsentCheck` and set it to true for help, usage-reporting and error-reporting commands. Make sure to prevent commandsService for checking the consent when this property is true.