### PR TITLE
Fail in prompter when console is not interactive

### DIFF
--- a/prompter.ts
+++ b/prompter.ts
@@ -41,13 +41,17 @@ export class Prompter implements IPrompter {
 
 	public get(schema: IPromptSchema[]): IFuture<any> {
 		let future = new Future;
-		prompt.prompt(schema, (result: any) => {
-			if(result) {
-				future.return(result);
-			} else {
-				future.throw(result);
-			}
-		});
+		if (!helpers.isInteractive() && _.any(schema, s => !s.default)) {
+			future.throw('Console is not interactive');
+		} else {
+			prompt.prompt(schema, (result: any) => {
+				if(result) {
+					future.return(result);
+				} else {
+					future.throw(result);
+				}
+			});
+		}
 		return future;
 	}
 


### PR DESCRIPTION
When the console is not interactive there's no point in using the prompter at all.
Part of [#297090](http://teampulse.telerik.com/view#item/297090)'s implementation.