### PR TITLE
Parse command line values as strings

### DIFF
--- a/dispatchers.ts
+++ b/dispatchers.ts
@@ -29,7 +29,7 @@ export class CommandDispatcher implements ICommandDispatcher {
 			}
 
 			let commandName = this.getCommandName();
-			let commandArguments = this.getCommandArguments();
+			let commandArguments = this.$options.argv._.slice(1);
 			let lastArgument: string = _.last(commandArguments);
 
 			if(this.$options.help) {
@@ -59,12 +59,6 @@ export class CommandDispatcher implements ICommandDispatcher {
 		// if only <CLI_NAME> is specified on console, show console help
 		this.$options.help = true;
 		return "";
-	}
-
-	// yargs convert parameters that are numbers to numbers, which we do not expect. undo its hard work.
-	private getCommandArguments(): string[] {
-		let remaining: string[] = this.$options.argv._.slice(1);
-		return _.map(remaining, (item) => (typeof item === "number") ? item.toString() : item);
 	}
 
 	private printVersion(): void {

--- a/options.ts
+++ b/options.ts
@@ -24,7 +24,9 @@ export class OptionsBase {
 		"help": { type: OptionType.Boolean, alias: "h" },
 		"profileDir": { type: OptionType.String },
 		"analyticsClient": {type: OptionType.String},
-		"path": { type: OptionType.String, alias: "p" }
+		"path": { type: OptionType.String, alias: "p" },
+		// This will parse all non-hyphenated values as strings.
+		"_": { type: OptionType.String }
 	};
 
 	constructor(public options: IDictionary<IDashedOption>,


### PR DESCRIPTION
Yargs will parse all non-hyphenated values as strings in case we tell we want this. So, let's declare we want this and remove our hack, that's doing it. This will also fix the case when numbers like 8.0 are passed on the console. Yargs is giving them to us as "8", but we need the full value. With this fix, we'll receive "8.0".