### PR TITLE
Read package.json encoded with BOM

### DIFF
--- a/dispatchers.ts
+++ b/dispatchers.ts
@@ -70,7 +70,7 @@ export class CommandDispatcher implements ICommandDispatcher {
 	private printVersion(): void {
 		let version = this.$staticConfig.version;
 
-		let json = require(this.$staticConfig.pathToPackageJson);
+		let json = this.$fs.readJson(this.$staticConfig.pathToPackageJson).wait();
 		if(json && json.buildVersion) {
 			version = `${version}-${json.buildVersion}`;
 		}


### PR DESCRIPTION
When package.json is changed from On premise scripts, it is encoded with BOM, so requiring it is failing with error. Use our readJson implementation which is able to read such file without errors.