### PR TITLE
Fix adb spawn when path contains spaces

### DIFF
--- a/mobile/mobile-core/device-discovery.ts
+++ b/mobile/mobile-core/device-discovery.ts
@@ -2,7 +2,6 @@
 "use strict";
 
 import ref = require("ref");
-import util = require("util");
 import os = require("os");
 import path = require("path");
 import IOSDevice = require("./../ios/ios-device");
@@ -199,7 +198,7 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery {
 		return(()=> {
 			this.ensureAdbServerStarted().wait();
 
-			let requestAllDevicesCommand = util.format("%s devices", this.Adb);
+			let requestAllDevicesCommand = `"${this.Adb}" devices`;
 			let result = this.$childProcess.exec(requestAllDevicesCommand).wait();
 
 			let devices = result.toString().split(os.EOL).slice(1)
@@ -217,7 +216,7 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery {
 	}
 
 	private ensureAdbServerStarted(): IFuture<void> {
-		let startAdbServerCommand = util.format("%s start-server", this.Adb);
+		let startAdbServerCommand =`"${this.Adb}" start-server`;
 		return this.$childProcess.exec(startAdbServerCommand);
 	}
 }


### PR DESCRIPTION
In case user does not have Android SDK installed, we are trying to execute adb from CLI resources. This fails in case `$ <CLI> device` command or `$ <CLI> deploy <platform>` is executed as the "exec" cannot resolve the path with spaces.

Also fix the check dependencies of AndroidEmulatorService in order to fail with correct error message when something is not configured properly (currently it is failing with ENOENT error).

Fixes http://teampulse.telerik.com/view#item/297604