### PR TITLE
Don't fail when more than one ios devices are attached

### DIFF
--- a/commands/device/stop-application.ts
+++ b/commands/device/stop-application.ts
@@ -18,12 +18,8 @@ export class StopApplicationOnDeviceCommand implements ICommand {
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
 			this.$devicesServices.initialize({ deviceId: this.$options.device, skipInferPlatform: true, platform: args[1] }).wait();
-
-			if (this.$devicesServices.deviceCount > 1) {
-				this.$errors.failWithoutHelp("More than one device found. Specify device explicitly with --device option.To discover device ID, use $%s device command.", this.$staticConfig.CLIENT_NAME.toLowerCase());
-			}
-
-			let action = (device: Mobile.IDevice) =>  { return (() => device.applicationManager.stopApplication(args[0]).wait()).future<void>()(); };
+			
+			let action = (device: Mobile.IDevice) => device.applicationManager.stopApplication(args[0]);
 			this.$devicesServices.execute(action).wait();
 		}).future<void>()();
 	}

--- a/mobile/ios/ios-core.ts
+++ b/mobile/ios/ios-core.ts
@@ -1080,7 +1080,8 @@ export class GDBServer implements Mobile.IGDBServer {
 	constructor(private socket: any, // socket is fd on Windows and net.Socket on mac
 		private $injector: IInjector,
 		private $hostInfo: IHostInfo,
-		private $options: IOptions) {
+		private $options: IOptions,
+		private $logger: ILogger) {
 		if(this.$hostInfo.isWindows) {
 			let winSocket = this.$injector.resolve(WinSocket, {service: this.socket, format: 0});
 			this.socket = {
@@ -1151,6 +1152,7 @@ export class GDBServer implements Mobile.IGDBServer {
 
 	private send(packet: string): void {
 		let data = this.createData(packet);
+		this.$logger.trace(`GDB: sending ${data}`);
 		this.socket.write(data);
 	}
 	


### PR DESCRIPTION
If you connect two iOS devices and execute `tns livesync` the following exception is thrown: 
`Multiple exceptions were thrown:
Command failed: /bin/sh -c node ~/Work/nativescript-cli/bin/nativescript.js device stop org.nativescript.debuggerApp iOS`