### PR TITLE
Prepare test infrastructure and rename promisify decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ node_modules
 !Gruntfile.js
 .d.ts
 !bin/**/*
+coverage/**/*
+xunit.xml
+test-reports.xml

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
 			},
 
 			devall: {
-				src: ["**/*.ts", "!node_modules/**/*.ts", "test/**/*.ts", ],
+				src: ["**/*.ts", "!node_modules/**/*.ts", "test/**/*.ts"],
 				reference: ".d.ts"
 			},
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ In order to expose public API, we use TypeScript decorators and some "magic" in 
 	```TypeScript
 	$injector.requirePublic("a", "./pathToFileWhereAClassIs")
 	```
-* On the method which you want to expose, just add the promisify decorator: `@decorators.promisify('a')`, where decorators are imported from the root of the project: `import decorators = require("./decorators");`
+* On the method which you want to expose, just add the exported decorator: `@decorators.exported('a')`, where decorators are imported from the root of the project: `import decorators = require("./decorators");`
 
-> IMPORTANT: `promisify` decorator requires one parameter which MUST be the first parameter passed to `requirePublic` method. This is the name of the module that will be publicly exposed.
+> IMPORTANT: `exported` decorator requires one parameter which MUST be the first parameter passed to `requirePublic` method. This is the name of the module that will be publicly exposed.
 
 After you have executed these two steps, you can start using your publicly available method:
 
@@ -40,7 +40,7 @@ When you require `mobile-cli-lib` module, you receive $injector's publicApi - it
 	$injector.requirePublic("a", "./pathToFileWhereAClassIs")
 ```
 a new property is added to publicApi - `a` and a getter is added for it. When you try to access this module, `require("mobile-cli-lib").a.<smth>`, the getter is called. It resolves the module, by parsing the provided file (`./pathToFileWhereAClassIs`)
-and that's the time when decorators are executed. For each decorated method, a new entry in `$injector._publicApi` is created. This is not the same method that you've decorated - it's entirely new method, that returns Promise.
+and that's the time when decorators are executed. For each decorated method, a new entry in `$injector.publicApi.__modules__` is created. This is not the same method that you've decorated - it's entirely new method, that returns Promise.
 The new method will be used in the publicApi, while original implementation will still be used in all other places in the code. The promisified method will call the original one (in a separate Fiber) and will resolve the Promise with the result of the method.
 
 ### Module fs
@@ -68,14 +68,6 @@ common.fs.getFileSize("D:\\Work\\t.txt")
 Issues
 ==
 
-### `grunt clean` deletes all javascript files
-
-Currently grunt clean is not working as expected - it deletes all javascript files, not only the ones which have corresponding TypeScript.
-
-### Handle Promisification of methods, which do not return future
-
-Currently we can promisify only methods, which return IFuture<T>. We should be able to promisify all kind of methods, no matter of their return type.
-
 ### Better error handling
 
 Currently all promises are `resolved` - add logic to `reject` them.
@@ -83,3 +75,7 @@ Currently all promises are `resolved` - add logic to `reject` them.
 ### Missing dependencies
 
 Some of our modules must be added: staticConfig, config, analyticsService, etc.
+
+### Tests for injector
+
+Add more tests for yok and for register decorator.

--- a/file-system.ts
+++ b/file-system.ts
@@ -135,7 +135,7 @@ export class FileSystem implements IFileSystem {
 		return future;
 	}
 	
-	@decorators.promisify("fs")
+	@decorators.exported("fs")
 	public getFileSize(path: string): IFuture<number> {
 		return ((): number => {
 			let stat = this.getFsStats(path).wait();

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "bin": {
     "mobile-cli-lib": "./bin/common-lib.js"
   },
+  "scripts": {
+    "test": "node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha -- --ui mocha-fibers --recursive --reporter spec-xunit-file --require test/test-bootstrap.js --timeout 15000 test/unit-tests/"
+  },
   "main": "./common-lib.js",
   "repository": {
     "type": "git",

--- a/test/definitions/chai.d.ts
+++ b/test/definitions/chai.d.ts
@@ -1,0 +1,283 @@
+﻿// Type definitions for chai 1.7.2
+// Project: http://chaijs.com/
+// Definitions by: Jed Hunsaker <https://github.com/jedhunsaker/>, Bart van der Schoor <https://github.com/Bartvds>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module chai {
+	export class AssertionError {
+		constructor(message: string, _props?: any, ssf?: Function);
+		name: string;
+		message: string;
+		showDiff: boolean;
+		stack: string;
+	}
+
+	function expect(target: any, message?: string): Expect;
+
+	export var assert: Assert;
+	export var config: Config;
+
+	export interface Config {
+		includeStack: boolean;
+	}
+
+	// Provides a way to extend the internals of Chai
+	function use(fn: (chai: any, utils: any) => void): any;
+
+	interface ExpectStatic {
+		(target: any): Expect;
+	}
+
+	interface Assertions {
+		attr(name: string, value?: string): any;
+		css(name: string, value?: string): any;
+		data(name: string, value?: string): any;
+		class(className: string): any;
+		id(id: string): any;
+		html(html: string): any;
+		text(text: string): any;
+		value(value: string): any;
+		visible: any;
+		hidden: any;
+		selected: any;
+		checked: any;
+		disabled: any;
+		empty: any;
+		exist: any;
+	}
+
+	interface Expect extends LanguageChains, NumericComparison, TypeComparison, Assertions {
+		not: Expect;
+		deep: Deep;
+		a: TypeComparison;
+		an: TypeComparison;
+		include: Include;
+		contain: Include;
+		ok: Expect;
+		true: Expect;
+		false: Expect;
+		null: Expect;
+		undefined: Expect;
+		exist: Expect;
+		empty: Expect;
+		arguments: Expect;
+		Arguments: Expect;
+		equal: Equal;
+		equals: Equal;
+		eq: Equal;
+		eql: Equal;
+		eqls: Equal;
+		property: Property;
+		ownProperty: OwnProperty;
+		haveOwnProperty: OwnProperty;
+		length: Length;
+		lengthOf: Length;
+		match(RegularExpression: RegExp, message?: string): Expect;
+		string(string: string, message?: string): Expect;
+		keys: Keys;
+		key(string: string): Expect;
+		throw: Throw;
+		throws: Throw;
+		Throw: Throw;
+		respondTo(method: string, message?: string): Expect;
+		itself: Expect;
+		satisfy(matcher: Function, message?: string): Expect;
+		closeTo(expected: number, delta: number, message?: string): Expect;
+		members: Members;
+	}
+
+	interface LanguageChains {
+		to: Expect;
+		be: Expect;
+		been: Expect;
+		is: Expect;
+		that: Expect;
+		and: Expect;
+		have: Expect;
+		with: Expect;
+		at: Expect;
+		of: Expect;
+		same: Expect;
+	}
+
+	interface NumericComparison {
+		above: NumberComparer;
+		gt: NumberComparer;
+		greaterThan: NumberComparer;
+		least: NumberComparer;
+		gte: NumberComparer;
+		below: NumberComparer;
+		lt: NumberComparer;
+		lessThan: NumberComparer;
+		most: NumberComparer;
+		lte: NumberComparer;
+		within(start: number, finish: number, message?: string): Expect;
+	}
+
+	interface NumberComparer {
+		(value: number, message?: string): Expect;
+	}
+
+	interface TypeComparison {
+		(type: string, message?: string): Expect;
+		instanceof: InstanceOf;
+		instanceOf: InstanceOf;
+	}
+
+	interface InstanceOf {
+		(constructor: Object, message?: string): Expect;
+	}
+
+	interface Deep {
+		equal: Equal;
+		property: Property;
+	}
+
+	interface Equal {
+		(value: any, message?: string): Expect;
+	}
+
+	interface Property {
+		(name: string, value?: any, message?: string): Expect;
+	}
+
+	interface OwnProperty {
+		(name: string, message?: string): Expect;
+	}
+
+	interface Length extends LanguageChains, NumericComparison {
+		(length: number, message?: string): Expect;
+	}
+
+	interface Include {
+		(value: Object, message?: string): Expect;
+		(value: string, message?: string): Expect;
+		(value: number, message?: string): Expect;
+		keys: Keys;
+		members: Members;
+	}
+
+	interface Keys {
+		(...keys: string[]): Expect;
+		(keys: any[]): Expect;
+	}
+
+	interface Members {
+		(set: any[], message?: string): Expect;
+	}
+
+	interface Throw {
+		(): Expect;
+		(expected: string, message?: string): Expect;
+		(expected: RegExp, message?: string): Expect;
+		(constructor: Error, expected?: string, message?: string): Expect;
+		(constructor: Error, expected?: RegExp, message?: string): Expect;
+		(constructor: Function, expected?: string, message?: string): Expect;
+		(constructor: Function, expected?: RegExp, message?: string): Expect;
+	}
+
+	export interface Assert {
+		(express: any, msg?: string):void;
+
+		fail(actual?: any, expected?: any, msg?: string, operator?: string):void;
+
+		ok(val: any, msg?: string):void;
+		notOk(val: any, msg?: string):void;
+
+		equal(act: any, exp: any, msg?: string):void;
+		notEqual(act: any, exp: any, msg?: string):void;
+
+		strictEqual(act: any, exp: any, msg?: string):void;
+		notStrictEqual(act: any, exp: any, msg?: string):void;
+
+		deepEqual(act: any, exp: any, msg?: string):void;
+		notDeepEqual(act: any, exp: any, msg?: string):void;
+
+		isTrue(val: any, msg?: string):void;
+		isFalse(val: any, msg?: string):void;
+
+		isNull(val: any, msg?: string):void;
+		isNotNull(val: any, msg?: string):void;
+
+		isUndefined(val: any, msg?: string):void;
+		isDefined(val: any, msg?: string):void;
+
+		isFunction(val: any, msg?: string):void;
+		isNotFunction(val: any, msg?: string):void;
+
+		isObject(val: any, msg?: string):void;
+		isNotObject(val: any, msg?: string):void;
+
+		isArray(val: any, msg?: string):void;
+		isNotArray(val: any, msg?: string):void;
+
+		isString(val: any, msg?: string):void;
+		isNotString(val: any, msg?: string):void;
+
+		isNumber(val: any, msg?: string):void;
+		isNotNumber(val: any, msg?: string):void;
+
+		isBoolean(val: any, msg?: string):void;
+		isNotBoolean(val: any, msg?: string):void;
+
+		typeOf(val: any, type: string, msg?: string):void;
+		notTypeOf(val: any, type: string, msg?: string):void;
+
+		instanceOf(val: any, type: Function, msg?: string):void;
+		notInstanceOf(val: any, type: Function, msg?: string):void;
+
+		include(exp: string, inc: any, msg?: string):void;
+		include(exp: any[], inc: any, msg?: string):void;
+
+		notInclude(exp: string, inc: any, msg?: string):void;
+		notInclude(exp: any[], inc: any, msg?: string):void;
+
+		match(exp: any, re: RegExp, msg?: string):void;
+		notMatch(exp: any, re: RegExp, msg?: string):void;
+
+		property(obj: Object, prop: string, msg?: string):void;
+		notProperty(obj: Object, prop: string, msg?: string):void;
+		deepProperty(obj: Object, prop: string, msg?: string):void;
+		notDeepProperty(obj: Object, prop: string, msg?: string):void;
+
+		propertyVal(obj: Object, prop: string, val: any, msg?: string):void;
+		propertyNotVal(obj: Object, prop: string, val: any, msg?: string):void;
+
+		deepPropertyVal(obj: Object, prop: string, val: any, msg?: string):void;
+		deepPropertyNotVal(obj: Object, prop: string, val: any, msg?: string):void;
+
+		lengthOf(exp: any, len: number, msg?: string):void;
+		//alias frenzy
+		throw(fn: Function, msg?: string):void;
+		throw(fn: Function, regExp: RegExp):void;
+		throw(fn: Function, errType: Function, msg?: string):void;
+		throw(fn: Function, errType: Function, regExp: RegExp):void;
+
+		throws(fn: Function, msg?: string):void;
+		throws(fn: Function, regExp: RegExp):void;
+		throws(fn: Function, errType: Function, msg?: string):void;
+		throws(fn: Function, errType: Function, regExp: RegExp):void;
+
+		Throw(fn: Function, msg?: string):void;
+		Throw(fn: Function, regExp: RegExp):void;
+		Throw(fn: Function, errType: Function, msg?: string):void;
+		Throw(fn: Function, errType: Function, regExp: RegExp):void;
+
+		doesNotThrow(fn: Function, msg?: string):void;
+		doesNotThrow(fn: Function, regExp: RegExp):void;
+		doesNotThrow(fn: Function, errType: Function, msg?: string):void;
+		doesNotThrow(fn: Function, errType: Function, regExp: RegExp):void;
+
+		operator(val: any, operator: string, val2: any, msg?: string):void;
+		closeTo(act: number, exp: number, delta: number, msg?: string):void;
+
+		sameMembers(set1: any[], set2: any[], msg?: string):void;
+		includeMembers(set1: any[], set2: any[], msg?: string):void;
+
+		ifError(val: any, msg?: string):void;
+	}
+}
+
+declare module "chai" {
+export = chai;
+}

--- a/test/definitions/mocha.d.ts
+++ b/test/definitions/mocha.d.ts
@@ -1,0 +1,87 @@
+// Type definitions for mocha 1.9.0
+// Project: http://visionmedia.github.io/mocha/
+// Definitions by: Kazi Manzur Rashid <https://github.com/kazimanzurrashid/>
+// DefinitelyTyped: https://github.com/borisyankov/DefinitelyTyped
+
+interface Mocha {
+    // Setup mocha with the given setting options.
+    setup(options: MochaSetupOptions): Mocha;
+
+    //Run tests and invoke `fn()` when complete.
+    run(callback?: () => void): void;
+
+    // Set reporter as function
+    reporter(reporter: () => void): Mocha;
+
+    // Set reporter, defaults to "dot"
+    reporter(reporter: string): Mocha;
+
+    // Enable growl support.
+    growl(): Mocha
+}
+
+interface MochaSetupOptions {
+    //milliseconds to wait before considering a test slow
+    slow?: number;
+
+    // timeout in milliseconds
+    timeout?: number;
+
+    // ui name "bdd", "tdd", "exports" etc
+    ui?: string;
+
+    //array of accepted globals
+    globals?: any[];
+
+    // reporter instance (function or string), defaults to `mocha.reporters.Dot`
+    reporter?: any;
+
+    // bail on the first test failure
+    bail?: Boolean;
+
+    // ignore global leaks
+    ignoreLeaks?: Boolean;
+
+    // grep string or regexp to filter tests with
+    grep?: any;
+}
+
+declare module mocha {
+    interface Done {
+        (error?: Error): void;
+    }
+}
+
+declare var describe : {
+    (description: string, spec: () => void): void;
+    only(description: string, spec: () => void): void;
+    skip(description: string, spec: () => void): void;
+    timeout(ms: number): void;
+}
+
+declare var it: {
+    (expectation: string, assertion?: () => void): void;
+    (expectation: string, assertion?: (done: mocha.Done) => void): void;
+    only(expectation: string, assertion?: () => void): void;
+    only(expectation: string, assertion?: (done: mocha.Done) => void): void;
+    skip(expectation: string, assertion?: () => void): void;
+    skip(expectation: string, assertion?: (done: mocha.Done) => void): void;
+    timeout(ms: number): void;
+};
+
+declare function before(action: () => void): void;
+
+declare function before(action: (done: mocha.Done) => void): void;
+
+declare function after(action: () => void): void;
+
+declare function after(action: (done: mocha.Done) => void): void;
+
+declare function beforeEach(action: () => void): void;
+
+declare function beforeEach(action: (done: mocha.Done) => void): void;
+
+declare function afterEach(action: () => void): void;
+
+declare function afterEach(action: (done: mocha.Done) => void): void;
+

--- a/test/test-bootstrap.ts
+++ b/test/test-bootstrap.ts
@@ -1,0 +1,27 @@
+import Future = require("fibers/future");
+
+global._ = require("lodash");
+global.$injector = require("../yok").injector;
+// $injector.require("config", "../lib/config");
+// $injector.require("resources", "../lib/resource-loader");
+$injector.require("hostInfo", "../host-info");
+$injector.register("config", {});
+
+// Our help reporting requires analyticsService. Give it this mock so that errors during test executions can be printed out
+$injector.register("analyticsService", {
+	checkConsent(): IFuture<void> { return Future.fromResult(); },
+	trackFeature(featureName: string): IFuture<void>{ return Future.fromResult(); },
+	trackException(exception: any, message: string): IFuture<void> { return Future.fromResult(); },
+	setStatus(settingName: string, enabled: boolean): IFuture<void>{ return Future.fromResult(); },
+	getStatusMessage(settingName: string, jsonFormat: boolean, readableSettingName: string): IFuture<string>{ return Future.fromResult("Fake message"); },
+	isEnabled(settingName: string): IFuture<boolean>{ return Future.fromResult(false); },
+	track(featureName: string, featureValue: string): IFuture<void>{ return Future.fromResult(); }
+});
+
+// Converts the js callstack to typescript
+import errors = require("../errors");
+errors.installUncaughtExceptionListener();
+
+process.on('exit', (code: number) => {
+	require("fibers/future").assertNoFutureLeftBehind();
+});

--- a/test/unit-tests/decorators.ts
+++ b/test/unit-tests/decorators.ts
@@ -1,0 +1,101 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import decoratorsLib = require("../../decorators");
+import yokLib = require("../../yok");
+import chai = require("chai");
+import Promise = require("bluebird");
+import Future = require("fibers/future");
+
+let originalInjector:any = {}
+_.extend(originalInjector, $injector);
+let assert: chai.Assert = chai.assert;
+
+describe("decorators", () => {
+	afterEach(() => {
+		$injector = originalInjector;
+		// Due to bug in lodash's extend method, manually set publicApi to the initial object.
+		$injector.publicApi = {__modules__: {}};
+	});
+
+	describe("exported", () => {
+		it("returns function", () => {
+			let result: any = decoratorsLib.exported("test");
+			assert.equal(typeof(result), "function");
+		});
+
+		it("does not change original method", () => {
+			let testInjector = new yokLib.Yok();
+			let promisifiedResult: any = decoratorsLib.exported("moduleName");
+			let expectedResult = {"originalObject": "originalValue"};
+			let actualResult = promisifiedResult({}, "myTest1", expectedResult);
+			assert.deepEqual(actualResult, expectedResult);
+		});
+
+		it("adds method to public api", () => {
+			let testInjector = new yokLib.Yok();
+			assert.deepEqual($injector.publicApi.__modules__["moduleName"], undefined);
+			let promisifiedResult: any = decoratorsLib.exported("moduleName");
+			let actualResult = promisifiedResult({}, "propertyName", {});
+			assert.deepEqual(typeof($injector.publicApi.__modules__["moduleName"]["propertyName"]), "function");
+		});
+
+		it("returns Promise", () => {
+			$injector = new yokLib.Yok();
+			let result = "result";
+			$injector.register("moduleName", {propertyName: () => {return result;}});
+			assert.deepEqual($injector.publicApi.__modules__["moduleName"], undefined);
+			let promisifiedResultFunction: any = decoratorsLib.exported("moduleName");
+			// Call this line in order to generate publicApi and get the real Promise
+			promisifiedResultFunction({}, "propertyName", {});
+			let promise: any = $injector.publicApi.__modules__["moduleName"]["propertyName"]();
+			assert.equal(typeof(promise.then), "function");
+			assert.equal(typeof(promise.catch), "function");
+			assert.deepEqual(promise.value(), result);
+		});
+
+		it("returns Promise, which is resolved to correct value (function without arguments)", () => {
+			$injector = new yokLib.Yok();
+			let result = "result";
+			$injector.register("moduleName", {propertyName: () => {return result;}});
+			let promisifiedResultFunction: any = decoratorsLib.exported("moduleName");
+			// Call this line in order to generate publicApi and get the real Promise
+			promisifiedResultFunction({}, "propertyName", {});
+			let promise: any = $injector.publicApi.__modules__["moduleName"]["propertyName"]();
+			assert.deepEqual(promise.value(), result);
+		});
+
+		it("returns Promise, which is resolved to correct value (function with arguments)", () => {
+			$injector = new yokLib.Yok();
+			let expectedArgs = ["result", "result1", "result2"];
+			$injector.register("moduleName", {propertyName: (functionArgs: string[]) => {return functionArgs;}});
+			let promisifiedResultFunction: any = decoratorsLib.exported("moduleName");
+			// Call this line in order to generate publicApi and get the real Promise
+			promisifiedResultFunction({}, "propertyName", {});
+			let promise: any = $injector.publicApi.__modules__["moduleName"]["propertyName"](expectedArgs);
+			assert.deepEqual(promise.value(), expectedArgs);
+		});
+
+		it("returns Promise, which is resolved to correct value (function returning IFuture without arguments)", () => {
+			$injector = new yokLib.Yok();
+			let result = "result";
+			$injector.register("moduleName", {propertyName: () => Future.fromResult(result)});
+			let promisifiedResultFunction: any = decoratorsLib.exported("moduleName");
+			// Call this line in order to generate publicApi and get the real Promise
+			promisifiedResultFunction({}, "propertyName", {});
+			let promise: any = $injector.publicApi.__modules__["moduleName"]["propertyName"]();
+			assert.deepEqual(promise.value(), result);
+		});
+
+		it("returns Promise, which is resolved to correct value (function returning IFuture with arguments)", () => {
+			$injector = new yokLib.Yok();
+			let expectedArgs = ["result", "result1", "result2"];
+			$injector.register("moduleName", {propertyName: (args: string[]) => Future.fromResult(args)});
+			let promisifiedResultFunction: any = decoratorsLib.exported("moduleName");
+			// Call this line in order to generate publicApi and get the real Promise
+			promisifiedResultFunction({}, "propertyName", {});
+			let promise: any = $injector.publicApi.__modules__["moduleName"]["propertyName"](expectedArgs);
+			assert.deepEqual(promise.value(), expectedArgs);
+		});
+	});
+});

--- a/test/unit-tests/yok.ts
+++ b/test/unit-tests/yok.ts
@@ -1,0 +1,161 @@
+///<reference path="../.d.ts"/>
+"use strict";
+import chai = require("chai");
+let assert:chai.Assert = chai.assert;
+import yok = require("../../yok");
+
+class MyClass {
+	constructor(private x:string, public y:any) {
+	}
+
+	public checkX():void {
+		assert.strictEqual(this.x, "foo");
+	}
+}
+
+describe("yok", () => {
+	it("resolves pre-constructed singleton", () => {
+		let injector = new yok.Yok();
+		let obj = {};
+		injector.register("foo", obj);
+
+		let resolved = injector.resolve("foo");
+
+		assert.strictEqual(obj, resolved);
+	});
+
+	it("resolves given constructor", () => {
+		let injector = new yok.Yok();
+		let obj:any;
+		injector.register("foo", () => {
+			obj = {foo:"foo"};
+			return obj;
+		});
+
+		let resolved = injector.resolve("foo");
+
+		assert.strictEqual(resolved, obj);
+	});
+
+	it("resolves constructed singleton", () => {
+		let injector = new yok.Yok();
+		injector.register("foo", {foo:"foo"});
+
+		let r1 = injector.resolve("foo");
+		let r2 = injector.resolve("foo");
+
+		assert.strictEqual(r1, r2);
+	});
+
+	it("injects directly into passed constructor", () => {
+		let injector = new yok.Yok();
+		let obj = {};
+		injector.register("foo", obj);
+
+		function Test(foo:any) {
+			this.foo = foo;
+		}
+
+		let result = injector.resolve(Test);
+
+		assert.strictEqual(obj, result.foo);
+	});
+
+	it("inject dependency into registered constructor", () => {
+		let injector = new yok.Yok();
+		let obj = {};
+		injector.register("foo", obj);
+
+		function Test(foo:any) {
+			this.foo = foo;
+		}
+
+		injector.register("test", Test);
+
+		let result = injector.resolve("test");
+
+		assert.strictEqual(obj, result.foo);
+	});
+
+	it("inject dependency with $ prefix", () => {
+		let injector = new yok.Yok();
+		let obj = {};
+		injector.register("foo", obj);
+
+		function Test($foo:any) {
+			this.foo = $foo;
+		}
+
+		let result = injector.resolve(Test);
+
+		assert.strictEqual(obj, result.foo);
+	});
+
+	it("inject into TS constructor", () => {
+		let injector = new yok.Yok();
+
+		injector.register("x", "foo");
+		injector.register("y", 123);
+
+		let result = <MyClass> injector.resolve(MyClass);
+
+		assert.strictEqual(result.y, 123);
+		result.checkX();
+	});
+
+	it("resolves a parameterless constructor", () => {
+		let injector = new yok.Yok();
+
+		function Test() {
+			this.foo = "foo";
+		}
+
+		let result = injector.resolve(Test);
+
+		assert.equal(result.foo, "foo");
+	});
+
+	it("returns null when it can't resolve a command", () => {
+		let injector = new yok.Yok();
+		let command = injector.resolveCommand("command");
+		assert.isNull(command);
+	});
+
+	it("throws when it can't resolve a registered command", () => {
+		let injector = new yok.Yok();
+
+		function Command(whatever:any) {}
+
+		injector.registerCommand("command", Command);
+
+		assert.throws(() => injector.resolveCommand("command"));
+	});
+
+	it("disposes", () => {
+		let injector = new yok.Yok();
+
+		function Thing() {}
+
+		Thing.prototype.dispose = function() {
+			this.disposed = true;
+		};
+
+		injector.register("thing", Thing);
+		let thing = injector.resolve("thing");
+		injector.dispose();
+
+		assert.isTrue(thing.disposed);
+	});
+
+	it("throws error when module is required more than once", () => {
+		let injector = new yok.Yok();
+		injector.require("foo", "test");
+		assert.throws(() => injector.require("foo", "test2"));
+	});
+
+	it("adds module to public api when requirePublic is used", () => {
+		let injector = new yok.Yok();
+		injector.requirePublic("foo", "test");
+		assert.isTrue(_.contains(Object.getOwnPropertyNames(injector.publicApi), "foo"));
+	});
+});


### PR DESCRIPTION
## Test infrastructure
Prepare test infrastructure by:
* Add tests dir and default .d.ts file.
* Modify package.json - add test script.
* Modify .gitignore to exclude test specific files.
* Get yok tests from appbuilder-cli and add some additional ones.
* Add decorators tests.
* Add mocha and chai definition files.
* Add initial test-bootstrap method.

## `promisify` decorator
`promisify` decorator had been renamed to `exported`
Also add logic to handle methods which do not return `IFuture`


Modify README.md according to latest changes.