### PR TITLE
Fix "An error was encountered processing the command (code=146): Exception encountered connecting to CoreSimulatorBridge: Unable to connect to CoreSimulatorBridge"

### DIFF
--- a/mobile/ios/ios-emulator-services.ts
+++ b/mobile/ios/ios-emulator-services.ts
@@ -202,15 +202,16 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 			
 			let runningSimulatorId = this.getRunningSimulatorId(appIdentifier).wait();
 			let applicationPath = this.getApplicationPath(appIdentifier, runningSimulatorId).wait();
+			let applicationName = path.basename(applicationPath);
 			syncAction(applicationPath);
 		
 			try {
-				this.$childProcess.exec("killall launchd_sim").wait();
-				this.$childProcess.exec(`xcrun simctl launch ${runningSimulatorId} ${appIdentifier}`).wait();				
+				this.$childProcess.exec(`killall ${applicationName.split(".")[0]}`).wait();					
 			} catch(e) {
 				this.$logger.trace("Unable to kill simulator: " + e);
 			}
 			
+			this.$childProcess.exec(`xcrun simctl launch ${runningSimulatorId} ${appIdentifier}`).wait();				
 		}).future<void>()();
 	}
 }


### PR DESCRIPTION
On some machines sometimes the following error was thrown: "An error was encountered processing the command (code=146): Exception encountered connecting to CoreSimulatorBridge: Unable to connect to CoreSimulatorBridge". This fix also speed up the livesync command on iOS simulator.