### PR TITLE
Add workflows for screenbuilder commands

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -12,6 +12,8 @@ $injector.require("hostInfo", "./host-info");
 $injector.require("dispatcher", "./dispatchers");
 $injector.require("commandDispatcher", "./dispatchers");
 
+$injector.require("resources", "./resource-loader");
+
 $injector.require("stringParameter", "./command-params");
 $injector.require("stringParameterBuilder", "./command-params");
 

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -67,7 +67,7 @@ interface IFileSystem {
 		bufferSize?: number;
 		start?: number;
 		end?: number;
-	}): any;
+	}): NodeJS.ReadableStream;
 	createWriteStream(path: string, options?: {
 		flags?: string;
 		encoding?: string;
@@ -265,7 +265,7 @@ interface IHtmlHelpService {
 interface IUsbLiveSyncServiceBase {
 	initialize(platform: string): IFuture<string>;
 	sync(platform: string, appIdentifier: string, projectFilesPath: string, excludedProjectDirsAndFiles: string[], watchGlob: any,
-		platformSpecificLiveSyncServices: IDictionary<any>,		
+		platformSpecificLiveSyncServices: IDictionary<any>,
 		restartAppOnDeviceAction: (device: Mobile.IDevice, deviceAppData: Mobile.IDeviceAppData) => IFuture<void>,
 		notInstalledAppOnDeviceAction: (device: Mobile.IDevice) => IFuture<void>,
 		notRunningiOSSimulatorAction: () => IFuture<void>,
@@ -468,3 +468,33 @@ interface IBinaryPlistParser {
 	parseFile(plistFilePath: string): IFuture<any>;
 }
 
+/**
+ *	Used for interaction with various resources located in a resources folder.
+ *	@interface
+ */
+interface IResourceLoader {
+	/**
+	 * Get an absolute path to a resource based on a relative one.
+	 * @param  {string} path Relative path to resource
+	 * @return {string}      Absolute path to resource
+	 */
+	resolvePath(path: string): string;
+	/**
+	 * Opens a resource file for reading.
+	 * @param  {string} path Relative path to resource
+	 * @return {NodeJS.ReadableStream} Read stream to the resource file
+	 */
+	openFile(path: string): NodeJS.ReadableStream;
+	/**
+	 * Reads the contents of a resource file in JSON format.
+	 * @param  {string}       path Relative path to resource
+	 * @return {IFuture<any>}      Object based on the JSON contents of the resource file.
+	 */
+	readJson(path: string): IFuture<any>;
+	/**
+	 * Returns the path to App_Resources folder, which contains all resources for a given application.
+	 * @param  {string} framework The application's framework name
+	 * @return {string}           The absolute path to App_Resources folder
+	 */
+	getPathToAppResources(framework: string): string;
+}

--- a/definitions/config.d.ts
+++ b/definitions/config.d.ts
@@ -23,6 +23,7 @@ declare module Config {
 		pathToPackageJson: string;
 		APP_RESOURCES_DIR_NAME: string;
 		COMMAND_HELP_FILE_NAME: string;
+		RESOURCE_DIR_PATH: string;
 	}
 
 	interface IConfig {

--- a/definitions/config.d.ts
+++ b/definitions/config.d.ts
@@ -21,6 +21,7 @@ declare module Config {
 		HTML_COMMON_HELPERS_DIR: string;
 		HTML_CLI_HELPERS_DIR: string;
 		pathToPackageJson: string;
+		APP_RESOURCES_DIR_NAME: string;
 	}
 
 	interface IConfig {

--- a/definitions/config.d.ts
+++ b/definitions/config.d.ts
@@ -22,6 +22,7 @@ declare module Config {
 		HTML_CLI_HELPERS_DIR: string;
 		pathToPackageJson: string;
 		APP_RESOURCES_DIR_NAME: string;
+		COMMAND_HELP_FILE_NAME: string;
 	}
 
 	interface IConfig {

--- a/file-system.ts
+++ b/file-system.ts
@@ -135,7 +135,7 @@ export class FileSystem implements IFileSystem {
 
 		return future;
 	}
-	
+
 	@decorators.exported("fs")
 	public getFileSize(path: string): IFuture<number> {
 		return ((): number => {
@@ -275,17 +275,17 @@ export class FileSystem implements IFileSystem {
 		let source = this.createReadStream(sourceFileName);
 		let target = this.createWriteStream(destinationFileName);
 
-		source.on("error", (e: Error) => { 
+		source.on("error", (e: Error) => {
 			if (!res.isResolved()) {
 				res.throw(e);
 			}
 		});
-		target.on("finish", () => { 
+		target.on("finish", () => {
 			if (!res.isResolved()) {
 				res.return();
 			}
 		})
-		.on("error", (e: Error) => { 
+		.on("error", (e: Error) => {
 			if (!res.isResolved()) {
 				res.throw(e);
 			}
@@ -301,7 +301,7 @@ export class FileSystem implements IFileSystem {
 		fd?: string;
 		mode?: number;
 		bufferSize?: number;
-	}): any {
+	}): NodeJS.ReadableStream {
 		return fs.createReadStream(path, options);
 	}
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ref-struct": "https://github.com/telerik/ref-struct/tarball/master",
     "rimraf": "2.2.6",
     "semver": "4.3.4",
-    "shelljs": "^0.5.1",
+    "shelljs": "0.5.1",
     "tabtab": "https://github.com/Icenium/node-tabtab/tarball/master",
     "temp": "0.8.1",
     "unzip": "0.1.11",

--- a/resource-loader.ts
+++ b/resource-loader.ts
@@ -1,0 +1,26 @@
+///<reference path=".d.ts"/>
+"use strict";
+
+import * as path from "path";
+
+export class ResourceLoader implements IResourceLoader {
+	constructor(private $fs: IFileSystem,
+		private $staticConfig: Config.IStaticConfig) { }
+
+	resolvePath(resourcePath: string): string {
+		return path.join(__dirname, "../../resources", resourcePath);
+	}
+
+	openFile(resourcePath: string): NodeJS.ReadableStream {
+		return this.$fs.createReadStream(this.resolvePath(resourcePath));
+	}
+
+	readJson(resourcePath: string): IFuture<any> {
+		return this.$fs.readJson(this.resolvePath(resourcePath));
+	}
+
+	public getPathToAppResources(framework: string): string {
+		return path.join(this.resolvePath(framework), this.$staticConfig.APP_RESOURCES_DIR_NAME);
+	}
+}
+$injector.register("resources", ResourceLoader);

--- a/resource-loader.ts
+++ b/resource-loader.ts
@@ -8,7 +8,7 @@ export class ResourceLoader implements IResourceLoader {
 		private $staticConfig: Config.IStaticConfig) { }
 
 	resolvePath(resourcePath: string): string {
-		return path.join(__dirname, "../../resources", resourcePath);
+		return path.join(this.$staticConfig.RESOURCE_DIR_PATH, resourcePath);
 	}
 
 	openFile(resourcePath: string): NodeJS.ReadableStream {

--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -13,6 +13,7 @@ export class StaticConfigBase implements Config.IStaticConfig {
 	public ERROR_REPORT_SETTING_NAME: string = null;
 	public APP_RESOURCES_DIR_NAME = "App_Resources";
 	public COMMAND_HELP_FILE_NAME = 'command-help.json';
+	public RESOURCE_DIR_PATH = __dirname;
 	public START_PACKAGE_ACTIVITY_NAME: string;
 	public SYS_REQUIREMENTS_LINK: string;
 	public HTML_CLI_HELPERS_DIR: string;

--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -12,25 +12,26 @@ export class StaticConfigBase implements Config.IStaticConfig {
 	public TRACK_FEATURE_USAGE_SETTING_NAME: string = null;
 	public ERROR_REPORT_SETTING_NAME: string = null;
 	public APP_RESOURCES_DIR_NAME = "App_Resources";
+	public COMMAND_HELP_FILE_NAME = 'command-help.json';
 	public START_PACKAGE_ACTIVITY_NAME: string;
 	public SYS_REQUIREMENTS_LINK: string;
-	public HTML_CLI_HELPERS_DIR: string;	
+	public HTML_CLI_HELPERS_DIR: string;
 	public version: string = null;
-	
+
 	private _adbFilePath: string = null;
-	
+
 	constructor(protected $injector: IInjector) { }
-	
+
 	public get helpTextPath(): string {
 		return null;
 	}
-	
+
 	public getAdbFilePath(): IFuture<string> {
 		return (() => {
 			if(!this._adbFilePath) {
 				this._adbFilePath = this.getAdbFilePathCore().wait();
 			}
-			
+
 			return this._adbFilePath;
 		}).future<string>()();
 	}
@@ -46,17 +47,17 @@ export class StaticConfigBase implements Config.IStaticConfig {
 	public get HTML_COMMON_HELPERS_DIR(): string {
 		return path.join(__dirname, "docs", "helpers");
 	}
-	
+
 	public pathToPackageJson: string;
-	
+
 	private getAdbFilePathCore(): IFuture<string> {
 		return ((): string => {
 			let defaultAdbFilePath = path.join(__dirname, `resources/platform-tools/android/${process.platform}/adb`);
 			let $childProcess: IChildProcess = this.$injector.resolve("$childProcess");
-			
+
 			try {
 				let proc = $childProcess.spawnFromEvent("adb", ["version"], "exit", undefined, { throwError: false }).wait();
-	
+
 				if(proc.stderr) {
 					return defaultAdbFilePath;
 				}
@@ -65,7 +66,7 @@ export class StaticConfigBase implements Config.IStaticConfig {
 					return defaultAdbFilePath;
 				}
 			}
-	
+
 			return "adb";
 		}).future<string>()();
 	}

--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -11,6 +11,7 @@ export class StaticConfigBase implements Config.IStaticConfig {
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME: string = null;
 	public TRACK_FEATURE_USAGE_SETTING_NAME: string = null;
 	public ERROR_REPORT_SETTING_NAME: string = null;
+	public APP_RESOURCES_DIR_NAME = "App_Resources";
 	public START_PACKAGE_ACTIVITY_NAME: string;
 	public SYS_REQUIREMENTS_LINK: string;
 	public HTML_CLI_HELPERS_DIR: string;	


### PR DESCRIPTION
Using the **command-help.json** file located inside the resources folder of any CLI client a tip can be shown after specific commands to help guide the user into successfully creating a project
