### PR TITLE
Improve packing of common lib

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
 **/*.ts
 **/*.js.map
+coverage
+.tscache
+test-reports.xml

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gaze": "0.5.1",
     "iconv-lite": "0.4.3",
     "inquirer": "0.8.2",
-    "ios-sim-portable": "https://github.com/telerik/ios-sim-portable/tarball/v1.0.9",
+    "ios-sim-portable": "1.0.9-alpha",
     "lodash": "3.5.0",
     "log4js": "0.6.9",
     "marked": "0.3.3",
@@ -61,7 +61,6 @@
     "shelljs": "^0.5.1",
     "tabtab": "https://github.com/Icenium/node-tabtab/tarball/master",
     "temp": "0.8.1",
-    "typescript": "1.5.3",
     "unzip": "0.1.11",
     "validator": "3.2.1",
     "winreg": "0.0.12",
@@ -81,7 +80,8 @@
     "istanbul": "0.3.17",
     "mocha": "2.2.5",
     "mocha-fibers": "https://github.com/Icenium/mocha-fibers/tarball/master",
-    "spec-xunit-file": "0.0.1-3"
+    "spec-xunit-file": "0.0.1-3",
+    "typescript": "1.5.3"
   },
   "bundledDependencies": [],
   "license": "Apache-2.0",


### PR DESCRIPTION
Set correct version of ios-sim-portable. Move typescript to devDependencies as it is not required for end users of common lib. Also npmignore some files.