### PR TITLE
Adds handling for version extraction in case of openjdk

### DIFF
--- a/sysinfo.ts
+++ b/sysinfo.ts
@@ -42,8 +42,9 @@ export class SysInfo implements ISysInfo {
 
 			// dependencies
 			try {
-				let output = this.$childProcess.spawnFromEvent("java", ["-version"], "exit").wait().stderr.split(os.EOL)[0];
-				res.javaVer = /^java version \"((?:\d+\.)+(?:\d+))/i.exec(output)[1];
+                // different java has different format for `java -version` command
+				let output = this.$childProcess.spawnFromEvent("java", ["-version"], "exit").wait().stderr;
+				res.javaVer = /(?:openjdk|java) version \"((?:\d+\.)+(?:\d+))/i.exec(output)[1];
 			} catch(e) {
 				res.javaVer = null;
 			}


### PR DESCRIPTION
Modified regex to extract java version for openjdk java version because
it has different format for showing version information than oracle
java.

For e.g. in case of __openjdk__
```
java -version
# Picked up JAVA_TOOL_OPTIONS: -javaagent:/usr/share/java/jayatanaag.jar 
# openjdk version "1.8.0_45-internal"
# OpenJDK Runtime Environment (build 1.8.0_45-internal-b14)
# OpenJDK 64-Bit Server VM (build 25.45-b02, mixed mode)
```