### PR TITLE
Introduce a way to disable command help suggestion

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -123,6 +123,7 @@ interface ICommandOptions {
 	disableAnalytics?: boolean;
 	enableHooks?: boolean;
 	disableAnalyticsConsentCheck?: boolean;
+	disableCommandHelpSuggestion?: boolean;
 }
 
 declare const enum ErrorCodes {

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -66,7 +66,7 @@ export class CommandsService implements ICommandsService {
 				}
 
 				let commandHelp = this.getCommandHelp().wait();
-				if (commandHelp && commandHelp[commandName]) {
+				if (!command.disableCommandHelpSuggestion && commandHelp && commandHelp[commandName]) {
 					this.$logger.info(commandHelp[commandName]);
 				}
 


### PR DESCRIPTION
Introduce non-mandatory ```disableCommandHelpSuggestion``` parameter for disabling suggestions upon successful execution of a command.