### PR TITLE
Introduce $logger.printMarkdown

### DIFF
--- a/commands/help.ts
+++ b/commands/help.ts
@@ -27,7 +27,7 @@ export class HelpCommand implements ICommand {
 
 			if(this.$options.help) {
 				let help = this.$htmlHelpService.getCommandLineHelpForCommand(topic).wait();
-				this.$logger.out(help);
+				this.$logger.printMarkdown(help);
 			} else {
 				this.$htmlHelpService.openHelpForCommandInBrowser(topic).wait();
 			}

--- a/definitions/logger.d.ts
+++ b/definitions/logger.d.ts
@@ -7,6 +7,7 @@ interface ILogger {
 	info(formatStr?: any, ...args: string[]): void;
 	debug(formatStr?: any, ...args: string[]): void;
 	trace(formatStr?: any, ...args: string[]): void;
+	printMarkdown(message: string): void;
 
 	out(formatStr?: any, ...args: string[]): void;
 	write(...args: string[]): void;

--- a/logger.ts
+++ b/logger.ts
@@ -5,6 +5,9 @@ import * as log4js from "log4js";
 import * as util from "util";
 import * as stream from "stream";
 import Future = require("fibers/future");
+import marked = require("marked");
+let TerminalRenderer = require("marked-terminal");
+let chalk = require("chalk");
 
 export class Logger implements ILogger {
 	private log4jsLogger: log4js.ILogger = null;
@@ -114,6 +117,27 @@ export class Logger implements ILogger {
 		}, timeout);
 
 		return printMsgFuture;
+	}
+
+	public printMarkdown(message: string): void {
+		let opts = {
+			unescape: true,
+			link: chalk.red,
+			tableOptions: {
+				chars: { 'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': '' },
+				style: {
+					'padding-left': 1,
+					'padding-right': 1,
+					head: ['green', 'bold'],
+					border: ['grey'],
+					compact: false
+				}
+			}
+		};
+
+		marked.setOptions({ renderer: new TerminalRenderer(opts) });
+		let formattedMessage = marked(message);
+		this.write(formattedMessage);
 	}
 
 	private getPasswordEncodedArguments(args: string[]): string[] {

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -67,7 +67,8 @@ export class CommandsService implements ICommandsService {
 
 				let commandHelp = this.getCommandHelp().wait();
 				if (!command.disableCommandHelpSuggestion && commandHelp && commandHelp[commandName]) {
-					this.$logger.info(commandHelp[commandName]);
+					let suggestionText: string = commandHelp[commandName];
+					this.$logger.printMarkdown(~suggestionText.indexOf('%s') ? require('util').format(suggestionText, commandArguments) : suggestionText);
 				}
 
 				return true;

--- a/services/html-help-service.ts
+++ b/services/html-help-service.ts
@@ -3,9 +3,6 @@
 
 import Future = require("fibers/future");
 import * as path from "path";
-import marked = require("marked");
-let TerminalRenderer = require("marked-terminal");
-let chalk = require("chalk");
 
 export class HtmlHelpService implements IHtmlHelpService {
 	private static MARKDOWN_FILE_EXTENSION = ".md";
@@ -153,23 +150,7 @@ export class HtmlHelpService implements IHtmlHelpService {
 				.replace(/&nbsp;/g, " ")
 				.replace(HtmlHelpService.MARKDOWN_LINK_REGEX, "$1");
 
-			let opts = {
-				unescape: true,
-				link: chalk.red,
-				tableOptions: {
-					chars: { 'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': '' },
-					style: {
-						'padding-left': 1,
-						'padding-right': 1,
-						head: ['green', 'bold'],
-						border: ['grey'],
-						compact: false
-					}
-				}
-			};
-
-			marked.setOptions({ renderer: new TerminalRenderer(opts) });
-			return marked(outputText);
+			return outputText;
 		}).future<string>()();
 	}
 }


### PR DESCRIPTION
This logic is used when printing help on the console, as well as for command suggestions.