### PR TITLE
Don't prepare platform N times if N files have been changed.

### DIFF
--- a/services/usb-livesync-service-base.ts
+++ b/services/usb-livesync-service-base.ts
@@ -149,6 +149,7 @@ export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 					this.$logger.trace("Syncing %s", filesToSync.join(", "));
 					this.$dispatcher.dispatch( () => {
 						return (() => {
+							this.preparePlatformForSync(platform);
 							this.syncCore(platform, filesToSync, appIdentifier, projectFilesPath, platformSpecificLiveSyncServices, notInstalledAppOnDeviceAction, beforeLiveSyncAction).wait();
 						}).future<void>()();
 					});
@@ -159,6 +160,9 @@ export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 		this.$dispatcher.dispatch( () => (() => {
 			this.syncQueue.push(beforeBatchLiveSyncAction ? beforeBatchLiveSyncAction(filePath).wait() : filePath);
 		}).future<void>()());
+	}
+
+	protected preparePlatformForSync(platform: string) {
 	}
 
 	private isFileExcluded(path: string, exclusionList: string[], projectDir: string): boolean {


### PR DESCRIPTION
Move platform preparation out of `beforeBatchLiveSyncAction` and call it once
before processing changed files.

The actual preparation override submitted in a separate PR for `nativescript-cli`. I'd be happy to add/update tests for that logic, so feel free to point me in the right direction.