### PR TITLE
Livesync iOS simulator restart fixes

### DIFF
--- a/mobile/ios/ios-emulator-services.ts
+++ b/mobile/ios/ios-emulator-services.ts
@@ -208,7 +208,12 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 				this.$logger.trace("Unable to kill simulator: " + e);
 			}
 
-			this.$childProcess.exec(`xcrun simctl launch ${runningSimulatorId} ${appIdentifier}`).wait();
+			setTimeout(() => {
+				// Killall doesn't always finish immediately, and the subsequent
+				// start fails since the app is already running.
+				// Give it some time to die before we attempt restarting.
+				this.$childProcess.exec(`xcrun simctl launch ${runningSimulatorId} ${appIdentifier}`);
+			}, 500);
 		}).future<void>()();
 	}
 }

--- a/services/usb-livesync-service-base.ts
+++ b/services/usb-livesync-service-base.ts
@@ -190,7 +190,7 @@ export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 		notInstalledAppOnDeviceAction: (_device: Mobile.IDevice) => IFuture<void>,
 		beforeLiveSyncAction?: (_device1: Mobile.IDevice, _deviceAppData: Mobile.IDeviceAppData) => IFuture<void>,
 		beforeBatchLiveSyncAction?: (_filePath: string) => IFuture<string>) : void {
-			if (this.batch == null || !this.batch.syncPending) {
+			if (!this.batch || !this.batch.syncPending) {
 				this.batch = new SyncBatch(
 					this.$logger, this.$dispatcher, (filesToSync) => {
 						this.preparePlatformForSync(platform);
@@ -219,7 +219,7 @@ export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 		filePath: string,
 		notRunningiOSSimulatorAction: () => IFuture<void>,
 		iOSSimulatorRelativeToProjectBasePathAction:(projectFile: string) => string): void {
-			if (this.batch == null || !this.batch.syncPending) {
+			if (!this.batch || !this.batch.syncPending) {
 				this.batch = new SyncBatch(
 					this.$logger, this.$dispatcher, (filesToSync) => {
 						this.$iOSEmulatorServices.syncFiles(appIdentifier, projectFilesPath, filesToSync, notRunningiOSSimulatorAction, iOSSimulatorRelativeToProjectBasePathAction);

--- a/services/usb-livesync-service-base.ts
+++ b/services/usb-livesync-service-base.ts
@@ -43,7 +43,7 @@ class SyncBatch {
 		}
 
 		public get syncPending() {
-			return this.syncQueue.length > 0
+			return this.syncQueue.length > 0;
 		}
 }
 
@@ -204,11 +204,11 @@ export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 							beforeLiveSyncAction
 						).wait();
 					}
-				)
+				);
 			}
 
 		this.$dispatcher.dispatch( () => (() => {
-			let fileToSync = beforeBatchLiveSyncAction ? beforeBatchLiveSyncAction(filePath).wait() : filePath
+			let fileToSync = beforeBatchLiveSyncAction ? beforeBatchLiveSyncAction(filePath).wait() : filePath;
 			this.batch.addFile(fileToSync);
 		}).future<void>()());
 	}
@@ -222,9 +222,9 @@ export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 			if (this.batch == null || !this.batch.syncPending) {
 				this.batch = new SyncBatch(
 					this.$logger, this.$dispatcher, (filesToSync) => {
-						this.$iOSEmulatorServices.syncFiles(appIdentifier, projectFilesPath, filesToSync, notRunningiOSSimulatorAction, iOSSimulatorRelativeToProjectBasePathAction)
+						this.$iOSEmulatorServices.syncFiles(appIdentifier, projectFilesPath, filesToSync, notRunningiOSSimulatorAction, iOSSimulatorRelativeToProjectBasePathAction);
 					}
-				)
+				);
 			}
 
 			this.batch.addFile(filePath);

--- a/services/usb-livesync-service-base.ts
+++ b/services/usb-livesync-service-base.ts
@@ -12,6 +12,41 @@ interface IProjectFileInfo {
 	shouldIncludeFile: boolean;
 }
 
+class SyncBatch {
+	private timer: NodeJS.Timer = null;
+	private syncQueue: string[] = [];
+
+	constructor(
+		private $logger: ILogger,
+		private $dispatcher: IFutureDispatcher,
+		private done: (filesToSync: Array<string>) => void) {
+		}
+
+		public addFile(filePath: string): void {
+			if (this.timer) {
+				clearTimeout(this.timer);
+			}
+
+			this.syncQueue.push(filePath);
+
+			this.timer = setTimeout(() => {
+				let filesToSync = this.syncQueue;
+				if (filesToSync.length > 0) {
+					this.syncQueue = [];
+					this.$logger.trace("Syncing %s", filesToSync.join(", "));
+					this.$dispatcher.dispatch( () => {
+						return (() => this.done(filesToSync)).future<void>()();
+					});
+				}
+				this.timer = null;
+			}, 500);
+		}
+
+		public get syncPending() {
+			return this.syncQueue.length > 0
+		}
+}
+
 export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 	private _initialized = false;
 
@@ -68,17 +103,31 @@ export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 
 			if(this.$options.watch) {
 				let that = this;
-
 				gaze("**/*", { cwd: watchGlob }, function(err: any, watcher: any) {
 					this.on('all', (event: string, filePath: string) => {
 						if(event === "added" || event === "changed") {
 							if(!_.contains(excludedProjectDirsAndFiles, filePath)) {
 								if(synciOSSimulator) {
-									that.$dispatcher.dispatch(() => that.$iOSEmulatorServices.syncFiles(appIdentifier, projectFilesPath, [filePath], notRunningiOSSimulatorAction, iOSSimulatorRelativeToProjectBasePathAction));
+									that.batchSimulatorLiveSync(
+										appIdentifier,
+										projectFilesPath,
+										filePath,
+										notRunningiOSSimulatorAction,
+										iOSSimulatorRelativeToProjectBasePathAction
+									);
 								}
 
 								if(!that.$options.emulator || platform.toLowerCase() === "android") {
-									that.batchLiveSync(platform, filePath, appIdentifier, localProjectRootPath || projectFilesPath,  platformSpecificLiveSyncServices, notInstalledAppOnDeviceAction, beforeLiveSyncAction, beforeBatchLiveSyncAction);
+									that.batchLiveSync(
+										platform,
+										filePath,
+										appIdentifier,
+										localProjectRootPath || projectFilesPath,
+										platformSpecificLiveSyncServices,
+										notInstalledAppOnDeviceAction,
+										beforeLiveSyncAction,
+										beforeBatchLiveSyncAction
+									);
 								}
 							}
 						}
@@ -134,38 +183,56 @@ export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 		}).future<void>()();
 	}
 
-	private timer: NodeJS.Timer = null;
-	private syncQueue: string[] = [];
+	private batch: SyncBatch = null;
+
 	private batchLiveSync(platform: string, filePath: string, appIdentifier: string, projectFilesPath: string,
 		platformSpecificLiveSyncServices: IDictionary<any>,
 		notInstalledAppOnDeviceAction: (_device: Mobile.IDevice) => IFuture<void>,
 		beforeLiveSyncAction?: (_device1: Mobile.IDevice, _deviceAppData: Mobile.IDeviceAppData) => IFuture<void>,
 		beforeBatchLiveSyncAction?: (_filePath: string) => IFuture<string>) : void {
-
-		if (!this.timer) {
-			this.timer = setInterval(() => {
-				let filesToSync = this.syncQueue;
-				if (filesToSync.length > 0) {
-					this.syncQueue = [];
-					this.$logger.trace("Syncing %s", filesToSync.join(", "));
-					this.$dispatcher.dispatch( () => {
-						return (() => {
-							this.preparePlatformForSync(platform);
-							this.syncCore(platform, filesToSync, appIdentifier, projectFilesPath, platformSpecificLiveSyncServices, notInstalledAppOnDeviceAction, beforeLiveSyncAction).wait();
-						}).future<void>()();
-					});
-				}
-			}, 500);
-		}
+			if (this.batch == null || !this.batch.syncPending) {
+				this.batch = new SyncBatch(
+					this.$logger, this.$dispatcher, (filesToSync) => {
+						this.preparePlatformForSync(platform);
+						this.syncCore(
+							platform,
+							filesToSync,
+							appIdentifier,
+							projectFilesPath,
+							platformSpecificLiveSyncServices,
+							notInstalledAppOnDeviceAction,
+							beforeLiveSyncAction
+						).wait();
+					}
+				)
+			}
 
 		this.$dispatcher.dispatch( () => (() => {
-			this.syncQueue.push(beforeBatchLiveSyncAction ? beforeBatchLiveSyncAction(filePath).wait() : filePath);
+			let fileToSync = beforeBatchLiveSyncAction ? beforeBatchLiveSyncAction(filePath).wait() : filePath
+			this.batch.addFile(fileToSync);
 		}).future<void>()());
 	}
 
-	protected preparePlatformForSync(platform: string) {
-        //Overridden in platform-specific services.
-	}
+	private batchSimulatorLiveSync(
+		appIdentifier: string,
+		projectFilesPath: string,
+		filePath: string,
+		notRunningiOSSimulatorAction: () => IFuture<void>,
+		iOSSimulatorRelativeToProjectBasePathAction:(projectFile: string) => string): void {
+			if (this.batch == null || !this.batch.syncPending) {
+				this.batch = new SyncBatch(
+					this.$logger, this.$dispatcher, (filesToSync) => {
+						this.$iOSEmulatorServices.syncFiles(appIdentifier, projectFilesPath, filesToSync, notRunningiOSSimulatorAction, iOSSimulatorRelativeToProjectBasePathAction)
+					}
+				)
+			}
+
+			this.batch.addFile(filePath);
+		}
+
+		protected preparePlatformForSync(platform: string) {
+			//Overridden in platform-specific services.
+		}
 
 	private isFileExcluded(path: string, exclusionList: string[], projectDir: string): boolean {
 		return !!_.find(exclusionList, (pattern) => minimatch(path, pattern, { nocase: true }));


### PR DESCRIPTION
1. We are now batching files and restarting just once.
2. No longer failing to restart the app after killing it since it hasn't already died by the time we try to start it.

I also pulled the batching/timeout code to a `SyncBatch` class, so we can share it with the android batch sync operation. Tested and working on an android emulator as well.