### PR TITLE
Fixes the javac version extraction issue

### DIFF
--- a/sysinfo.ts
+++ b/sysinfo.ts
@@ -77,7 +77,9 @@ export class SysInfo implements ISysInfo {
 			res.gradleVer = procOutput ? /Gradle (.*)/i.exec(procOutput)[1] : null;
 
 			let output = this.exec("javac -version", { showStderr: true });
-			res.javacVersion = output ? /^javac (.*)/i.exec(output.stderr)[1]: null;
+            // for other versions of java javac version output is not on first line
+            // thus can't use ^ for starts with in regex
+			res.javacVersion = output ? /javac (.*)/i.exec(output.stderr)[1]: null;
 
 			this.sysInfoCache = res;
 		}


### PR DESCRIPTION
Fix NativeScript/nativescript-cli#936. Regex to read javac version was not working for openjdk java
version because it was expecting the output to starts with javac.

output with openjdk is:
```
Picked up JAVA_TOOL_OPTIONS: -javaagent:/usr/share/java/jayatanaag.jar 
javac 1.8.0_45-internal
```