### PR TITLE
Remove check for ant version

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -306,8 +306,6 @@ interface ISysInfoData {
 	// dependencies
 	/** version of java, as returned by `java -version` */
 	javaVer: string;
-	/** version string of ant, as returned by `ant -version` */
-	antVer: string;
 	/** Xcode version string as returned by `xcodebuild -version`. Valid only on Mac */
 	xcodeVer: string;
 	/** Version string of adb, as returned by `adb version` */

--- a/sysinfo.ts
+++ b/sysinfo.ts
@@ -42,15 +42,12 @@ export class SysInfo implements ISysInfo {
 
 			// dependencies
 			try {
-                // different java has different format for `java -version` command
+				// different java has different format for `java -version` command
 				let output = this.$childProcess.spawnFromEvent("java", ["-version"], "exit").wait().stderr;
 				res.javaVer = /(?:openjdk|java) version \"((?:\d+\.)+(?:\d+))/i.exec(output)[1];
 			} catch(e) {
 				res.javaVer = null;
 			}
-
-			procOutput = this.exec("ant -version");
-			res.antVer = procOutput ? procOutput.split(os.EOL)[0] : null;
 
 			res.nodeGypVer = this.exec("node-gyp -v");
 			res.xcodeVer = this.$hostInfo.isDarwin ? this.exec("xcodebuild -version") : null;


### PR DESCRIPTION
Ant had been used in older versions of NativeScript CLI. We do not use it
anymore, so remove the antVersion check.