### PR TITLE
Fix resolving of child when parent is registered

### DIFF
--- a/yok.ts
+++ b/yok.ts
@@ -36,7 +36,7 @@ function annotate(fn: any) {
 		argDecl: string[];
 
 	if(typeof fn === "function") {
-		if(!($inject = fn.$inject)) {
+		if(!($inject = fn.$inject) || $inject.name !== fn.name) {
 			$inject = { args: [], name: "" };
 			fnText = fn.toString().replace(STRIP_COMMENTS, '');
 			argDecl = fnText.match(FN_NAME_AND_ARGS);


### PR DESCRIPTION
When you have class A in file A and class B in file B, that extends class A and you register both classes in the injector, trying to resolve the child (B) is leading to unexpected behavior. The constructor of B is called with arguments that are applicable to the base class (A). The reason is that the "extend" method is copying all properties from base class to the child. This includes the $inject property of the base class, so the annotate of the child class is not executed.
Fix this by checking both $inject property and the name of the function.