### PR TITLE
Don't cache installed applications

### DIFF
--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -24,10 +24,12 @@ export class AndroidApplicationManager implements Mobile.IDeviceApplicationManag
 	}
 
 	public installApplication(packageFilePath: string): IFuture<void> {
+		this._installedApplications = null;
 		return this.adb.executeCommand(["install", "-r", `${packageFilePath}`]);
 	}
 
 	public uninstallApplication(appIdentifier: string): IFuture<void> {
+		this._installedApplications = null;
 		return this.adb.executeShellCommand(["pm", "uninstall", `${appIdentifier}`]);
 	}
 


### PR DESCRIPTION
If livesync android --watch command is executed and the application is not deployed on device, {N} deploys the app on every change. This happens because the installed applications are cached and actually the new application never appears in installed applications.

Fixes https://github.com/NativeScript/nativescript-cli/issues/977