### PR TITLE
Fix tns emulate ios

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -283,7 +283,7 @@ declare module Mobile {
 		checkDependencies(): IFuture<void>;
 		checkAvailability(dependsOnProject?: boolean): IFuture<void>;
 		startEmulator(app: string, emulatorOptions?: IEmulatorOptions): IFuture<void>;
-		getEmulatorId?(): IFuture<string>;
+		getEmulatorId(): IFuture<string>;
 	}
 
 	interface IiOSSimulatorService extends IEmulatorPlatformServices {

--- a/mobile/ios/ios-emulator-services.ts
+++ b/mobile/ios/ios-emulator-services.ts
@@ -19,6 +19,10 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 		private $fs: IFileSystem,
 		private $bplistParser: IBinaryPlistParser) { }
 
+	public getEmulatorId(): IFuture<string> {
+		return Future.fromResult("");
+	}
+
 	public checkDependencies(): IFuture<void> {
 		return Future.fromResult();
 	}

--- a/mobile/wp8/wp8-emulator-services.ts
+++ b/mobile/wp8/wp8-emulator-services.ts
@@ -12,6 +12,10 @@ class Wp8EmulatorServices implements Mobile.IEmulatorPlatformServices {
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $hostInfo: IHostInfo) { }
 
+	public getEmulatorId(): IFuture<string> {
+		return future.fromResult("");
+	}
+
 	public checkDependencies(): IFuture<void> {
 		return future.fromResult();
 	}


### PR DESCRIPTION
If `tns emulate ios` command is executed, `undefined is not a function` error is thrown