### PR TITLE
Add option to handle the ios-sim-portable output so that we could get…

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -282,7 +282,7 @@ declare module Mobile {
 	interface IEmulatorPlatformServices {
 		checkDependencies(): IFuture<void>;
 		checkAvailability(dependsOnProject?: boolean): IFuture<void>;
-		startEmulator(app: string, emulatorOptions?: IEmulatorOptions): IFuture<void>;
+		startEmulator(app: string, emulatorOptions?: IEmulatorOptions): IFuture<any>;
 		getEmulatorId?(): IFuture<string>;
 	}
 
@@ -304,6 +304,8 @@ declare module Mobile {
 		appId?: string;
 		args?: string;
 		deviceType?: string;
+		waitForDebugger?: boolean;
+		captureStdin?: boolean;
 	}
 
 	interface IPlatformsCapabilities {


### PR DESCRIPTION
… the PID of the running application. Also pass a wait for debugger option if available

Part of the fix for https://github.com/NativeScript/nativescript-cli/issues/1044