### PR TITLE
Restructure error messaging

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -22,6 +22,8 @@ $injector.require("stringParameterBuilder", "./command-params");
 
 $injector.require("commandsService", "./services/commands-service");
 
+$injector.require("messagesService", "./services/messages-service");
+
 $injector.require("cancellation", "./services/cancellation");
 $injector.require("analyticsService", "./services/analytics-service");
 $injector.require("hooksService", "./services/hooks-service");
@@ -95,7 +97,9 @@ $injector.require("microTemplateService", "./services/micro-templating-service")
 $injector.require("mobileHelper", "./mobile/mobile-helper");
 $injector.require("devicePlatformsConstants", "./mobile/device-platforms-constants");
 $injector.require("htmlHelpService", "./services/html-help-service");
+$injector.require("messageContractGenerator", "./services/message-contract-generator");
 $injector.requireCommand("dev-preuninstall", "./commands/preuninstall");
+$injector.requireCommand("dev-generate-messages", "./commands/generate-messages");
 $injector.requireCommand("doctor", "./commands/doctor");
 
 $injector.require("utils", "./utils");

--- a/codeGeneration/code-entity.ts
+++ b/codeGeneration/code-entity.ts
@@ -1,0 +1,57 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+export enum CodeEntityType {
+	Line,
+	Block
+}
+
+export class Line implements CodeGeneration.ILine {
+	public content: string;
+
+	constructor(content: string) {
+		this.content = content;
+	}
+
+	public get codeEntityType() {
+		return CodeEntityType.Line;
+	}
+
+	public static create(content: string): CodeGeneration.ILine {
+		return new Line(content);
+	}
+}
+$injector.register("swaggerLine", Line);
+
+export class Block implements CodeGeneration.IBlock {
+	public opener: string;
+	public codeEntities: CodeGeneration.ICodeEntity[];
+	public endingCharacter: string;
+
+	constructor(opener?: string) {
+		this.opener = opener;
+		this.codeEntities = [];
+	}
+
+	public get codeEntityType() {
+		return CodeEntityType.Block;
+	}
+
+	public addBlock(block: CodeGeneration.IBlock): void {
+		this.codeEntities.push(block);
+	}
+
+	public addLine(line: CodeGeneration.ILine): void {
+		this.codeEntities.push(line);
+	}
+
+	public addBlocks(blocks: CodeGeneration.IBlock[]): void {
+		_.each(blocks, (block: CodeGeneration.IBlock) => this.addBlock(block));
+	}
+
+	public writeLine(content: string): void {
+		let line = Line.create(content);
+		this.codeEntities.push(line);
+	}
+}
+$injector.register("swaggerBlock", Block);

--- a/codeGeneration/code-generation.d.ts
+++ b/codeGeneration/code-generation.d.ts
@@ -1,0 +1,46 @@
+declare module CodeGeneration {
+
+	interface IModel {
+		id: string;
+		properties: IDictionary<IModelProperty>;
+	}
+
+	interface IModelProperty {
+		type: string;
+		items: IModelPropertyItems;
+		allowableValues: IModelPropertyValue;
+	}
+
+	interface IModelPropertyItems {
+		$ref: string;
+	}
+
+	interface IModelPropertyValue {
+		valueType: string;
+		values: string[];
+	}
+
+	interface ICodeEntity {
+		opener?: string;
+		codeEntityType: any;
+	}
+
+	interface ILine extends ICodeEntity {
+		content: string;
+	}
+
+	interface IBlock extends ICodeEntity {
+		opener: string;
+		codeEntities: ICodeEntity[];
+		writeLine(content: string): void;
+		addLine(line: ILine): void;
+		addBlock(block: IBlock): void;
+		addBlocks(blocks: IBlock[]): void;
+		endingCharacter?: string;
+	}
+
+	interface IService {
+		serviceInterface: IBlock;
+		serviceImplementation: IBlock;
+	}
+}

--- a/codeGeneration/code-printer.ts
+++ b/codeGeneration/code-printer.ts
@@ -2,9 +2,9 @@
 "use strict";
 
 import {EOL} from "os";
-import codeEntityLib = require("./code-entity");
+import {CodeEntityType} from "./code-entity";
 
-export class SwaggerCodePrinter {
+export class CodePrinter {
 	private static INDENT_CHAR = "\t";
 	private static NEW_LINE_CHAR = EOL;
 	private static START_BLOCK_CHAR = "{";
@@ -15,39 +15,39 @@ export class SwaggerCodePrinter {
 
 		if(block.opener) {
 			content += block.opener;
-			content += SwaggerCodePrinter.START_BLOCK_CHAR;
-			content += SwaggerCodePrinter.NEW_LINE_CHAR;
+			content += CodePrinter.START_BLOCK_CHAR;
+			content += CodePrinter.NEW_LINE_CHAR;
 		}
 
 		_.each(block.codeEntities, (codeEntity: CodeGeneration.ICodeEntity) => {
-			if(codeEntity.codeEntityType === codeEntityLib.CodeEntityType.Line) {
+			if(codeEntity.codeEntityType === CodeEntityType.Line) {
 				content += this.composeLine(<CodeGeneration.ILine>codeEntity, indentSize + 1);
-			} else if(codeEntity.codeEntityType === codeEntityLib.CodeEntityType.Block){
+			} else if(codeEntity.codeEntityType === CodeEntityType.Block){
 				content += this.composeBlock(<CodeGeneration.IBlock>codeEntity, indentSize + 1);
 			}
 		});
 
 		if(block.opener) {
 			content += this.getIndentation(indentSize);
-			content += SwaggerCodePrinter.END_BLOCK_CHAR;
-			content += block.endingCharacter ? block.endingCharacter : '';
+			content += CodePrinter.END_BLOCK_CHAR;
+			content += block.endingCharacter || '';
 		}
 
-		content += SwaggerCodePrinter.NEW_LINE_CHAR;
+		content += CodePrinter.NEW_LINE_CHAR;
 
 		return content;
 	}
 
 	private getIndentation(indentSize: number): string {
-		return Array(indentSize).join(SwaggerCodePrinter.INDENT_CHAR);
+		return Array(indentSize).join(CodePrinter.INDENT_CHAR);
 	}
 
 	private composeLine(line: CodeGeneration.ILine, indentSize: number): string {
 		let content = this.getIndentation(indentSize);
 		content += line.content;
-		content += SwaggerCodePrinter.NEW_LINE_CHAR;
+		content += CodePrinter.NEW_LINE_CHAR;
 
 		return content;
 	}
 }
-$injector.register("swaggerCodePrinter", SwaggerCodePrinter);
+$injector.register("swaggerCodePrinter", CodePrinter);

--- a/codeGeneration/code-printer.ts
+++ b/codeGeneration/code-printer.ts
@@ -1,0 +1,53 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import {EOL} from "os";
+import codeEntityLib = require("./code-entity");
+
+export class SwaggerCodePrinter {
+	private static INDENT_CHAR = "\t";
+	private static NEW_LINE_CHAR = EOL;
+	private static START_BLOCK_CHAR = "{";
+	private static END_BLOCK_CHAR = "}";
+
+	public composeBlock(block: CodeGeneration.IBlock, indentSize: number = 0): string {
+		let content = this.getIndentation(indentSize);
+
+		if(block.opener) {
+			content += block.opener;
+			content += SwaggerCodePrinter.START_BLOCK_CHAR;
+			content += SwaggerCodePrinter.NEW_LINE_CHAR;
+		}
+
+		_.each(block.codeEntities, (codeEntity: CodeGeneration.ICodeEntity) => {
+			if(codeEntity.codeEntityType === codeEntityLib.CodeEntityType.Line) {
+				content += this.composeLine(<CodeGeneration.ILine>codeEntity, indentSize + 1);
+			} else if(codeEntity.codeEntityType === codeEntityLib.CodeEntityType.Block){
+				content += this.composeBlock(<CodeGeneration.IBlock>codeEntity, indentSize + 1);
+			}
+		});
+
+		if(block.opener) {
+			content += this.getIndentation(indentSize);
+			content += SwaggerCodePrinter.END_BLOCK_CHAR;
+			content += block.endingCharacter ? block.endingCharacter : '';
+		}
+
+		content += SwaggerCodePrinter.NEW_LINE_CHAR;
+
+		return content;
+	}
+
+	private getIndentation(indentSize: number): string {
+		return Array(indentSize).join(SwaggerCodePrinter.INDENT_CHAR);
+	}
+
+	private composeLine(line: CodeGeneration.ILine, indentSize: number): string {
+		let content = this.getIndentation(indentSize);
+		content += line.content;
+		content += SwaggerCodePrinter.NEW_LINE_CHAR;
+
+		return content;
+	}
+}
+$injector.register("swaggerCodePrinter", SwaggerCodePrinter);

--- a/commands/generate-messages.ts
+++ b/commands/generate-messages.ts
@@ -1,0 +1,24 @@
+///<reference path="../.d.ts"/>
+"use strict";
+import * as path from "path";
+
+export class GenerateMessages implements ICommand {
+	constructor(private $fs: IFileSystem,
+				private $messageContractGenerator: IServiceContractGenerator,
+				private $staticConfig: Config.IStaticConfig) {
+	}
+
+	allowedParameters: ICommandParameter[] = [];
+
+	execute(args: string[]): IFuture<void> {
+		return (() => {
+			let result = this.$messageContractGenerator.generate().wait(),
+				interfaceFilePath = this.$staticConfig.CLIENT_NAME ? path.join(__dirname, "../../messages.d.ts") : path.join(__dirname, "../messages/messages.d.ts"),
+				implementationFilePath = this.$staticConfig.CLIENT_NAME ? path.join(__dirname, "../../messages.ts") : path.join(__dirname, "../messages/messages.ts");
+
+			this.$fs.writeFile(interfaceFilePath, result.interfaceFile).wait();
+			this.$fs.writeFile(implementationFilePath, result.implementationFile).wait();
+		}).future<void>()();
+	}
+}
+$injector.registerCommand("dev-generate-messages", GenerateMessages);

--- a/commands/generate-messages.ts
+++ b/commands/generate-messages.ts
@@ -3,6 +3,9 @@
 import * as path from "path";
 
 export class GenerateMessages implements ICommand {
+	private static MESSAGES_DEFINITIONS_FILE_NAME = "messages.d.ts";
+	private static MESSAGES_IMPLEMENTATION_FILE_NAME = "messages.ts";
+
 	constructor(private $fs: IFileSystem,
 				private $messageContractGenerator: IServiceContractGenerator,
 				private $staticConfig: Config.IStaticConfig) {
@@ -13,8 +16,18 @@ export class GenerateMessages implements ICommand {
 	execute(args: string[]): IFuture<void> {
 		return (() => {
 			let result = this.$messageContractGenerator.generate().wait(),
-				interfaceFilePath = this.$staticConfig.CLIENT_NAME ? path.join(__dirname, "../../messages.d.ts") : path.join(__dirname, "../messages/messages.d.ts"),
-				implementationFilePath = this.$staticConfig.CLIENT_NAME ? path.join(__dirname, "../../messages.ts") : path.join(__dirname, "../messages/messages.ts");
+				outerMessagesDirectory = path.join(__dirname, "../messages"),
+				innerMessagesDirectory = path.join(__dirname, "../.."),
+				interfaceFilePath: string,
+				implementationFilePath: string;
+
+			if (this.$staticConfig.CLIENT_NAME) {
+				interfaceFilePath = path.join(outerMessagesDirectory, GenerateMessages.MESSAGES_DEFINITIONS_FILE_NAME);
+				implementationFilePath = path.join(outerMessagesDirectory, GenerateMessages.MESSAGES_IMPLEMENTATION_FILE_NAME);
+			} else {
+				interfaceFilePath = path.join(innerMessagesDirectory, GenerateMessages.MESSAGES_DEFINITIONS_FILE_NAME);
+				implementationFilePath = path.join(innerMessagesDirectory, GenerateMessages.MESSAGES_IMPLEMENTATION_FILE_NAME);
+			}
 
 			this.$fs.writeFile(interfaceFilePath, result.interfaceFile).wait();
 			this.$fs.writeFile(implementationFilePath, result.implementationFile).wait();

--- a/commands/generate-messages.ts
+++ b/commands/generate-messages.ts
@@ -8,25 +8,26 @@ export class GenerateMessages implements ICommand {
 
 	constructor(private $fs: IFileSystem,
 				private $messageContractGenerator: IServiceContractGenerator,
-				private $staticConfig: Config.IStaticConfig) {
+				private $options: ICommonOptions) {
 	}
 
 	allowedParameters: ICommandParameter[] = [];
 
 	execute(args: string[]): IFuture<void> {
 		return (() => {
-			let result = this.$messageContractGenerator.generate().wait(),
-				outerMessagesDirectory = path.join(__dirname, "../messages"),
-				innerMessagesDirectory = path.join(__dirname, "../.."),
+			let definitionsPath = `"${this.$options.default ? "../" : ""}.d.ts"`,
+				result = this.$messageContractGenerator.generate(definitionsPath).wait(),
+				innerMessagesDirectory = path.join(__dirname, "../messages"),
+				outerMessagesDirectory = path.join(__dirname, "../.."),
 				interfaceFilePath: string,
 				implementationFilePath: string;
 
-			if (this.$staticConfig.CLIENT_NAME) {
-				interfaceFilePath = path.join(outerMessagesDirectory, GenerateMessages.MESSAGES_DEFINITIONS_FILE_NAME);
-				implementationFilePath = path.join(outerMessagesDirectory, GenerateMessages.MESSAGES_IMPLEMENTATION_FILE_NAME);
-			} else {
+			if (this.$options.default) {
 				interfaceFilePath = path.join(innerMessagesDirectory, GenerateMessages.MESSAGES_DEFINITIONS_FILE_NAME);
 				implementationFilePath = path.join(innerMessagesDirectory, GenerateMessages.MESSAGES_IMPLEMENTATION_FILE_NAME);
+			} else {
+				interfaceFilePath = path.join(outerMessagesDirectory, GenerateMessages.MESSAGES_DEFINITIONS_FILE_NAME);
+				implementationFilePath = path.join(outerMessagesDirectory, GenerateMessages.MESSAGES_IMPLEMENTATION_FILE_NAME);
 			}
 
 			this.$fs.writeFile(interfaceFilePath, result.interfaceFile).wait();

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -429,6 +429,7 @@ interface ICommonOptions {
 	emulator: boolean;
 	sdk: string;
 	var: Object;
+	default: Boolean;
 }
 
 interface IYargArgv extends IDictionary<any> {
@@ -591,7 +592,8 @@ interface IServiceContractClientCode {
 interface IServiceContractGenerator {
 	/**
 	 * Generate code implementation along with interface
-	 * @return {IFuture<IServiceContractClientCode>} The generated code parts
+	 * @param  {string}                              definitionsPath The path to the desired parent .d.ts file
+	 * @return {IFuture<IServiceContractClientCode>}                 The generated code parts
 	 */
-	generate(): IFuture<IServiceContractClientCode>;
+	generate(definitionsPath?: string): IFuture<IServiceContractClientCode>;
 }

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -576,3 +576,22 @@ interface IMessagesService {
 	 */
 	getMessage(id: string, ...args: string[]): string;
 }
+
+/**
+ * Describes generated code parts.
+ */
+interface IServiceContractClientCode {
+	interfaceFile: string;
+	implementationFile: string;
+}
+
+/**
+ * Used for code generation.
+ */
+interface IServiceContractGenerator {
+	/**
+	 * Generate code implementation along with interface
+	 * @return {IFuture<IServiceContractClientCode>} The generated code parts
+	 */
+	generate(): IFuture<IServiceContractClientCode>;
+}

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -558,3 +558,21 @@ interface IPluginVariablesHelper {
 	getPluginVariableFromVarOption(variableName: string, configuration?: string): any;
 	simplifyYargsObject(obj: any, configuration?: string): any;
 }
+
+/**
+ * Used for getting strings for informational/error messages.
+ */
+interface IMessagesService {
+	/**
+	 * Array of the paths to the .json files containing all the messages.
+	 * @type {string[]}
+	 */
+	pathsToMessageJsonFiles: string[];
+
+	/**
+	 * @param  {string} 	id		Message's key in corresponding messages json file, could be complex (e.g. 'iOS.iTunes.ConnectError').
+	 * @param  {string[]} 	args	Additional arguments used when the message's value is a string format.
+	 * @return {string}				The value found under the given id. If no value is found returns the id itself.
+	 */
+	getMessage(id: string, ...args: string[]): string;
+}

--- a/errors.ts
+++ b/errors.ts
@@ -93,6 +93,8 @@ export function installUncaughtExceptionListener(actionOnException?: () => void)
 }
 
 export class Errors implements IErrors {
+	constructor(private $injector: IInjector) {
+	}
 
 	public printCallStack: boolean = false;
 
@@ -102,15 +104,13 @@ export class Errors implements IErrors {
 			opts = { formatStr: opts };
 		}
 
-		args.unshift(opts.formatStr);
-
 		let exception: any = new (<any>Exception)();
 		exception.name = opts.name || "Exception";
-		exception.message = util.format.apply(null, args);
+		exception.message = this.$injector.resolve("messagesService").getMessage(opts.formatStr, ...args);
 		exception.stack = (new Error(exception.message)).stack;
 		exception.errorCode = opts.errorCode || ErrorCodes.UNKNOWN;
 		exception.suppressCommandHelp = opts.suppressCommandHelp;
-
+		this.$injector.resolve("logger").trace(opts.formatStr);
 		throw exception;
 	}
 

--- a/file-system.ts
+++ b/file-system.ts
@@ -12,8 +12,7 @@ import * as crypto from "crypto";
 
 @injector.register("fs")
 export class FileSystem implements IFileSystem {
-	constructor(private $injector: IInjector,
-		private $hostInfo: IHostInfo) { }
+	constructor(private $injector: IInjector) { }
 
 	//TODO: try 'archiver' module for zipping
 	public zipFiles(zipFile: string, files: string[], zipPathCallback: (path: string) => string): IFuture<void> {
@@ -60,15 +59,16 @@ export class FileSystem implements IFileSystem {
 		return (() => {
 			let shouldOverwriteFiles = !(options && options.overwriteExisitingFiles === false);
 			let isCaseSensitive = !(options && options.caseSensitive === false);
+			let $hostInfo = this.$injector.resolve("$hostInfo");
 
 			this.createDirectory(destinationDir).wait();
 
 			let proc: string;
-			if (this.$hostInfo.isWindows) {
+			if ($hostInfo.isWindows) {
 				proc = path.join(__dirname, "resources/platform-tools/unzip/win32/unzip");
-			} else if (this.$hostInfo.isDarwin) {
+			} else if ($hostInfo.isDarwin) {
 				proc = "unzip"; // darwin unzip is info-zip
-			} else if (this.$hostInfo.isLinux) {
+			} else if ($hostInfo.isLinux) {
 				proc = "unzip"; // linux unzip is info-zip
 			}
 
@@ -441,7 +441,7 @@ export class FileSystem implements IFileSystem {
 		return (() => {
 			let $childProcess = this.$injector.resolve("childProcess");
 
-			if(!this.$hostInfo.isWindows) {
+			if(!this.$injector.resolve("$hostInfo").isWindows) {
 				let chown = $childProcess.spawn("chown", ["-R", owner, path],
 					{ stdio: "ignore", detached: true });
 				this.futureFromEvent(chown, "close").wait();

--- a/messages/messages.d.ts
+++ b/messages/messages.d.ts
@@ -1,12 +1,12 @@
 //
 // automatically generated code; do not edit manually!
 //
-///<reference path="../.d.ts"/>
+///<reference path=".d.ts"/>
 interface IMessages{
-			DEVICES : {
-			NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE: string;
-			NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE_WITH_IDENTIFIER: string;
-			NOT_FOUND_DEVICE_BY_INDEX_ERROR_MESSAGE: string;
+			Devices : {
+			NotFoundDeviceByIdentifierErrorMessage: string;
+			NotFoundDeviceByIdentifierErrorMessageWithIdentifier: string;
+			NotFoundDeviceByIndexErrorMessage: string;
 		};
 
 }

--- a/messages/messages.d.ts
+++ b/messages/messages.d.ts
@@ -1,0 +1,13 @@
+//
+// automatically generated code; do not edit manually!
+//
+///<reference path="../.d.ts"/>
+interface IMessages{
+			DEVICES : {
+			NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE: string;
+			NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE_WITH_IDENTIFIER: string;
+			NOT_FOUND_DEVICE_BY_INDEX_ERROR_MESSAGE: string;
+		};
+
+}
+

--- a/messages/messages.d.ts
+++ b/messages/messages.d.ts
@@ -1,7 +1,7 @@
+///<reference path="../.d.ts"/>
 //
 // automatically generated code; do not edit manually!
 //
-///<reference path=".d.ts"/>
 interface IMessages{
 			Devices : {
 			NotFoundDeviceByIdentifierErrorMessage: string;

--- a/messages/messages.ts
+++ b/messages/messages.ts
@@ -1,4 +1,4 @@
-///<reference path=".d.ts"/>
+///<reference path="../.d.ts"/>
 "use strict";
 //
 // automatically generated code; do not edit manually!

--- a/messages/messages.ts
+++ b/messages/messages.ts
@@ -1,14 +1,14 @@
-///<reference path="../.d.ts"/>
+///<reference path=".d.ts"/>
 "use strict";
 //
 // automatically generated code; do not edit manually!
 //
 
 export class Messages implements IMessages{
-			DEVICES = {
-			NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE: "DEVICES.NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE",
-			NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE_WITH_IDENTIFIER: "DEVICES.NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE_WITH_IDENTIFIER",
-			NOT_FOUND_DEVICE_BY_INDEX_ERROR_MESSAGE: "DEVICES.NOT_FOUND_DEVICE_BY_INDEX_ERROR_MESSAGE",
+			Devices = {
+			NotFoundDeviceByIdentifierErrorMessage: "Devices.NotFoundDeviceByIdentifierErrorMessage",
+			NotFoundDeviceByIdentifierErrorMessageWithIdentifier: "Devices.NotFoundDeviceByIdentifierErrorMessageWithIdentifier",
+			NotFoundDeviceByIndexErrorMessage: "Devices.NotFoundDeviceByIndexErrorMessage",
 		};
 
 }

--- a/messages/messages.ts
+++ b/messages/messages.ts
@@ -1,0 +1,16 @@
+///<reference path="../.d.ts"/>
+"use strict";
+//
+// automatically generated code; do not edit manually!
+//
+
+export class Messages implements IMessages{
+			DEVICES = {
+			NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE: "DEVICES.NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE",
+			NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE_WITH_IDENTIFIER: "DEVICES.NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE_WITH_IDENTIFIER",
+			NOT_FOUND_DEVICE_BY_INDEX_ERROR_MESSAGE: "DEVICES.NOT_FOUND_DEVICE_BY_INDEX_ERROR_MESSAGE",
+		};
+
+}
+$injector.register('messages', Messages);
+

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -118,7 +118,7 @@ export class DevicesService implements Mobile.IDevicesService {
 	private getDeviceByIdentifier(identifier: string): Mobile.IDevice {
 		let searchedDevice = _.find(this.getDeviceInstances(), (device: Mobile.IDevice) => { return device.deviceInfo.identifier === identifier; });
 		if(!searchedDevice) {
-			this.$errors.fail(this.$messages.DEVICES.NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE_WITH_IDENTIFIER, identifier, this.$staticConfig.CLIENT_NAME.toLowerCase());
+			this.$errors.fail(this.$messages.Devices.NotFoundDeviceByIdentifierErrorMessageWithIdentifier, identifier, this.$staticConfig.CLIENT_NAME.toLowerCase());
 		}
 
 		return searchedDevice;
@@ -136,7 +136,7 @@ export class DevicesService implements Mobile.IDevicesService {
 			}
 
 			if(!device) {
-				this.$errors.fail(this.$messages.DEVICES.NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE, this.$staticConfig.CLIENT_NAME.toLowerCase());
+				this.$errors.fail(this.$messages.Devices.NotFoundDeviceByIdentifierErrorMessage, this.$staticConfig.CLIENT_NAME.toLowerCase());
 			}
 
 			return device;
@@ -265,7 +265,7 @@ export class DevicesService implements Mobile.IDevicesService {
 
 	private validateIndex(index: number): void {
 		if (index < 0 || index > this.getDeviceInstances().length) {
-			throw new Error(util.format(this.$messages.DEVICES.NOT_FOUND_DEVICE_BY_INDEX_ERROR_MESSAGE, index, this.$staticConfig.CLIENT_NAME.toLowerCase()));
+			throw new Error(util.format(this.$messages.Devices.NotFoundDeviceByIndexErrorMessage, index, this.$staticConfig.CLIENT_NAME.toLowerCase()));
 		}
 	}
 }

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -12,8 +12,6 @@ import * as fiberBootstrap from "../../fiber-bootstrap";
 export class DevicesService implements Mobile.IDevicesService {
 	private _devices: IDictionary<Mobile.IDevice> = {};
 	private platforms: string[] = [];
-	private static NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE = "Could not find device by specified identifier '%s'. To list currently connected devices and verify that the specified identifier exists, run '%s device'.";
-	private static NOT_FOUND_DEVICE_BY_INDEX_ERROR_MESSAGE = "Could not find device by specified index %d. To list currently connected devices and verify that the specified index exists, run '%s device'.";
 	private static DEVICE_LOOKING_INTERVAL = 2200;
 	private _platform: string;
 	private _device: Mobile.IDevice;
@@ -24,6 +22,7 @@ export class DevicesService implements Mobile.IDevicesService {
 		private $iOSDeviceDiscovery: Mobile.IDeviceDiscovery,
 		private $androidDeviceDiscovery: Mobile.IDeviceDiscovery,
 		private $staticConfig: Config.IStaticConfig,
+		private $messages: IMessages,
 		private $mobileHelper: Mobile.IMobileHelper) {
 		this.attachToDeviceDiscoveryEvents();
 	}
@@ -119,7 +118,7 @@ export class DevicesService implements Mobile.IDevicesService {
 	private getDeviceByIdentifier(identifier: string): Mobile.IDevice {
 		let searchedDevice = _.find(this.getDeviceInstances(), (device: Mobile.IDevice) => { return device.deviceInfo.identifier === identifier; });
 		if(!searchedDevice) {
-			this.$errors.fail(DevicesService.NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE, identifier, this.$staticConfig.CLIENT_NAME.toLowerCase());
+			this.$errors.fail(this.$messages.DEVICES.NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE_WITH_IDENTIFIER, identifier, this.$staticConfig.CLIENT_NAME.toLowerCase());
 		}
 
 		return searchedDevice;
@@ -137,7 +136,7 @@ export class DevicesService implements Mobile.IDevicesService {
 			}
 
 			if(!device) {
-				this.$errors.fail("Cannot resolve the specified connected device by the provided index or identifier. To list currently connected devices and verify that the specified index or identifier exists, run '%s device'.", this.$staticConfig.CLIENT_NAME.toLowerCase());
+				this.$errors.fail(this.$messages.DEVICES.NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE, this.$staticConfig.CLIENT_NAME.toLowerCase());
 			}
 
 			return device;
@@ -266,7 +265,7 @@ export class DevicesService implements Mobile.IDevicesService {
 
 	private validateIndex(index: number): void {
 		if (index < 0 || index > this.getDeviceInstances().length) {
-			throw new Error(util.format(DevicesService.NOT_FOUND_DEVICE_BY_INDEX_ERROR_MESSAGE, index, this.$staticConfig.CLIENT_NAME.toLowerCase()));
+			throw new Error(util.format(this.$messages.DEVICES.NOT_FOUND_DEVICE_BY_INDEX_ERROR_MESSAGE, index, this.$staticConfig.CLIENT_NAME.toLowerCase()));
 		}
 	}
 }

--- a/options.ts
+++ b/options.ts
@@ -69,6 +69,7 @@ export class OptionsBase {
 			"emulator": { type: OptionType.Boolean },
 			"sdk": { type: OptionType.String },
 			var: {type: OptionType.Object},
+			default: {type: OptionType.Boolean},
 		};
 	}
 

--- a/resources/messages/errorMessages.json
+++ b/resources/messages/errorMessages.json
@@ -1,7 +1,7 @@
 {
-	"DEVICES": {
-		"NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE": "Cannot resolve the specified connected device by the provided index or identifier. To list currently connected devices and verify that the specified index or identifier exists, run '%s device'.",
-		"NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE_WITH_IDENTIFIER": "Could not find device by specified identifier '%s'. To list currently connected devices and verify that the specified identifier exists, run '%s device'.",
-		"NOT_FOUND_DEVICE_BY_INDEX_ERROR_MESSAGE": "Could not find device by specified index %d. To list currently connected devices and verify that the specified index exists, run '%s device'."
+	"Devices": {
+		"NotFoundDeviceByIdentifierErrorMessage": "Cannot resolve the specified connected device by the provided index or identifier. To list currently connected devices and verify that the specified index or identifier exists, run '%s device'.",
+		"NotFoundDeviceByIdentifierErrorMessageWithIdentifier": "Could not find device by specified identifier '%s'. To list currently connected devices and verify that the specified identifier exists, run '%s device'.",
+		"NotFoundDeviceByIndexErrorMessage": "Could not find device by specified index %d. To list currently connected devices and verify that the specified index exists, run '%s device'."
 	}
 }

--- a/resources/messages/errorMessages.json
+++ b/resources/messages/errorMessages.json
@@ -1,0 +1,7 @@
+{
+	"DEVICES": {
+		"NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE": "Cannot resolve the specified connected device by the provided index or identifier. To list currently connected devices and verify that the specified index or identifier exists, run '%s device'.",
+		"NOT_FOUND_DEVICE_BY_IDENTIFIER_ERROR_MESSAGE_WITH_IDENTIFIER": "Could not find device by specified identifier '%s'. To list currently connected devices and verify that the specified identifier exists, run '%s device'.",
+		"NOT_FOUND_DEVICE_BY_INDEX_ERROR_MESSAGE": "Could not find device by specified index %d. To list currently connected devices and verify that the specified index exists, run '%s device'."
+	}
+}

--- a/services/message-contract-generator.ts
+++ b/services/message-contract-generator.ts
@@ -2,7 +2,7 @@
 "use strict";
 
 import {Block} from "../codeGeneration/code-entity";
-import {SwaggerCodePrinter} from "../codeGeneration/code-printer";
+import {CodePrinter} from "../codeGeneration/code-printer";
 
 export class MessageContractGenerator implements IServiceContractGenerator {
 	private pendingModels: any;
@@ -20,7 +20,7 @@ export class MessageContractGenerator implements IServiceContractGenerator {
 			let definitionsPath = `"${this.$staticConfig.CLIENT_NAME ? "" : "../"}.d.ts"`;
 
 			implementationsFile.writeLine(`///<reference path=${definitionsPath}/>`);
-			implementationsFile.writeLine("\"use strict\";");
+			implementationsFile.writeLine('"use strict";');
 			implementationsFile.writeLine("//");
 			implementationsFile.writeLine("// automatically generated code; do not edit manually!");
 			implementationsFile.writeLine("//");
@@ -50,7 +50,7 @@ export class MessageContractGenerator implements IServiceContractGenerator {
 			implementationsFile.addBlock(messagesClass);
 			implementationsFile.writeLine("$injector.register('messages', Messages);");
 
-			let codePrinter = new SwaggerCodePrinter();
+			let codePrinter = new CodePrinter();
 			return {
 				interfaceFile: codePrinter.composeBlock(interfacesFile),
 				implementationFile: codePrinter.composeBlock(implementationsFile)

--- a/services/message-contract-generator.ts
+++ b/services/message-contract-generator.ts
@@ -1,0 +1,83 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import {Block} from "../codeGeneration/code-entity";
+import {SwaggerCodePrinter} from "../codeGeneration/code-printer";
+
+export class MessageContractGenerator implements IServiceContractGenerator {
+	private pendingModels: any;
+
+	constructor(private $fs: IFileSystem,
+				private $messagesService: IMessagesService,
+				private $staticConfig: Config.IStaticConfig) {
+		this.pendingModels = {};
+	}
+
+	public generate(): IFuture<IServiceContractClientCode> {
+		return ((): IServiceContractClientCode => {
+			let interfacesFile= new Block();
+			let implementationsFile = new Block();
+			let definitionsPath = `"${this.$staticConfig.CLIENT_NAME ? "" : "../"}.d.ts"`;
+
+			implementationsFile.writeLine(`///<reference path=${definitionsPath}/>`);
+			implementationsFile.writeLine("\"use strict\";");
+			implementationsFile.writeLine("//");
+			implementationsFile.writeLine("// automatically generated code; do not edit manually!");
+			implementationsFile.writeLine("//");
+			implementationsFile.writeLine("");
+
+			interfacesFile.writeLine("//");
+			interfacesFile.writeLine("// automatically generated code; do not edit manually!");
+			interfacesFile.writeLine("//");
+			interfacesFile.writeLine(`///<reference path=${definitionsPath}/>`);
+
+			let messagesClass = new Block("export class Messages implements IMessages");
+			let messagesInterface = new Block("interface IMessages");
+
+			_.each(this.$messagesService.pathsToMessageJsonFiles, jsonFilePath => {
+				let jsonContents = this.$fs.readJson(jsonFilePath).wait(),
+					implementationBlock: CodeGeneration.IBlock = new Block(),
+					interfaceBlock: CodeGeneration.IBlock = new Block();
+
+				this.generateFileRecursive(jsonContents, "", implementationBlock, 0, {shouldGenerateInterface: false});
+				this.generateFileRecursive(jsonContents, "", interfaceBlock, 0, {shouldGenerateInterface: true});
+				messagesClass.addBlock(implementationBlock);
+				messagesInterface.addBlock(interfaceBlock);
+			});
+
+			interfacesFile.addBlock(messagesInterface);
+
+			implementationsFile.addBlock(messagesClass);
+			implementationsFile.writeLine("$injector.register('messages', Messages);");
+
+			let codePrinter = new SwaggerCodePrinter();
+			return {
+				interfaceFile: codePrinter.composeBlock(interfacesFile),
+				implementationFile: codePrinter.composeBlock(implementationsFile)
+			};
+
+		}).future<IServiceContractClientCode>()();
+	}
+
+	private generateFileRecursive(jsonContents: any, propertyValue: string, block: CodeGeneration.IBlock, depth: number, options: {shouldGenerateInterface: boolean}): void {
+		_.each(jsonContents, (val: any, key: string) => {
+			let newPropertyValue = propertyValue + key,
+				separator = options.shouldGenerateInterface || depth ? ":" : "=",
+				endingSymbol = options.shouldGenerateInterface || !depth ? ";" : ",";
+
+			if (typeof val === "string") {
+				let actualValue = options.shouldGenerateInterface ? "string" : `"${newPropertyValue}"`;
+
+				block.writeLine(`${key}${separator} ${actualValue}${endingSymbol}`);
+				newPropertyValue = propertyValue;
+				return;
+			}
+
+			let newBlock = new Block(`${key} ${separator} `);
+			newBlock.endingCharacter = endingSymbol;
+			this.generateFileRecursive(val, newPropertyValue + ".", newBlock, depth + 1, options);
+			block.addBlock(newBlock);
+		});
+	}
+}
+$injector.register("messageContractGenerator", MessageContractGenerator);

--- a/services/message-contract-generator.ts
+++ b/services/message-contract-generator.ts
@@ -13,11 +13,11 @@ export class MessageContractGenerator implements IServiceContractGenerator {
 		this.pendingModels = {};
 	}
 
-	public generate(): IFuture<IServiceContractClientCode> {
+	public generate(definitionsPath?: string): IFuture<IServiceContractClientCode> {
 		return ((): IServiceContractClientCode => {
 			let interfacesFile= new Block();
 			let implementationsFile = new Block();
-			let definitionsPath = `"${this.$staticConfig.CLIENT_NAME ? "" : "../"}.d.ts"`;
+			definitionsPath = definitionsPath || `"${this.$staticConfig.CLIENT_NAME ? "" : "../"}.d.ts"`;
 
 			implementationsFile.writeLine(`///<reference path=${definitionsPath}/>`);
 			implementationsFile.writeLine('"use strict";');
@@ -26,10 +26,10 @@ export class MessageContractGenerator implements IServiceContractGenerator {
 			implementationsFile.writeLine("//");
 			implementationsFile.writeLine("");
 
+			interfacesFile.writeLine(`///<reference path=${definitionsPath}/>`);
 			interfacesFile.writeLine("//");
 			interfacesFile.writeLine("// automatically generated code; do not edit manually!");
 			interfacesFile.writeLine("//");
-			interfacesFile.writeLine(`///<reference path=${definitionsPath}/>`);
 
 			let messagesClass = new Block("export class Messages implements IMessages");
 			let messagesInterface = new Block("interface IMessages");

--- a/services/messages-service.ts
+++ b/services/messages-service.ts
@@ -1,0 +1,88 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import * as util from "util";
+import * as path from "path";
+
+export class MessagesService implements IMessagesService {
+	private _pathsToMessageJsonFiles: string[] = null;
+	private _messageJsonFilesContentsCache: any[] = null;
+
+	private get pathToDefaultMessageJson(): string {
+		return path.join(path.dirname(__dirname), "resources", "messages", "errorMessages.json");
+	}
+
+	private get messageJsonFilesContents(): any[] {
+		if (!this._messageJsonFilesContentsCache || !this._messageJsonFilesContentsCache.length) {
+			this.refreshMessageJsonContentsCache();
+		}
+
+		return this._messageJsonFilesContentsCache;
+	}
+
+	constructor(private $fs: IFileSystem) {
+		this._pathsToMessageJsonFiles = [this.pathToDefaultMessageJson];
+	}
+
+	public get pathsToMessageJsonFiles(): string[] {
+		if (!this._pathsToMessageJsonFiles) {
+			throw new Error("No paths to message json files provided.");
+		}
+
+		return this._pathsToMessageJsonFiles;
+	}
+
+	public set pathsToMessageJsonFiles(pathsToMessageJsonFiles: string[]) {
+		this._pathsToMessageJsonFiles = pathsToMessageJsonFiles.concat(this.pathToDefaultMessageJson);
+		this.refreshMessageJsonContentsCache();
+	}
+
+	public getMessage(id: string, ...args: string[]): string {
+		let keys = id.split("."),
+			result = this.getFormatedMessage(id, ...args);
+
+		_.each(this.messageJsonFilesContents, jsonFileContents => {
+			let messageValue = this.getMessageFromJsonRecursive(keys, jsonFileContents, 0);
+			if (messageValue) {
+				result = this.getFormatedMessage(messageValue, ...args);
+				return false;
+			}
+		});
+
+		return result;
+	}
+
+	private getMessageFromJsonRecursive(keys: string[], jsonContents: any, index: number): string {
+		if (index >= keys.length) {
+			return null;
+		}
+
+		let jsonValue = jsonContents[keys[index]];
+		if (!jsonValue) {
+			return null;
+		}
+
+		if (typeof jsonValue === "string") {
+			return jsonValue;
+		}
+
+		return this.getMessageFromJsonRecursive(keys, jsonValue, index + 1);
+	}
+
+	private refreshMessageJsonContentsCache(): void {
+		this._messageJsonFilesContentsCache = [];
+		_.each(this.pathsToMessageJsonFiles, path => {
+			if (!this.$fs.exists(path).wait()) {
+				throw new Error("Message json file " + path + " does not exist.");
+			}
+
+			this._messageJsonFilesContentsCache.push(this.$fs.readJson(path).wait());
+		});
+	}
+
+	private getFormatedMessage(message: string, ...args: string[]): string {
+		return ~message.indexOf("%") ? util.format.apply(null, [message, ...args]) : message;
+	}
+}
+
+$injector.register("messagesService", MessagesService);

--- a/services/messages-service.ts
+++ b/services/messages-service.ts
@@ -9,7 +9,7 @@ export class MessagesService implements IMessagesService {
 	private _messageJsonFilesContentsCache: any[] = null;
 
 	private get pathToDefaultMessageJson(): string {
-		return path.join(path.dirname(__dirname), "resources", "messages", "errorMessages.json");
+		return path.join(__dirname, "..", "resources", "messages", "errorMessages.json");
 	}
 
 	private get messageJsonFilesContents(): any[] {
@@ -81,7 +81,7 @@ export class MessagesService implements IMessagesService {
 	}
 
 	private getFormatedMessage(message: string, ...args: string[]): string {
-		return ~message.indexOf("%") ? util.format.apply(null, [message, ...args]) : message;
+		return ~message.indexOf("%") ? util.format(message, ...args) : message;
 	}
 }
 

--- a/test/unit-tests/messages-service.ts
+++ b/test/unit-tests/messages-service.ts
@@ -1,0 +1,121 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import {Yok} from "../../yok";
+import {format} from "util";
+import {join} from "path";
+import {MessagesService} from "../../services/messages-service";
+import {existsSync} from "fs";
+import {assert} from "chai";
+import Future = require("fibers/future");
+
+function createTestInjector(jsonContents: any, options?: {useRealFsExists: boolean}): IInjector {
+	let testInjector = new Yok();
+	testInjector.register("fs", {
+		exists: (path: string): IFuture<boolean> => Future.fromResult(options && options.useRealFsExists ? existsSync(path) : true),
+		readJson: (filename: string, encoding?: string): IFuture<any> => Future.fromResult(jsonContents)
+	});
+	testInjector.register("messagesService", MessagesService);
+
+	return testInjector;
+}
+describe("messages-service", () => {
+	let service: IMessagesService;
+
+	describe("pathsToMessageJsonFiles property", () => {
+		it("initializes with the default json file", () => {
+			let injector = createTestInjector({});
+			service = injector.resolve("$messagesService");
+
+			assert.deepEqual(1, service.pathsToMessageJsonFiles.length, "Messages service should initialize with a default json file.");
+		});
+
+		it("appends the default json file when setting pathsToMessageJsonFiles", () => {
+			let injector = createTestInjector({}, {useRealFsExists: false});
+			service = injector.resolve("$messagesService");
+			service.pathsToMessageJsonFiles = ["someHackyJsonFile.json"];
+
+			assert.deepEqual(2, service.pathsToMessageJsonFiles.length, "Messages service should append the default json file.");
+		});
+
+		it("should throw if non-existent json file is provided", () => {
+			let injector = createTestInjector({}, {useRealFsExists: true});
+			service = injector.resolve("$messagesService");
+			assert.throws(() => { service.pathsToMessageJsonFiles = ["someJsonFile.json"]; }, "someJsonFile.json does not exist");
+		});
+	});
+
+	describe("getMessage", () => {
+		it("returns the given message if not found as key in any json file", () => {
+			let injector = createTestInjector({});
+			service = injector.resolve("$messagesService");
+			let stringMessage = "Some message",
+				resultMessage = service.getMessage(stringMessage);
+			assert.deepEqual(stringMessage, resultMessage, "Messages service should return the given message if not found as key in any json file in `pathsToMessageJsonFiles` property.");
+		});
+
+		it("util.formats the given message if not found as key in any json file and contains special symbol (%s,%d, etc.)", () => {
+			let injector = createTestInjector({});
+			service = injector.resolve("$messagesService");
+			let messageFormat = "Some %s message.",
+				formatArg = "formatted",
+				expectedMessage = format(messageFormat, formatArg),
+				resultMessage = service.getMessage(messageFormat, formatArg);
+
+			assert.deepEqual(expectedMessage, resultMessage, "Messages service should apply util.format.");
+		});
+
+		it("should return correct value from json file if found in json message files", () => {
+			let jsonContents = {KEY: "Value"},
+				injector = createTestInjector(jsonContents);
+			service = injector.resolve("$messagesService");
+
+			assert.deepEqual(jsonContents.KEY, service.getMessage("KEY"), "Messages service should return correct value from json file by given key.");
+		});
+
+		it("should util.format value from json file if found in json message files and contains special symbol (%s,%d, etc.)", () => {
+			let jsonContents = {KEY: "%s value"},
+				injector = createTestInjector(jsonContents);
+			service = injector.resolve("$messagesService");
+
+			let formatArg = "Formatted",
+				expectedMessage = format(jsonContents.KEY, formatArg),
+				actualMessage = service.getMessage(jsonContents.KEY, formatArg);
+
+			assert.deepEqual(expectedMessage, actualMessage, "Messages service should util.format value from json file by given key when value is format.");
+		});
+
+		it("should return correct value from json file if found in json message files with complex key", () => {
+			let jsonContents = {
+					KEY: {
+						NESTED_KEY: "Value"
+					}
+				},
+				injector = createTestInjector(jsonContents);
+			service = injector.resolve("$messagesService");
+
+			assert.deepEqual(jsonContents.KEY.NESTED_KEY, service.getMessage("KEY.NESTED_KEY"), "Messages service should return correct value from json file by given complex key.");
+		});
+
+		it("should return correct value from json file if found in client json before common json", () => {
+			let commonJsonContents = {
+					KEY: "Value"
+				},
+				clientJsonContents = {
+					KEY: "Overriden value"
+				},
+				pathToDefaultMessageJson = join(__dirname, "..", "..", "resources", "messages", "errorMessages.json"),
+				injector = createTestInjector({});
+
+			injector.register("fs", {
+				exists: (path: string): IFuture<boolean> => Future.fromResult(true),
+				readJson: (filename: string, encoding?: string): IFuture<any> => Future.fromResult(filename === pathToDefaultMessageJson ? commonJsonContents : clientJsonContents)
+			});
+			service = injector.resolve("$messagesService");
+			service.pathsToMessageJsonFiles = ["clientJsonFile.json"];
+
+			assert.notDeepEqual(commonJsonContents.KEY, service.getMessage("KEY"), "Messages service should return correct value from json file when value is overriden by client.");
+			assert.deepEqual(clientJsonContents.KEY, service.getMessage("KEY"), "Messages service should return correct value from json file when value is overriden by client.");
+		});
+	});
+});


### PR DESCRIPTION
References [#300626](http://teampulse.telerik.com/view#item/300626)

Introduces a new messaging service which reads messages from given **.json** files. There is one such file placed in this library and is loaded by default. Its **keys can be overriden** by providing other, client-specific .json files containing the same keys but with a different value.

In order to achieve autocompletion on referencing these error messages a new generation command is introduced - **dev-generate-messages**. It produces a .d.ts interface, as well as a .ts implementation file, which contain all keys from all provided json files as properties. If run as-is it generates files for the client from which the command is launched. If `--default` option is provided generates messages in common lib only.

In order to apply this change I've **moved some of the code-generation logic** related to AppBuilder-CLI's swagger here. The **only change other than physically moving these files** is the introduction of a non-mandatory field - `endingCharacter?: string;` - needed in order to generate Typescript properties more aesthetically

Sample usage of this whole effort can be seen in `devices-services.ts` file in this PR.