### PR TITLE
Improve prompter behavior in interactive console

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -202,7 +202,7 @@ interface IAnalyticsService {
 }
 
 interface IPrompter extends IDisposable {
-	get(schema: IPromptSchema[]): IFuture<any>;
+	get(schemas: IPromptSchema[]): IFuture<any>;
 	getPassword(prompt: string, options?: {allowEmpty?: boolean}): IFuture<string>;
 	getString(prompt: string, defaultAction?: () => string): IFuture<string>;
 	promptForChoice(promptMessage: string, choices: any[]): IFuture<string>;

--- a/prompter.ts
+++ b/prompter.ts
@@ -39,12 +39,23 @@ export class Prompter implements IPrompter {
 		}
 	}
 
-	public get(schema: IPromptSchema[]): IFuture<any> {
+	public get(schemas: IPromptSchema[]): IFuture<any> {
 		let future = new Future;
-		if (!helpers.isInteractive() && _.any(schema, s => !s.default)) {
-			future.throw(new Error('Console is not interactive'));
+		if (!helpers.isInteractive()) {
+			if (_.any(schemas, s => !s.default)) {
+				future.throw(new Error("Console is not interactive and no default action specified."));
+			} else {
+				let result: any = {};
+
+				_.each(schemas, s => {
+					// Curly brackets needed because s.default() may return false and break the loop
+					result[s.name] = s.default();
+				});
+
+				future.return(result);
+			}
 		} else {
-			prompt.prompt(schema, (result: any) => {
+			prompt.prompt(schemas, (result: any) => {
 				if(result) {
 					future.return(result);
 				} else {


### PR DESCRIPTION
If all schemas have default actions just execute them instead of throwing.
If any schema does not however have a default action throw.