### PR TITLE
Add renameIfExists method to fs

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -53,6 +53,14 @@ interface IFileSystem {
 	isRelativePath(path: string): boolean /* feels so lonely here, I don't have a Future */;
 	ensureDirectoryExists(directoryPath: string): IFuture<void>;
 	rename(oldPath: string, newPath: string): IFuture<void>;
+	/**
+	 * Renames specified file to the specified name only in case it exists.
+	 * Used to skip ENOENT errors when rename is called directly.
+	 * @param {string} oldPath Path to original file that has to be renamed. If this file does not exists, no operation is executed.
+	 * @param {string} newPath The path where the file will be moved.
+	 * @return {boolean} True in case of successful rename. False in case the file does not exist.
+	 */
+	renameIfExists(oldPath: string, newPath: string): IFuture<boolean>
 	getFsStats(path: string): IFuture<IFsStats>;
 	symlink(sourcePath: string, destinationPath: string, type: "file"): IFuture<void>;
 	symlink(sourcePath: string, destinationPath: string, type: "dir"): IFuture<void>;

--- a/file-system.ts
+++ b/file-system.ts
@@ -395,6 +395,20 @@ export class FileSystem implements IFileSystem {
 		return future;
 	}
 
+	public renameIfExists(oldPath: string, newPath: string): IFuture<boolean> {
+		return ((): boolean => {
+			try {
+				this.rename(oldPath, newPath).wait();
+				return true;
+			} catch(e) {
+				if (e.code === "ENOENT") {
+					return false;
+				}
+				throw e;
+			}
+		}).future<boolean>()();
+	}
+
 	public symlink(sourcePath: string, destinationPath: string, type?: string): IFuture<void> {
 		let future = new Future<void>();
 		fs.symlink(sourcePath, destinationPath, type, (err: Error) => {


### PR DESCRIPTION
Add renameIfExists method to fs. Used to skip ENOENT errors when rename is called directly. Renames specified file to the specified name only in case it exists.
Returns True in case of successful rename. False in case the file does not exist.