### PR TITLE
Fix livesync file watch exclusion check.

### DIFF
--- a/services/usb-livesync-service-base.ts
+++ b/services/usb-livesync-service-base.ts
@@ -106,7 +106,7 @@ export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 				gaze("**/*", { cwd: watchGlob }, function(err: any, watcher: any) {
 					this.on('all', (event: string, filePath: string) => {
 						if(event === "added" || event === "changed") {
-							if(!_.contains(excludedProjectDirsAndFiles, filePath)) {
+							if(!that.isFileExcluded(filePath, excludedProjectDirsAndFiles, projectFilesPath)) {
 								if(synciOSSimulator) {
 									that.batchSimulatorLiveSync(
 										appIdentifier,


### PR DESCRIPTION
The check for modified files being excluded from livesync wasn't working.
Fixed by using the same code from the initial sync.