### PR TITLE
Fix leaking of adb processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.0.4
+Latest version: 0.0.5
 
-Release date: 2015, October 30
+Release date: 2015, November 3
 
 ### System Requirements
 

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -60,7 +60,7 @@ declare module Mobile {
 	}
 
 	interface ILogcatHelper {
-		start(deviceIdentifier: string): any;
+		start(deviceIdentifier: string): void;
 	}
 
 	interface IDeviceLogProvider {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
When we print device logs, we execute `adb -s <device identifier> logcat`.
In case the device is not unlocked, we receive `undefined` for deviceIdentifier and the command leaks adb processes.
It looks like executing `adb -s <invalid id> logcat` is not closed even after our process exits.
Fix this by checking the passed value. Also change the return type of `LogcatHelper`'s `start` method to void
as noone is using the returned child_process.