### PR TITLE
Fix printing of adb logcat

### DIFF
--- a/mobile/android/logcat-helper.ts
+++ b/mobile/android/logcat-helper.ts
@@ -1,7 +1,6 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
 import byline = require("byline");
-import * as util from "util";
 
 export class LogcatHelper implements Mobile.ILogcatHelper {
 	constructor(private $childProcess: IChildProcess,
@@ -13,7 +12,8 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 	public start(deviceIdentifier: string): void {
 		if(deviceIdentifier) {
 			let adbPath = this.$staticConfig.getAdbFilePath().wait();
-			this.$childProcess.exec(util.format("%s -s %s logcat -c", adbPath, deviceIdentifier)).wait(); // remove cached logs
+			// remove cached logs:
+			this.$childProcess.spawnFromEvent(adbPath, ["-s", deviceIdentifier,  "logcat",  "-c"], "close",  {}, {throwError: false}).wait();
 			let adbLogcat = this.$childProcess.spawn(adbPath, ["-s", deviceIdentifier, "logcat"]);
 			let lineStream = byline(adbLogcat.stdout);
 

--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -18,7 +18,7 @@ export class StaticConfigBase implements Config.IStaticConfig {
 	public HTML_CLI_HELPERS_DIR: string;
 	public version: string = null;
 
-	private _adbFilePath: string = null;
+	protected _adbFilePath: string = null;
 
 	constructor(protected $injector: IInjector) { }
 


### PR DESCRIPTION
Also add quotes around path to adb, so even when the path contains spaces, the command will be executed without troubles.

Fix checking for javac version to use JAVA_HOME in case it is defined.