### PR TITLE
Do NOT execute ios device commands if iTunes error present

### DIFF
--- a/commands/device/list-devices.ts
+++ b/commands/device/list-devices.ts
@@ -35,7 +35,7 @@ export class ListDevicesCommand implements ICommand {
 
 			this.$devicesService.execute(action, undefined, {allowNoDevices: true}).wait();
 
-			if (!this.$options.json) {
+			if (!this.$options.json && table.length) {
 				this.$logger.out(table.toString());
 			}
 		}).future<void>()();


### PR DESCRIPTION
Instead of directly trying to execute ios device-related commands, first check for an error in iTunes.
If an error is present cache it and do not execute anything anymore.
If no error is present try and execute command but do NOT cache. Next command execution attempt will trigger a new check to make sure everything's still all right

Includes minor fix for not showing CLI table when no appropriate devices attached
Ping @Fatme @rosen-vladimirov 