### PR TITLE
Introduce warnWithLabel method in logger

### DIFF
--- a/definitions/logger.d.ts
+++ b/definitions/logger.d.ts
@@ -4,6 +4,7 @@ interface ILogger {
 	fatal(formatStr?: any, ...args: string[]): void;
 	error(formatStr?: any, ...args: string[]): void;
 	warn(formatStr?: any, ...args: string[]): void;
+	warnWithLabel(formatStr?: any, ...args: string[]): void;
 	info(formatStr?: any, ...args: string[]): void;
 	debug(formatStr?: any, ...args: string[]): void;
 	trace(formatStr?: any, ...args: string[]): void;

--- a/logger.ts
+++ b/logger.ts
@@ -15,6 +15,7 @@ export class Logger implements ILogger {
 	private encodeBody: boolean = false;
 	private passwordRegex = /[Pp]assword=(.*?)(['&,]|$)|\"[Pp]assword\":\"(.*?)\"/;
 	private requestBodyRegex = /^\"(.*?)\"$/;
+	private static LABEL = "[WARNING]:";
 
 	constructor($config: Config.IConfig,
 		private $options: ICommonOptions) {
@@ -64,6 +65,11 @@ export class Logger implements ILogger {
 		let colorizedMessage = message.yellow;
 
 		this.log4jsLogger.warn.apply(this.log4jsLogger, [colorizedMessage]);
+	}
+
+	warnWithLabel(...args: string[]): void {
+		let message = util.format(...args);
+		this.warn(`${Logger.LABEL} ${message}`);
 	}
 
 	info(...args: string[]): void {

--- a/test/unit-tests/stubs.ts
+++ b/test/unit-tests/stubs.ts
@@ -10,6 +10,7 @@ export class CommonLoggerStub implements ILogger {
 	fatal(...args: string[]): void {}
 	error(...args: string[]): void {}
 	warn(...args: string[]): void {}
+	warnWithLabel(...args: string[]): void {}
 	info(...args: string[]): void {}
 	debug(...args: string[]): void {}
 	trace(...args: string[]): void {}


### PR DESCRIPTION
Would be used for issuing warnings with a [WARNING] label. This way relevant warnings can easily be recognized when parsing a CLI client's output

Ping @rosen-vladimirov @Fatme @teobugslayer 