### PR TITLE
Improve getting device info for Android

### DIFF
--- a/commands/device/list-devices.ts
+++ b/commands/device/list-devices.ts
@@ -28,7 +28,7 @@ export class ListDevicesCommand implements ICommand {
 			} else {
 				action = (device) => {
 					return (() => {
-						table.push([(index++).toString(), device.deviceInfo.displayName, device.deviceInfo.platform, device.deviceInfo.identifier]);
+						table.push([(index++).toString(), device.deviceInfo.displayName || '', device.deviceInfo.platform || '', device.deviceInfo.identifier || '']);
 					}).future<void>()();
 				};
 			}


### PR DESCRIPTION
In order to get information about Android devices, CLI's calling `adb shell cat /system/build.prop` and parsing the result.
For new emulators and devices, the file does not contain all information that we need.
We can get it by using `adb shell getprop`. As I'm not sure if this command will work on all devices, I've try-catched the code and call the old code for backwards compatibility.
Fix the regex that parses the result to work with both commands.

Also fix bug in list devices command that pushes undefined to cli-table and causes exception there. Pass empty strings instead.