### PR TITLE
List dev commands when searching help pages

### DIFF
--- a/services/html-help-service.ts
+++ b/services/html-help-service.ts
@@ -103,7 +103,7 @@ export class HtmlHelpService implements IHtmlHelpService {
 			commandName = defaultCommandMatch[1];
 		}
 
-		let availableCommands = this.$injector.getRegisteredCommandsNames(false).sort();
+		let availableCommands = this.$injector.getRegisteredCommandsNames(true).sort();
 		this.$logger.trace("List of registered commands: %s", availableCommands.join(", "));
 		if(commandName && _.startsWith(commandName, this.$commandsServiceProvider.dynamicCommandsPrefix) && !_.contains(availableCommands, commandName)) {
 			let dynamicCommands = this.$commandsServiceProvider.getDynamicCommands().wait();


### PR DESCRIPTION
When we search for correct help page, we have to list dev commands as well as we want to show the help of dev-test command in NS CLI.