### PR TITLE
Prevent Future resolved more than once errors

### DIFF
--- a/mobile/ios/ios-core.ts
+++ b/mobile/ios/ios-core.ts
@@ -1213,7 +1213,7 @@ export class GDBServer implements Mobile.IGDBServer {
 					clearInterval(timer);
 				}
 
-				if (!retryCount) {
+				if (!retryCount && !future.isResolved()) {
 					future.throw(new Error("Unable to kill the application."));
 				}
 			}, 1000);
@@ -1225,7 +1225,9 @@ export class GDBServer implements Mobile.IGDBServer {
 				isDataReceived = true;
 				this.socket.removeListener("data", dataCallback);
 				clearInterval(timer);
-				future.return(data.toString());
+				if(!future.isResolved()) {
+					future.return(data.toString());
+				}
 			}
 		};
 


### PR DESCRIPTION
Different node versions have different behaviors of timers. In some cases, on some machines we throw error that future is resolved more than once.
Prevent it.