### PR TITLE
Fix cocoapods check and add unit tests for doctor service

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -100,3 +100,4 @@ $injector.requireCommand("doctor", "./commands/doctor");
 
 $injector.require("utils", "./utils");
 $injector.require("bplistParser", "./bplist-parser");
+$injector.require("winreg", "./winreg");

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -366,10 +366,11 @@ interface ISysInfoData {
 interface ISysInfo {
 	/**
 	 * Returns information for the current system.
+	 * @param {string} pathToPackageJson Path to package.json of the CLI.
 	 * @param {any} androidToolsInfo Defines paths to adb and android executables.
 	 * @return {IFuture<ISysInfoData>} Object containing information for current system.
 	 */
-	getSysInfo(androidToolsInfo?: {pathToAdb: string, pathToAndroid: string}): IFuture<ISysInfoData>;
+	getSysInfo(pathToPackageJson: string, androidToolsInfo?: {pathToAdb: string, pathToAndroid: string}): IFuture<ISysInfoData>;
 }
 
 interface IHostInfo {
@@ -558,4 +559,105 @@ interface IResourceLoader {
 interface IPluginVariablesHelper {
 	getPluginVariableFromVarOption(variableName: string, configuration?: string): any;
 	simplifyYargsObject(obj: any, configuration?: string): any;
+}
+
+/**
+ * Describes Registry values returned from winreg
+ */
+interface IWinRegResult {
+	/**
+	 * The hostname, if it has been set in the options.
+	 */
+	host: string;
+
+	/**
+	 * The hive id, as specified in the options
+	 */
+	hive: string;
+	/**
+	 * The key, as specified in the options
+	 */
+	key: string;
+
+	/**
+	 * The name of the registry value
+	 */
+	name: string;
+
+	/**
+	 * One of the types:
+	 * 	REG_SZ a string value
+	 * 	REG_MULTI_SZ a multiline string value
+	 * 	REG_EXPAND_SZ an expandable string value
+	 * 	REG_DWORD a double word value (32 bit integer)
+	 * 	REG_QWORD a quad word value (64 bit integer)
+	 * 	REG_BINARY a binary value
+	 * 	REG_NONE a value of unknown type
+	 */
+	type: string;
+
+	/**
+	 * A string containing the value
+	 */
+	value: string;
+}
+
+/**
+ * Describes single registry available for search.
+ */
+interface IHiveId {
+	/**
+	 * Name of the registry that will be checked.
+	 */
+	registry: string;
+}
+
+/**
+ * Describes available for search registry ids.
+ */
+interface IHiveIds {
+	/**
+	 * HKEY_LOCAL_MACHINE
+	 */
+	HKLM: IHiveId;
+
+	/**
+	 * HKEY_CURRENT_USER
+	 */
+	HKCU: IHiveId;
+
+	/**
+	 * HKEY_CLASSES_ROOT
+	 */
+	HKCR: IHiveId;
+
+	/**
+	 * HKEY_CURRENT_CONFIG
+	 */
+	HKCC: IHiveId;
+
+	/**
+	 * HKEY_USERS
+	 */
+	HKU: IHiveId;
+}
+
+/**
+ * Defines reading values from registry. Wrapper for node-winreg module.s
+ */
+interface IWinReg {
+	/**
+	 * Gets specified value from the registry.
+	 * The following options are processed by the Winreg constructor:
+	 * @param {string} valueName Value that has to be checked in the registry.
+	 * @param {IHiveId} hive The optional hive id, the default is HKLM.
+	 * @param {string} key The optional key, the default is the root key
+	 * @param {string} host The optional hostname, must start with the '\\' sequence
+	 */
+	getRegistryValue(valueName: string, hive?: IHiveId, key?: string, host?: string): IFuture<IWinRegResult>;
+
+	/**
+	 * Gets object containing available registries for search.
+	 */
+	registryKeys: IHiveIds;
 }

--- a/dispatchers.ts
+++ b/dispatchers.ts
@@ -2,6 +2,7 @@
 "use strict";
 
 import * as queue from "./queue";
+import * as path from "path";
 
 export class CommandDispatcher implements ICommandDispatcher {
 	constructor(private $logger: ILogger,
@@ -19,7 +20,8 @@ export class CommandDispatcher implements ICommandDispatcher {
 			}
 
 			if (this.$logger.getLevel() === "TRACE") {
-				let sysInfo = this.$sysInfo.getSysInfo().wait();
+				// CommandDispatcher is called from external CLI's only, so pass the path to their package.json
+				let sysInfo = this.$sysInfo.getSysInfo(path.join(__dirname, "..", "..", "package.json")).wait();
 				this.$logger.trace("System information:");
 				this.$logger.trace(sysInfo);
 			}

--- a/test/unit-tests/sys-info-base.ts
+++ b/test/unit-tests/sys-info-base.ts
@@ -1,0 +1,264 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import {Yok} from "../../yok";
+import * as assert from "assert";
+import Future = require("fibers/future");
+import {SysInfoBase} from "../../sys-info-base";
+import * as temp from "temp";
+import {writeFileSync} from "fs";
+import * as path from "path";
+temp.track();
+
+let toolsPackageJsonDir = temp.mkdirSync("dirWithPackageJson");
+let toolsPackageJson = path.join(toolsPackageJsonDir, "package.json");
+writeFileSync(toolsPackageJson, '{ "name": "unit-testing-doctor-service", "version": "1.0.0" }');
+
+interface IChildProcessResultDescription {
+	result?: any;
+	shouldThrowError?: boolean;
+}
+
+interface IChildProcessResults {
+	uname: IChildProcessResultDescription;
+	npmV: IChildProcessResultDescription;
+	javaVersion: IChildProcessResultDescription;
+	javacVersion: IChildProcessResultDescription;
+	nodeGypVersion: IChildProcessResultDescription;
+	xCodeVersion: IChildProcessResultDescription;
+	adbVersion: IChildProcessResultDescription;
+	androidInstalled: IChildProcessResultDescription;
+	monoVersion: IChildProcessResultDescription;
+	gradleVersion: IChildProcessResultDescription;
+	gitVersion: IChildProcessResultDescription;
+	podVersion: IChildProcessResultDescription;
+}
+
+function getResultFromChildProcess(childProcessResultDescription: IChildProcessResultDescription): any {
+	if(childProcessResultDescription.shouldThrowError) {
+		throw new Error("This one throws error.");
+	}
+
+	return childProcessResultDescription.result;
+}
+
+function createChildProcessResults(childProcessResult: IChildProcessResults): IDictionary<IChildProcessResultDescription> {
+	return {
+		"uname -a": childProcessResult.uname,
+		"npm -v": childProcessResult.npmV,
+		"java": childProcessResult.javaVersion,
+		'"javac" -version': childProcessResult.javacVersion,
+		"node-gyp -v": childProcessResult.nodeGypVersion,
+		"xcodebuild -version": childProcessResult.xCodeVersion,
+		"pod --version": childProcessResult.podVersion,
+		'"adb" version': childProcessResult.adbVersion,
+		"'adb' version": childProcessResult.adbVersion, // for Mac and Linux
+		'android': childProcessResult.androidInstalled,
+		"mono --version": childProcessResult.monoVersion,
+		"git --version": childProcessResult.gitVersion,
+		"gradle -v": childProcessResult.gradleVersion
+	};
+}
+
+function createTestInjector(childProcessResult: IChildProcessResults, hostInfoData: {isWindows: boolean, dotNetVersion: string, isDarwin: boolean}, itunesError: string): IInjector {
+	let injector = new Yok();
+	let childProcessResultDictionary = createChildProcessResults(childProcessResult);
+	injector.register("childProcess", {
+		exec: (command: string, options?: any, execOptions?: IExecOptions) => {
+			return (() => {
+				return getResultFromChildProcess(childProcessResultDictionary[command]);
+			}).future<any>()();
+		},
+
+		spawnFromEvent: (command: string, args: string[], event: string) => {
+			return (() => {
+				return getResultFromChildProcess(childProcessResultDictionary[command]);
+			}).future<any>()();
+		}
+	});
+
+	injector.register("hostInfo", {
+		dotNetVersion: () => Future.fromResult(hostInfoData.dotNetVersion),
+		isWindows: hostInfoData.isWindows,
+		isDarwin: hostInfoData.isDarwin
+	});
+
+	injector.register("iTunesValidator", {
+		getError: () => Future.fromResult(itunesError)
+	});
+
+	injector.register("logger", {
+		trace: (formatStr?: any, ...args: string[]) => { /* intentionally left blank */}
+	});
+
+	injector.register("winreg", {
+		getRegistryValue: (valueName: string, hive?: IHiveId, key?: string, host?: string) => { return {value: "registryKey"}; },
+		registryKeys: {
+			HKLM: "HKLM"
+		}
+	});
+
+	injector.register("sysInfoBase", SysInfoBase);
+
+	return injector;
+}
+
+describe("sysInfoBase", () => {
+	// TODO: Add tests when JAVA_HOME is set and when it is not
+	let originalJavaHome = process.env.JAVA_HOME;
+	process.env.JAVA_HOME = '';
+
+	after(() => process.env.JAVA_HOME = originalJavaHome);
+
+	let childProcessResult: IChildProcessResults,
+		testInjector: IInjector,
+		sysInfoBase: ISysInfo;
+
+	beforeEach(() => {
+		childProcessResult = {
+			uname: { result: "name" },
+			npmV: { result: "2.14.1" },
+			javaVersion: { result: {stderr: 'java version "1.8.0_60"'} },
+			javacVersion: { result: {stderr: 'javac 1.8.0_60'} },
+			nodeGypVersion: { result: "2.0.0" },
+			xCodeVersion: { result: "6.4.0" },
+			adbVersion: { result: "Android Debug Bridge version 1.0.32" },
+			androidInstalled: { result: { stdout: "android" } },
+			monoVersion: { result: "version 1.0.6 " },
+			gradleVersion: { result: "Gradle 2.8" },
+			gitVersion: { result: "git version 1.9.5" },
+			podVersion: { result: "0.38.2" },
+		};
+
+		testInjector = null;
+		sysInfoBase = null;
+	});
+	describe("getSysInfo", () => {
+		describe("returns correct results when everything is installed", () => {
+			let assertCommonValues = (result: ISysInfoData) => {
+				assert.deepEqual(result.npmVer, childProcessResult.npmV.result);
+				assert.deepEqual(result.javaVer, "1.8.0");
+				assert.deepEqual(result.javacVersion, "1.8.0_60");
+				assert.deepEqual(result.nodeGypVer, childProcessResult.nodeGypVersion.result);
+				assert.deepEqual(result.adbVer, childProcessResult.adbVersion.result);
+				assert.deepEqual(result.androidInstalled, true);
+				assert.deepEqual(result.monoVer, "1.0.6");
+				assert.deepEqual(result.gradleVer, "2.8");
+				assert.deepEqual(result.gitVer, "1.9.5");
+			};
+
+			it("on Windows", () => {
+				testInjector = createTestInjector(childProcessResult, {isWindows: true, isDarwin: false, dotNetVersion: "4.5.1"}, null);
+				sysInfoBase = testInjector.resolve("sysInfoBase");
+				let result = sysInfoBase.getSysInfo(toolsPackageJson).wait();
+				assertCommonValues(result);
+				assert.deepEqual(result.xcodeVer, null);
+				assert.deepEqual(result.cocoapodVer, null);
+			});
+
+			it("on Mac", () => {
+				testInjector = createTestInjector(childProcessResult, {isWindows: false, isDarwin: true, dotNetVersion: "4.5.1"}, null);
+				sysInfoBase = testInjector.resolve("sysInfoBase");
+				let result = sysInfoBase.getSysInfo(toolsPackageJson).wait();
+				assertCommonValues(result);
+				assert.deepEqual(result.xcodeVer, childProcessResult.xCodeVersion.result);
+				assert.deepEqual(result.cocoapodVer, childProcessResult.podVersion.result);
+			});
+
+			it("on Linux", () => {
+				testInjector = createTestInjector(childProcessResult, {isWindows: false, isDarwin: false, dotNetVersion: "4.5.1"}, null);
+				sysInfoBase = testInjector.resolve("sysInfoBase");
+				let result = sysInfoBase.getSysInfo(toolsPackageJson).wait();
+				assertCommonValues(result);
+				assert.deepEqual(result.xcodeVer, null);
+				assert.deepEqual(result.cocoapodVer, null);
+			});
+		});
+
+		describe("cocoapods version", () => {
+			it("is null when cocoapods are not installed", () => {
+				// simulate error when pod --version command is executed
+				childProcessResult.podVersion = { shouldThrowError: true };
+				testInjector = createTestInjector(childProcessResult, {isWindows: false, isDarwin: true, dotNetVersion: "4.5.1"}, null);
+				sysInfoBase = testInjector.resolve("sysInfoBase");
+				let result = sysInfoBase.getSysInfo(toolsPackageJson).wait();
+				assert.deepEqual(result.cocoapodVer, null);
+			});
+
+			it("is null when OS is not Mac", () => {
+				testInjector = createTestInjector(childProcessResult, {isWindows: true, isDarwin: false, dotNetVersion: "4.5.1"}, null);
+				sysInfoBase = testInjector.resolve("sysInfoBase");
+				let result = sysInfoBase.getSysInfo(toolsPackageJson).wait();
+				assert.deepEqual(result.cocoapodVer, null);
+			});
+
+			it("is correct when cocoapods output has warning after version output", () => {
+				childProcessResult.podVersion = { result: "0.38.2\nWARNING:\n" };
+				testInjector = createTestInjector(childProcessResult, {isWindows: false, isDarwin: true, dotNetVersion: "4.5.1"}, null);
+				sysInfoBase = testInjector.resolve("sysInfoBase");
+				let result = sysInfoBase.getSysInfo(toolsPackageJson).wait();
+				assert.deepEqual(result.cocoapodVer, "0.38.2");
+			});
+
+			it("is correct when cocoapods output has warnings before version output", () => {
+				childProcessResult.podVersion = { result: "WARNING\nWARNING2\n0.38.2" };
+				testInjector = createTestInjector(childProcessResult, {isWindows: false, isDarwin: true, dotNetVersion: "4.5.1"}, null);
+				sysInfoBase = testInjector.resolve("sysInfoBase");
+				let result = sysInfoBase.getSysInfo(toolsPackageJson).wait();
+				assert.deepEqual(result.cocoapodVer, "0.38.2");
+			});
+		});
+
+		describe("returns correct results when exceptions are raised during sysInfo data collection", () => {
+			beforeEach(() => {
+				childProcessResult = {
+					uname: { shouldThrowError: true },
+					npmV: { shouldThrowError: true },
+					javaVersion: { shouldThrowError: true },
+					javacVersion: { shouldThrowError: true },
+					nodeGypVersion: { shouldThrowError: true },
+					xCodeVersion: { shouldThrowError: true },
+					adbVersion: { shouldThrowError: true },
+					androidInstalled: { shouldThrowError: true },
+					monoVersion: { shouldThrowError: true },
+					gradleVersion: { shouldThrowError: true },
+					gitVersion: { shouldThrowError: true },
+					podVersion: { shouldThrowError: true },
+				};
+			});
+
+			describe("when all of calls throw", () => {
+				let assertAllValuesAreNull = () => {
+					sysInfoBase = testInjector.resolve("sysInfoBase");
+					let result = sysInfoBase.getSysInfo(toolsPackageJson).wait();
+					assert.deepEqual(result.npmVer, null);
+					assert.deepEqual(result.javaVer, null);
+					assert.deepEqual(result.javacVersion, null);
+					assert.deepEqual(result.nodeGypVer, null);
+					assert.deepEqual(result.xcodeVer, null);
+					assert.deepEqual(result.adbVer, null);
+					assert.deepEqual(result.androidInstalled, false);
+					assert.deepEqual(result.monoVer, null);
+					assert.deepEqual(result.gradleVer, null);
+					assert.deepEqual(result.gitVer, null);
+					assert.deepEqual(result.cocoapodVer, null);
+				};
+
+				it("on Windows", () => {
+					testInjector = createTestInjector(childProcessResult, {isWindows: true, isDarwin: false, dotNetVersion: "4.5.1"}, null);
+					assertAllValuesAreNull();
+				});
+
+				it("on Mac", () => {
+					testInjector = createTestInjector(childProcessResult, {isWindows: false, isDarwin: true, dotNetVersion: "4.5.1"}, null);
+					assertAllValuesAreNull();
+				});
+
+				it("on Linux", () => {
+					testInjector = createTestInjector(childProcessResult, {isWindows: false, isDarwin: false, dotNetVersion: "4.5.1"}, null);
+					assertAllValuesAreNull();
+				});
+			});
+		});
+	});
+});

--- a/winreg.ts
+++ b/winreg.ts
@@ -1,0 +1,39 @@
+///<reference path=".d.ts"/>
+"use strict";
+
+import Future = require("fibers/future");
+let Registry = require("winreg");
+
+export class WinReg implements IWinReg {
+	public registryKeys: IHiveIds = {
+		HKLM: { registry: Registry.HKLM },
+		HKCU: { registry: Registry.HKCU },
+		HKCR: { registry: Registry.HKCR },
+		HKCC: { registry: Registry.HKCC },
+		HKU: { registry: Registry.HKU }
+	};
+
+	public getRegistryValue(valueName: string, hive?: IHiveId, key?: string, host?: string): IFuture<IWinRegResult> {
+		let future = new Future<IWinRegResult>();
+		try {
+			let regKey = new Registry({
+				hive: (hive && hive.registry) ? hive.registry : null,
+				key:  key,
+				host: host
+			});
+
+			regKey.get(valueName, (err: Error, value: IWinRegResult) => {
+				if (err) {
+					future.throw(err);
+				} else {
+					future.return(value);
+				}
+			});
+		} catch(err) {
+			future.throw(err);
+		}
+
+		return future;
+	}
+}
+$injector.register("winreg", WinReg);


### PR DESCRIPTION
When cocoapods are not installed on Mac machine, doctor is failing.
Fix this by skipping match check in case pods are not installed.
Add basic unit tests for doctor service.

Add unit test for the failing cocoapods check.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1245