### PR TITLE
Add canStartApplication to applicationManager

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -75,6 +75,7 @@ declare module Mobile {
 		startApplication(appIdentifier: string): IFuture<void>;
 		stopApplication(appIdentifier: string): IFuture<void>;
 		restartApplication(applicationId: string): IFuture<void>;
+		canStartApplication(): boolean;
 	}
 
 	interface IDeviceFileSystem {

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -57,4 +57,8 @@ export class AndroidApplicationManager implements Mobile.IDeviceApplicationManag
 			this.startApplication(appIdentifier).wait();
 		}).future<void>()();
 	}
+
+	public canStartApplication(): boolean {
+		return true;
+	}
 }

--- a/mobile/ios/ios-application-manager.ts
+++ b/mobile/ios/ios-application-manager.ts
@@ -91,6 +91,10 @@ export class IOSApplicationManager implements Mobile.IDeviceApplicationManager {
 		}).future<void>()();
 	}
 
+	public canStartApplication(): boolean {
+		return this.$hostInfo.isDarwin || (this.$hostInfo.isWindows && this.$staticConfig.enableDeviceRunCommandOnWindows);
+	}
+
 	private lookupApplications(): IDictionary<Mobile.IDeviceApplication> {
 		let func = () => {
 			let dictionaryPointer = ref.alloc(CoreTypes.cfDictionaryRef);


### PR DESCRIPTION
We have different cases when we can start the application, based on current platform and device platform.
Add `canStartApplication` in applicationManager's which evaluates all circumstances and can be used to check if we are able to start the application on device.