### PR TITLE
Still fixing removed files from iOS simulator

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -305,7 +305,8 @@ declare module Mobile {
 		syncFiles(appIdentifier: string, projectFilesPath: string, projectFiles: string[], notRunningSimulatorAction: () => IFuture<void>, getApplicationPathForiOSSimulatorAction: () => IFuture<string>, relativeToProjectBasePathAction?: (projectFile: string) => string): IFuture<void>;
 		isSimulatorRunning(): IFuture<boolean>;
 		transferFiles(appIdentifier: string, projectFiles: string[], relativeToProjectBasePathAction?: (_projectFile: string) => string, applicationPath?: string): IFuture<void>;
-		removeFiles(appIdentifier: string, projectFilesPath: string, projectFiles: string[], notRunningSimulatorAction: () => IFuture<void>, getApplicationPathForiOSSimulatorAction: () => IFuture<string>, relativeToProjectBasePathAction?: (projectFile: string) => string): IFuture<void>;
+		removeFiles(appIdentifier: string, projectFilesPath: string, projectFiles: string[], relativeToProjectBasePathAction?: (_projectFile: string) => string): void;
+		restartApplication(appIdentifier: string, getApplicationPathForiOSSimulatorAction: () => IFuture<string>): IFuture<void>;
 	}
 
 	interface IEmulatorSettingsService {

--- a/services/usb-livesync-service-base.ts
+++ b/services/usb-livesync-service-base.ts
@@ -113,7 +113,7 @@ export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 						if (event === "added" || event === "changed") {
 							if (!that.isFileExcluded(filePath, data.excludedProjectDirsAndFiles, data.projectFilesPath)) {
 								that.$dispatcher.dispatch(() => (() => {
-									let fileHash = that.$fs.getFileShasum(filePath).wait();
+									let fileHash = that.$fs.getFsStats(filePath).wait().isFile() ? that.$fs.getFileShasum(filePath).wait() : "";
 									if (fileHash === that.fileHashes[filePath]) {
 										that.$logger.trace(`Skipping livesync for ${filePath} file with ${fileHash} hash.`);
 										return;

--- a/services/usb-livesync-service-base.ts
+++ b/services/usb-livesync-service-base.ts
@@ -188,7 +188,15 @@ export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 			let synciOSSimulator = this.shouldSynciOSSimulator(data.platform).wait();
 			if (synciOSSimulator) {
 				let fileToSync = data.beforeBatchLiveSyncAction ? data.beforeBatchLiveSyncAction(filePath).wait() : filePath;
-				this.$iOSEmulatorServices.removeFiles(data.appIdentifier, data.projectFilesPath, [fileToSync], data.notRunningiOSSimulatorAction, data.getApplicationPathForiOSSimulatorAction, data.iOSSimulatorRelativeToProjectBasePathAction).wait();
+				this.$iOSEmulatorServices.removeFiles(data.appIdentifier, data.projectFilesPath, [fileToSync], data.iOSSimulatorRelativeToProjectBasePathAction);
+
+				let canExecuteFastLiveSync = data.canExecuteFastLiveSync && data.canExecuteFastLiveSync(filePath);
+				if (canExecuteFastLiveSync) {
+					let platformSpecificUsbLiveSyncService = <any>this.resolvePlatformSpecificLiveSyncService(data.platform || this.$devicesService.platform, null, data.platformSpecificLiveSyncServices);
+					platformSpecificUsbLiveSyncService.sendPageReloadMessageToSimulator().wait();
+				} else {
+					this.$iOSEmulatorServices.restartApplication(data.appIdentifier, data.getApplicationPathForiOSSimulatorAction).wait();
+				}
 			} else {
 				if (!this.isInitialized) {
 					this.$devicesService.initialize({ platform: data.platform, deviceId: this.$options.device }).wait();


### PR DESCRIPTION
Do not restart the application when .xml or .css file is deleted and build correct path to files on ios simulator.