### PR TITLE
Introduce proton logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.0.5
+Latest version: 0.1.3
 
-Release date: 2015, November 3
+Release date: 2015, December 15
 
 ### System Requirements
 

--- a/appbuilder/proton-bootstrap.ts
+++ b/appbuilder/proton-bootstrap.ts
@@ -2,6 +2,7 @@
 "use strict";
 
 require("../bootstrap");
+$injector.require("logger", "./appbuilder/proton-logger");
 
 import {OptionsBase} from "../options";
 $injector.require("staticConfig", "./appbuilder/proton-static-config");

--- a/appbuilder/proton-logger.ts
+++ b/appbuilder/proton-logger.ts
@@ -1,0 +1,86 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import * as stream from "stream";
+import Future = require("fibers/future");
+
+export class ProtonLogger implements ILogger {
+	setLevel(level: string): void {
+		/* left for future implementation */
+	}
+
+	getLevel(): string {
+		/* improve future implementation */
+		return "INFO";
+	}
+
+	fatal(...args: string[]): void {
+		/* left for future implementation */
+	}
+
+	error(...args: string[]): void {
+		/* left for future implementation */
+	}
+
+	warn(...args: string[]): void {
+		/* left for future implementation */
+	}
+
+	warnWithLabel(...args: string[]): void {
+		/* left for future implementation */
+	}
+
+	info(...args: string[]): void {
+		/* left for future implementation */
+	}
+
+	debug(...args: string[]): void {
+		/* left for future implementation */
+	}
+
+	trace(...args: string[]): void {
+		/* left for future implementation */
+	}
+
+	out(...args: string[]): void {
+		/* left for future implementation */
+	}
+
+	write(...args: string[]): void {
+		/* left for future implementation */
+	}
+
+	prepare(item: any): string {
+		if (typeof item === "undefined" || item === null) {
+			return "[no content]";
+		}
+		if (typeof item  === "string") {
+			return item;
+		}
+		// do not try to read streams, because they may not be rewindable
+		if (item instanceof stream.Readable) {
+			return "[ReadableStream]";
+		}
+
+		return JSON.stringify(item);
+	}
+
+	public printInfoMessageOnSameLine(message: string): void {
+		/* left for future implementation */
+	}
+
+	public printMsgWithTimeout(message: string, timeout: number): IFuture <void> {
+		let printMsgFuture = new Future<void>();
+		setTimeout(() => {
+			this.printInfoMessageOnSameLine(message);
+			printMsgFuture.return();
+		}, timeout);
+
+		return printMsgFuture;
+	}
+
+	public printMarkdown(...args: string[]): void {
+		/* left for future implementation */
+	}
+}
+$injector.register("logger", ProtonLogger);

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -8,7 +8,6 @@ if (!global.Promise) {
 require("colors");
 $injector.require("errors", "./errors");
 $injector.requirePublic("fs", "./file-system");
-$injector.require("logger", "./logger");
 $injector.require("sysInfoBase", "./sys-info-base");
 $injector.require("hostInfo", "./host-info");
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
Fix `EPERM: operation not permitted, write` error when started from Proton installation and trying to write to stdout.
The process does not have stdout, so all logger calls will cause such failure.
Introduce new logger, special for Proton, that will not do anything at the moment. We'll extend it in the future to send messages to Proton with the messages.

Set version to 0.1.3