### PR TITLE
Improve device discovery and fix some issues

### DIFF
--- a/appbuilder/proton-bootstrap.ts
+++ b/appbuilder/proton-bootstrap.ts
@@ -2,6 +2,7 @@
 "use strict";
 
 require("../bootstrap");
+$injector.require("messages", "./messages/messages");
 $injector.require("logger", "./appbuilder/proton-logger");
 
 import {OptionsBase} from "../options";
@@ -13,7 +14,6 @@ $injector.register("analyiticsService", {});
 $injector.register("options", $injector.resolve(OptionsBase, {options: {}, defaultProfileDir: ""}));
 $injector.requirePublicClass("deviceEmitter", "./appbuilder/device-emitter");
 $injector.requirePublicClass("deviceLogProvider", "./appbuilder/device-log-provider");
-$injector.require("messages", "./messages/messages");
 import {installUncaughtExceptionListener} from "../errors";
 installUncaughtExceptionListener();
 $injector.register("deviceAppDataProvider", {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -13,6 +13,9 @@ declare module Mobile {
 		version: string;
 		vendor: string;
 		platform: string;
+		status: string;
+		errorHelp: string;
+		color?: string;
 	}
 
 	interface IDevice {

--- a/mobile/constants.ts
+++ b/mobile/constants.ts
@@ -12,3 +12,6 @@ export let ERROR_NO_DEVICES = "Cannot find connected devices. Reconnect any conn
 
 // LiveSync constants
 export let CHECK_LIVESYNC_INTENT_NAME = "com.telerik.IsLiveSyncSupported";
+
+export let UNAUTHORIZED_STATUS = "Unauthorized";
+export let CONNECTED_STATUS = "Connected";

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -86,12 +86,20 @@ export class DevicesService implements Mobile.IDevicesService {
 		return (() => {
 			this.$logger.trace("startLookingForDevices; platform is %s", this._platform);
 			if(!this._platform) {
-				this.$iOSDeviceDiscovery.startLookingForDevices().wait();
-				this.$androidDeviceDiscovery.startLookingForDevices().wait();
+				try {
+					this.$iOSDeviceDiscovery.startLookingForDevices().wait();
+					this.$androidDeviceDiscovery.startLookingForDevices().wait();
+				} catch (err) {
+					this.$logger.trace("Error while detecting devices.", err);
+				}
 				setInterval(() => {
 					fiberBootstrap.run(() => {
-						Future.wait([this.$iOSDeviceDiscovery.checkForDevices(),
-									 this.$androidDeviceDiscovery.checkForDevices()]);
+						try {
+							Future.wait([this.$iOSDeviceDiscovery.checkForDevices(),
+										this.$androidDeviceDiscovery.checkForDevices()]);
+						} catch (err) {
+							this.$logger.trace("Error while checking for new devices.", err);
+						}
 					});
 				}, DevicesService.DEVICE_LOOKING_INTERVAL).unref();
 			} else if(this.$mobileHelper.isiOSPlatform(this._platform)) {

--- a/mobile/mobile-core/ios-device-discovery.ts
+++ b/mobile/mobile-core/ios-device-discovery.ts
@@ -9,6 +9,7 @@ import {IOSDevice} from "../ios/ios-device";
 class IOSDeviceDiscovery extends DeviceDiscovery {
 	private static ADNCI_MSG_CONNECTED = 1;
 	private static ADNCI_MSG_DISCONNECTED = 2;
+	private static ADNCI_MSG_TRUSTED = 4;
 	private static APPLE_SERVICE_NOT_STARTED_ERROR_CODE = 0xE8000063;
 
 	private timerCallbackPtr: NodeBuffer = null;
@@ -82,12 +83,15 @@ class IOSDeviceDiscovery extends DeviceDiscovery {
 	private static deviceNotificationCallback(devicePointer?: NodeBuffer, user?: number) : any {
 		let iOSDeviceDiscovery: IOSDeviceDiscovery = $injector.resolve("iOSDeviceDiscovery");
 		let deviceInfo = ref.deref(devicePointer);
-
 		if(deviceInfo.msg === IOSDeviceDiscovery.ADNCI_MSG_CONNECTED) {
 			iOSDeviceDiscovery.createAndAddDevice(deviceInfo.dev);
 		} else if(deviceInfo.msg === IOSDeviceDiscovery.ADNCI_MSG_DISCONNECTED) {
 			let deviceIdentifier = iOSDeviceDiscovery.$coreFoundation.convertCFStringToCString(iOSDeviceDiscovery.$mobileDevice.deviceCopyDeviceIdentifier(deviceInfo.dev));
 			iOSDeviceDiscovery.removeDevice(deviceIdentifier);
+		} else if(deviceInfo.msg === IOSDeviceDiscovery.ADNCI_MSG_TRUSTED) {
+			let deviceIdentifier = iOSDeviceDiscovery.$coreFoundation.convertCFStringToCString(iOSDeviceDiscovery.$mobileDevice.deviceCopyDeviceIdentifier(deviceInfo.dev));
+			iOSDeviceDiscovery.removeDevice(deviceIdentifier);
+			iOSDeviceDiscovery.createAndAddDevice(deviceInfo.dev);
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.1.3",
+  "version": "0.2.0",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
### Improve device discovery for Proton by fixing:
* Crash when iPhone is not trusted.
* Crash when error is raised during device detection. From now on the error is caught. We'll report it to Proton (this will be handled in separate PR).
* Crash when trying to provide sysLogs for unauthorized devices.
* In case more than one Android device has "USB Debugging" disabled, we were showing only one device. Show all devices from now on.

### Add new properties to IDeviceInfo inteface:
* status - string, describing the status of the device, can be `Connected` or `Unauthorized`. Could be expanded in the future.
* errorHelp - in case status is `Unauthorized` we provide some information to the user how to resolve the issue. In case status is `Connected` this should be null.
* color - Color of the device. Not mandatory part of the Interface. Currently provided only for iOS devices.

### Additional changes, implementation details:
Change the way we work with iOS devices - currently if the device is Unauthorized, we were just failing, without creating instance of the iOSDevice.
From now on we create instance and set the values that we cannot get from the device (like Name) to null.
Added **ADNCI_MSG_TRUSTED=4** to iOSDeviceDiscovery. I'm not sure the value is correct, but I've received it when I select "Trust" option on iOS device.
When we receive 4, we remove the old Untrusted device and add a new one with all correct properties.
Keep current behavior in `AndroidDeviceDiscovery` to report device as newly attached when its status is changed.