### PR TITLE
Fix android and ios device detection

### DIFF
--- a/mobile/android/android-device.ts
+++ b/mobile/android/android-device.ts
@@ -32,19 +32,19 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 		},
 		"offline": {
 			errorHelp: "The device instance is not connected to adb or is not responding.",
-			deviceStatus: constants.UNAUTHORIZED_STATUS
+			deviceStatus: constants.UNREACHABLE_STATUS
 		},
 		"unauthorized": {
 			errorHelp: "Allow USB Debugging on your device.",
-			deviceStatus: constants.UNAUTHORIZED_STATUS
+			deviceStatus: constants.UNREACHABLE_STATUS
 		},
 		"recovery": {
 			errorHelp: "Your device is in recovery mode. This mode is used to recover your phone when it is broken or to install custom roms.",
-			deviceStatus: constants.UNAUTHORIZED_STATUS
+			deviceStatus: constants.UNREACHABLE_STATUS
 		},
 		"no permissions": {
 			errorHelp: "Insufficient permissions to communicate with the device.",
-			deviceStatus: constants.UNAUTHORIZED_STATUS
+			deviceStatus: constants.UNREACHABLE_STATUS
 		},
 	};
 

--- a/mobile/constants.ts
+++ b/mobile/constants.ts
@@ -13,5 +13,5 @@ export let ERROR_NO_DEVICES = "Cannot find connected devices. Reconnect any conn
 // LiveSync constants
 export let CHECK_LIVESYNC_INTENT_NAME = "com.telerik.IsLiveSyncSupported";
 
-export let UNAUTHORIZED_STATUS = "Unauthorized";
+export let UNREACHABLE_STATUS = "Unreachable";
 export let CONNECTED_STATUS = "Connected";

--- a/mobile/ios/ios-device.ts
+++ b/mobile/ios/ios-device.ts
@@ -17,7 +17,6 @@ export class IOSDevice implements Mobile.IiOSDevice {
 	// We receive them as decimal values.
 	private static IMAGE_ALREADY_MOUNTED_ERROR_CODE = 3892314230;
 	private static INCOMPATIBLE_IMAGE_SIGNATURE_ERROR_CODE = 3892314163;
-	private static PASSWORD_PROTECTED_ERROR_CODE = 3892314138;
 	private static INTERFACE_USB = 1;
 
 	private mountImageCallbackPtr: NodeBuffer = null;
@@ -83,9 +82,7 @@ export class IOSDevice implements Mobile.IiOSDevice {
 
 	private validateResult(result: number, error: string) {
 		if (result !== 0) {
-			if(result === IOSDevice.PASSWORD_PROTECTED_ERROR_CODE) {
-				this.deviceInfo.status = constants.UNAUTHORIZED_STATUS;
-			}
+			this.deviceInfo.status = constants.UNREACHABLE_STATUS;
 			this.$errors.fail(util.format("%s. Result code is: %s", error, result));
 		}
 	}
@@ -314,7 +311,7 @@ export class IOSDevice implements Mobile.IiOSDevice {
 	}
 
 	public openDeviceLogStream() {
-		if(this.deviceInfo.status !== constants.UNAUTHORIZED_STATUS) {
+		if(this.deviceInfo.status !== constants.UNREACHABLE_STATUS) {
 			let iOSSystemLog = this.$injector.resolve(iOSProxyServices.IOSSyslog, {device: this});
 			iOSSystemLog.read();
 		}

--- a/mobile/mobile-core/android-device-discovery.ts
+++ b/mobile/mobile-core/android-device-discovery.ts
@@ -37,7 +37,7 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery implements Mobile.IA
 	}
 
 	private deleteAndRemoveDevice(deviceIdentifier: string): void {
-		_.remove(this._devices, d => d === deviceIdentifier);
+		_.remove(this._devices, d => d.identifier === deviceIdentifier);
 		this.removeDevice(deviceIdentifier);
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
Fix android device detection - remove method was not correct and was never removing device.
Fix ios device detection - always set status to Unreachable when there's error.

Change name of Unauthorized status to Unreachable.