### PR TITLE
Add tests for androidDeviceDiscovery

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -148,7 +148,7 @@ declare module Mobile {
 	}
 
 	interface IAndroidDeviceDiscovery extends IDeviceDiscovery {
-		ensureAdbServerStarted(): IFuture<void>;
+		ensureAdbServerStarted(): IFuture<any>;
 	}
 
 	interface IDevicesServicesInitializationOptions {

--- a/mobile/mobile-core/android-device-discovery.ts
+++ b/mobile/mobile-core/android-device-discovery.ts
@@ -103,8 +103,8 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery implements Mobile.IA
 		}).future<void>()();
 	}
 
-	public ensureAdbServerStarted(): IFuture<void> {
-		return this.$childProcess.spawnFromEvent(this.$staticConfig.getAdbFilePath().wait(), ["start-server"], "close");
+	public ensureAdbServerStarted(): IFuture<any> {
+		return this.$childProcess.spawnFromEvent(this.pathToAdb, ["start-server"], "close");
 	}
 }
 $injector.register("androidDeviceDiscovery", AndroidDeviceDiscovery);

--- a/test/unit-tests/decorators.ts
+++ b/test/unit-tests/decorators.ts
@@ -2,18 +2,13 @@
 "use strict";
 
 import * as decoratorsLib from "../../decorators";
-import * as yokLib from "../../yok";
+import { Yok } from "../../yok";
 import {assert} from "chai";
 import Future = require("fibers/future");
 
-let originalInjector:any = {};
-_.extend(originalInjector, $injector);
-
 describe("decorators", () => {
 	afterEach(() => {
-		$injector = originalInjector;
-		// Due to bug in lodash's extend method, manually set publicApi to the initial object.
-		$injector.publicApi = {__modules__: {}};
+		$injector = new Yok();
 	});
 
 	describe("exportedPromise", () => {
@@ -37,7 +32,7 @@ describe("decorators", () => {
 		});
 
 		it("returns Promise", () => {
-			$injector = new yokLib.Yok();
+			$injector = new Yok();
 			let expectedResult = "result";
 			$injector.register("moduleName", {propertyName: () => {return expectedResult;}});
 			assert.deepEqual($injector.publicApi.__modules__["moduleName"], undefined);
@@ -52,7 +47,7 @@ describe("decorators", () => {
 		});
 
 		it("returns Promise, which is resolved to correct value (function without arguments)", () => {
-			$injector = new yokLib.Yok();
+			$injector = new Yok();
 			let expectedResult = "result";
 			$injector.register("moduleName", {propertyName: () => {return expectedResult;}});
 			let promisifiedResultFunction: any = decoratorsLib.exportedPromise("moduleName");
@@ -65,7 +60,7 @@ describe("decorators", () => {
 		});
 
 		it("returns Promise, which is resolved to correct value (function with arguments)", () => {
-			$injector = new yokLib.Yok();
+			$injector = new Yok();
 			let expectedArgs = ["result", "result1", "result2"];
 			$injector.register("moduleName", {propertyName: (functionArgs: string[]) => {return functionArgs;}});
 			let promisifiedResultFunction: any = decoratorsLib.exportedPromise("moduleName");
@@ -78,7 +73,7 @@ describe("decorators", () => {
 		});
 
 		it("returns Promise, which is resolved to correct value (function returning IFuture without arguments)", () => {
-			$injector = new yokLib.Yok();
+			$injector = new Yok();
 			let expectedResult = "result";
 			$injector.register("moduleName", {propertyName: () => Future.fromResult(expectedResult)});
 			let promisifiedResultFunction: any = decoratorsLib.exportedPromise("moduleName");
@@ -91,7 +86,7 @@ describe("decorators", () => {
 		});
 
 		it("returns Promise, which is resolved to correct value (function returning IFuture with arguments)", () => {
-			$injector = new yokLib.Yok();
+			$injector = new Yok();
 			let expectedArgs = ["result", "result1", "result2"];
 			$injector.register("moduleName", {propertyName: (args: string[]) => Future.fromResult(args)});
 			let promisifiedResultFunction: any = decoratorsLib.exportedPromise("moduleName");
@@ -104,7 +99,7 @@ describe("decorators", () => {
 		});
 
 		it("rejects Promise, which is resolved to correct error (function without arguments throws)", () => {
-			$injector = new yokLib.Yok();
+			$injector = new Yok();
 			let expectedError = new Error("Test msg");
 			$injector.register("moduleName", {propertyName: () => {throw expectedError;}});
 			let promisifiedResultFunction: any = decoratorsLib.exportedPromise("moduleName");
@@ -119,7 +114,7 @@ describe("decorators", () => {
 		});
 
 		it("rejects Promise, which is resolved to correct error (function returning IFuture without arguments throws)", () => {
-			$injector = new yokLib.Yok();
+			$injector = new Yok();
 			let expectedError = new Error("Test msg");
 			$injector.register("moduleName", {propertyName: () => { return (() => { throw expectedError; }).future<void>()(); }});
 			let promisifiedResultFunction: any = decoratorsLib.exportedPromise("moduleName");
@@ -135,7 +130,7 @@ describe("decorators", () => {
 		});
 
 		it("returns Promises, which are resolved to correct value (function returning IFuture<T>[] without arguments)", () => {
-			$injector = new yokLib.Yok();
+			$injector = new Yok();
 			let expectedResults = ["result1", "result2", "result3"];
 			$injector.register("moduleName", { propertyName: () => _.map(expectedResults, expectedResult => Future.fromResult(expectedResult)) });
 			let promisifiedResultFunction: any = decoratorsLib.exportedPromise("moduleName");
@@ -148,7 +143,7 @@ describe("decorators", () => {
 		});
 
 		it("rejects Promises, which are resolved to correct error (function returning IFuture<T>[] without arguments throws)", () => {
-			$injector = new yokLib.Yok();
+			$injector = new Yok();
 			let expectedErrors = [new Error("result1"), new Error("result2"), new Error("result3")];
 			$injector.register("moduleName", { propertyName: () => _.map(expectedErrors, expectedError => { return (() => { throw expectedError; }).future<void>()(); })});
 			let promisifiedResultFunction: any = decoratorsLib.exportedPromise("moduleName");
@@ -164,7 +159,7 @@ describe("decorators", () => {
 		});
 
 		it("rejects only Promises which throw, resolves the others correctly (function returning IFuture<T>[] without arguments)", () => {
-			$injector = new yokLib.Yok();
+			$injector = new Yok();
 			let expectedResults: any[] = ["result1", new Error("result2")];
 			$injector.register("moduleName", { propertyName: () => _.map(expectedResults, expectedResult => Future.fromResult(expectedResult)) });
 			let promisifiedResultFunction: any = decoratorsLib.exportedPromise("moduleName");

--- a/test/unit-tests/mobile/android-device-discovery.ts
+++ b/test/unit-tests/mobile/android-device-discovery.ts
@@ -1,0 +1,271 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+import {AndroidDeviceDiscovery} from "../../../mobile/mobile-core/android-device-discovery";
+import {Yok} from "../../../yok";
+import Future = require("fibers/future");
+import { EventEmitter } from "events";
+import { EOL } from "os";
+import { assert } from "chai";
+
+class AndroidDeviceMock {
+	public deviceInfo: any = {};
+	constructor(public identifier: string, public status: string) {
+		this.deviceInfo.identifier = identifier;
+	}
+};
+
+interface IChildProcessMock {
+	stdout: MockEventEmitter;
+	stderr: MockEventEmitter;
+};
+
+class MockEventEmitter extends EventEmitter implements IChildProcessMock {
+	public stdout: MockEventEmitter;
+	public stderr: MockEventEmitter;
+};
+
+let mockStdoutEmitter: MockEventEmitter,
+	mockStderrEmitter: MockEventEmitter,
+	mockChildProcess: any;
+
+function createTestInjector(): IInjector {
+	let injector = new Yok();
+	injector.register("injector", injector);
+	injector.register("childProcess", {
+		spawn: (command: string, args?: string[], options?: any) => {
+			mockChildProcess = new MockEventEmitter();
+			mockChildProcess.stdout = mockStdoutEmitter;
+			mockChildProcess.stderr = mockStderrEmitter;
+			return mockChildProcess;
+		},
+		spawnFromEvent: (command: string, args: string[], event: string, options?: any, spawnFromEventOptions?: any) => {
+			return Future.fromResult(args);
+		}
+	});
+
+	injector.register("staticConfig", {
+		getAdbFilePath: () => {
+			return Future.fromResult("adbPath");
+		}
+	});
+
+	injector.register("androidDeviceDiscovery", AndroidDeviceDiscovery);
+	let originalResolve = injector.resolve;
+	// replace resolve as we do not want to create real AndroidDevice
+	let resolve = (param: any, ctorArguments?: IDictionary<any>) => {
+		if(ctorArguments && Object.prototype.hasOwnProperty.call(ctorArguments, "status") &&
+			Object.prototype.hasOwnProperty.call(ctorArguments, "identifier")){
+			return new AndroidDeviceMock(ctorArguments["identifier"], ctorArguments["status"]);
+		} else {
+			return originalResolve.apply(injector, [param, ctorArguments]);
+		}
+	};
+	injector.resolve = resolve;
+
+	return injector;
+}
+
+describe("androidDeviceDiscovery", () => {
+	let androidDeviceDiscovery: Mobile.IAndroidDeviceDiscovery,
+		injector: IInjector,
+		androidDeviceIdentifier = "androidDevice",
+		androidDeviceStatus = "device",
+		devicesFound: any[];
+
+	beforeEach(() => {
+		mockChildProcess = null;
+		injector = createTestInjector();
+		mockStdoutEmitter = new MockEventEmitter();
+		mockStderrEmitter = new MockEventEmitter();
+		androidDeviceDiscovery = injector.resolve("androidDeviceDiscovery");
+		devicesFound = [];
+	});
+
+	describe("startLookingForDevices", () => {
+		it("finds correctly one device", () => {
+			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+				devicesFound.push(device);
+			});
+			// As startLookingForDevices is blocking, we should emit data on the next tick, so the future will be resolved and we'll receive the data.
+			setTimeout(() => {
+				let output = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}${EOL}`;
+				mockStdoutEmitter.emit('data', output);
+			}, 1);
+			androidDeviceDiscovery.startLookingForDevices().wait();
+			assert.isTrue(devicesFound.length === 1, "We should have found ONE device.");
+			assert.deepEqual(devicesFound[0].deviceInfo.identifier, androidDeviceIdentifier);
+			assert.deepEqual(devicesFound[0].status, androidDeviceStatus);
+		});
+	});
+
+	describe("ensureAdbServerStarted", () => {
+		it("should spawn adb with start-server parameter", () => {
+			let ensureAdbServerStartedOutput = androidDeviceDiscovery.ensureAdbServerStarted().wait();
+			assert.isTrue(_.contains(ensureAdbServerStartedOutput, "start-server"), "start-server should be passed to adb.");
+		});
+	});
+
+	describe("checkForDevices", () => {
+		it("finds correctly one device", () => {
+			let future = new Future<void>();
+			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+				devicesFound.push(device);
+				future.return();
+			});
+			androidDeviceDiscovery.checkForDevices().wait();
+			let output = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}${EOL}`;
+			mockStdoutEmitter.emit('data', output);
+			future.wait();
+			assert.isTrue(devicesFound.length === 1, "We should have found ONE device.");
+			assert.deepEqual(devicesFound[0].deviceInfo.identifier, androidDeviceIdentifier);
+			assert.deepEqual(devicesFound[0].status, androidDeviceStatus);
+		});
+
+		it("finds correctly more than one device", () => {
+			let future = new Future<void>();
+			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+				devicesFound.push(device);
+				if(devicesFound.length === 2) {
+					future.return();
+				}
+			});
+			androidDeviceDiscovery.checkForDevices().wait();
+			let output = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}secondDevice	${androidDeviceStatus}${EOL}`;
+			mockStdoutEmitter.emit('data', output);
+			future.wait();
+			assert.isTrue(devicesFound.length === 2, "We should have found two devices.");
+			assert.deepEqual(devicesFound[0].deviceInfo.identifier, androidDeviceIdentifier);
+			assert.deepEqual(devicesFound[0].status, androidDeviceStatus);
+			assert.deepEqual(devicesFound[1].deviceInfo.identifier, "secondDevice");
+			assert.deepEqual(devicesFound[1].status, androidDeviceStatus);
+		});
+
+		it("does not find any devices when there are no devices", () => {
+			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+				throw new Error("Devices should not be found.");
+			});
+			androidDeviceDiscovery.checkForDevices().wait();
+			let output = `List of devices attached${EOL}`;
+			mockStdoutEmitter.emit('data', output);
+			assert.isTrue(devicesFound.length === 0, "We should have NOT found devices.");
+		});
+
+		describe("when device is already found", () => {
+			let defaultAdbOutput = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}${EOL}`;
+			beforeEach(() => {
+				let future = new Future<void>();
+				let deviceFoundHandler = (device: Mobile.IDevice) => {
+					devicesFound.push(device);
+					future.return();
+				};
+				androidDeviceDiscovery.on("deviceFound", deviceFoundHandler);
+				androidDeviceDiscovery.checkForDevices().wait();
+				mockStdoutEmitter.emit('data', defaultAdbOutput);
+				future.wait();
+				androidDeviceDiscovery.removeListener("deviceFound", deviceFoundHandler);
+			});
+
+			it("does not report it as found next time when checkForDevices is called and same device is still connected", () => {
+				androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+					throw new Error("Should not report same device as found");
+				});
+				androidDeviceDiscovery.checkForDevices().wait();
+				mockStdoutEmitter.emit('data', defaultAdbOutput);
+				assert.isTrue(devicesFound.length === 1, "We should have found ONE device.");
+				assert.deepEqual(devicesFound[0].deviceInfo.identifier, androidDeviceIdentifier);
+				assert.deepEqual(devicesFound[0].status, androidDeviceStatus);
+			});
+
+			it("reports it as removed next time when called and device is removed", () => {
+				let future = new Future<any>();
+				androidDeviceDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+					future.return(device);
+				});
+
+				androidDeviceDiscovery.checkForDevices().wait();
+				let output = `List of devices attached${EOL}`;
+				mockStdoutEmitter.emit('data', output);
+				let lostDevice = future.wait();
+				assert.deepEqual(lostDevice.deviceInfo.identifier, androidDeviceIdentifier);
+				assert.deepEqual(lostDevice.status, androidDeviceStatus);
+			});
+
+			it("does not report it as removed two times when called and device is removed", () => {
+				let future = new Future<any>();
+				androidDeviceDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+					future.return(device);
+				});
+
+				androidDeviceDiscovery.checkForDevices().wait();
+				let output = `List of devices attached${EOL}`;
+				mockStdoutEmitter.emit('data', output);
+				let lostDevice = future.wait();
+				assert.deepEqual(lostDevice.deviceInfo.identifier, androidDeviceIdentifier);
+				assert.deepEqual(lostDevice.status, androidDeviceStatus);
+
+				androidDeviceDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+					throw new Error("Should not report device as removed next time after it has been already reported.");
+				});
+				androidDeviceDiscovery.checkForDevices().wait();
+				mockStdoutEmitter.emit('data', output);
+			});
+
+			it("reports it as removed and added after that next time when called and device's status is changed", () => {
+				let deviceLostFuture = new Future<any>();
+				let deviceFoundFuture = new Future<any>();
+				androidDeviceDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+					_.remove(devicesFound, d => d.deviceInfo.identifier === device.deviceInfo.identifier);
+					deviceLostFuture.return(device);
+				});
+
+				androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+					devicesFound.push(device);
+					deviceFoundFuture.return(device);
+				});
+
+				androidDeviceDiscovery.checkForDevices().wait();
+				let output = `List of devices attached${EOL}${androidDeviceIdentifier}	unauthorized${EOL}${EOL}`;
+				mockStdoutEmitter.emit('data', output);
+				let lostDevice = deviceLostFuture.wait();
+				assert.deepEqual(lostDevice.deviceInfo.identifier, androidDeviceIdentifier);
+				assert.deepEqual(lostDevice.status, androidDeviceStatus);
+
+				deviceFoundFuture.wait();
+				assert.isTrue(devicesFound.length === 1, "We should have found ONE device.");
+				assert.deepEqual(devicesFound[0].deviceInfo.identifier, androidDeviceIdentifier);
+				assert.deepEqual(devicesFound[0].status, "unauthorized");
+
+				// Verify the device will not be reported as found next time when adb returns the same output:
+				// In case it is reported, an error will be raised - Future resolved more than once for deviceFoundFuture
+				mockStdoutEmitter.emit('data', output);
+				assert.isTrue(devicesFound.length === 1, "We should have found ONE device.");
+			});
+		});
+
+		it("throws error when adb writes on stderr", () => {
+			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+				throw new Error("Devices should not be found.");
+			});
+			let error = new Error("ADB Error");
+			try {
+				androidDeviceDiscovery.checkForDevices().wait();
+				mockStderrEmitter.emit('data', error);
+			} catch (err) {
+				assert.deepEqual(err, error);
+			}
+		});
+
+		it("throws error when adb's child process throws error", () => {
+			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+				throw new Error("Devices should not be found.");
+			});
+			let error = new Error("ADB Error");
+			try {
+				androidDeviceDiscovery.checkForDevices().wait();
+				mockChildProcess.emit('error', error);
+			} catch (err) {
+				assert.deepEqual(err, error);
+			}
+		});
+	});
+});


### PR DESCRIPTION
Add tests for androidDeviceDiscovery that will verify the behavior.
Fix issue in decorators tests, where global $injector had been incorrectly reset.