### PR TITLE
Add device log filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.3.0
+Latest version: 0.4.0
 
-Release date: 2015, December 21
+Release date: 2015, December 29
 
 ### System Requirements
 

--- a/appbuilder/device-log-provider.ts
+++ b/appbuilder/device-log-provider.ts
@@ -4,8 +4,33 @@
 import { EventEmitter } from "events";
 
 export class DeviceLogProvider extends EventEmitter implements Mobile.IDeviceLogProvider {
+	private devicesLogLevel: IStringDictionary = {};
+
+	constructor(private $logFilter: Mobile.ILogFilter) {
+		super();
+	}
+
 	public logData(line: string, platform: string, deviceIdentifier?: string): void {
-		this.emit('data', deviceIdentifier, line);
+		let logLevel = this.$logFilter.loggingLevel;
+		if(deviceIdentifier) {
+			logLevel = this.devicesLogLevel[deviceIdentifier] = this.devicesLogLevel[deviceIdentifier] || this.$logFilter.loggingLevel;
+		}
+
+		let data = this.$logFilter.filterData(platform, line, logLevel);
+		if(data) {
+			this.emit('data', deviceIdentifier, data);
+		}
+	}
+
+	public setLogLevel(logLevel: string, deviceIdentifier?: string): void {
+		if(deviceIdentifier) {
+			this.devicesLogLevel[deviceIdentifier] = logLevel.toUpperCase();
+		} else {
+			this.$logFilter.loggingLevel = logLevel.toUpperCase();
+			_.each(this.devicesLogLevel, (deviceLogLevel: string, deviceId: string) => {
+				this.devicesLogLevel[deviceId] = this.$logFilter.loggingLevel;
+			});
+		}
 	}
 }
 $injector.register("deviceLogProvider", DeviceLogProvider);

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -104,3 +104,8 @@ $injector.requireCommand("doctor", "./commands/doctor");
 $injector.require("utils", "./utils");
 $injector.require("bplistParser", "./bplist-parser");
 $injector.require("winreg", "./winreg");
+
+$injector.require("loggingLevels", "./mobile/logging-levels");
+$injector.require("logFilter", "./mobile/log-filter");
+$injector.require("androidLogFilter", "./mobile/android/android-log-filter");
+$injector.require("iOSLogFilter", "./mobile/ios/ios-log-filter");

--- a/commands/device/device-log-stream.ts
+++ b/commands/device/device-log-stream.ts
@@ -7,12 +7,16 @@ export class OpenDeviceLogStreamCommand implements ICommand {
 	constructor(private $devicesService: Mobile.IDevicesService,
 		private $errors: IErrors,
 		private $commandsService: ICommandsService,
-		private $options: ICommonOptions) { }
+		private $options: ICommonOptions,
+		private $deviceLogProvider: Mobile.IDeviceLogProvider,
+		private $loggingLevels: Mobile.ILoggingLevels) { }
 
 	allowedParameters: ICommandParameter[] = [];
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
+			this.$deviceLogProvider.setLogLevel(this.$loggingLevels.full);
+
 			this.$devicesService.initialize({ deviceId: this.$options.device, skipInferPlatform: true }).wait();
 
 			if (this.$devicesService.deviceCount > 1) {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -69,6 +69,45 @@ declare module Mobile {
 
 	interface IDeviceLogProvider {
 		logData(line: string, platform: string, deviceIdentifier: string): void;
+		setLogLevel(level: string, deviceIdentifier?: string): void;
+	}
+
+	/**
+	 * Describes common filtering rules for device logs.
+	 */
+	interface ILogFilter {
+		/**
+		 * The logging level that will be used for filtering in case logLevel is not passed to filterData method.
+		 * Defaults to INFO.
+		 */
+		loggingLevel: string;
+
+		/**
+		 * Filters data for specified platform.
+		 * @param {string} platform The platform for which is the device log.
+		 * @param {string} data The input data for filtering.
+		 * @param {string} logLevel @optional The logging level based on which input data will be filtered.
+		 * @return {string} The filtered result based on the input or null when the input data shouldn't be shown.
+		 */
+		filterData(platform: string, data: string, logLevel?: string): string;
+	}
+
+	/**
+	 * Describes filtering logic for specific platform (Android, iOS).
+	 */
+	interface IPlatformLogFilter {
+		/**
+		 * Filters passed string data based on the passed logging level.
+		 * @param {string} data The string data that will be checked based on the logging level.
+		 * @param {string} logLevel Selected logging level.
+		 * @return {string} The filtered result based on the input or null when the input data shouldn't be shown.
+		 */
+		filterData(data: string, logLevel: string): string;
+	}
+
+	interface ILoggingLevels {
+		info: string;
+		full: string;
 	}
 
 	interface IDeviceApplicationManager {

--- a/helpers.ts
+++ b/helpers.ts
@@ -237,7 +237,7 @@ export function hook(commandName: string) {
 }
 
 export function isFuture(candidateFuture: any): boolean {
-	return candidateFuture && typeof(candidateFuture.wait) === "function";
+	return !!(candidateFuture && typeof(candidateFuture.wait) === "function");
 }
 
 export function whenAny<T>(...futures: IFuture<T>[]): IFuture<IFuture<T>> {

--- a/mobile/android/android-log-filter.ts
+++ b/mobile/android/android-log-filter.ts
@@ -1,0 +1,44 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+export class AndroidLogFilter implements Mobile.IPlatformLogFilter {
+
+	//sample line is "I/Web Console(    4438): Received Event: deviceready at file:///storage/emulated/0/Icenium/com.telerik.TestApp/js/index.js:48"
+	private static LINE_REGEX = /.\/(.+?)\s*\(\s*\d+?\): (.*)/;
+
+	// sample line is "11-23 12:39:07.310  1584  1597 I art     : Background sticky concurrent mark sweep GC freed 21966(1780KB) AllocSpace objects, 4(80KB) LOS objects, 77% free, 840KB/3MB, paused 4.018ms total 158.629ms"
+	// or '12-28 10:45:08.020  3329  3329 W chromium: [WARNING:data_reduction_proxy_settings.cc(328)] SPDY proxy OFF at startup'
+	private static API_LEVEL_23_LINE_REGEX = /.+?\s+?(?:[A-Z]\s+?)([A-Za-z ]+?)\s*?\: (.*)/;
+
+	constructor(private $loggingLevels: Mobile.ILoggingLevels) {}
+
+	public filterData(data: string, logLevel: string): string {
+		let specifiedLogLevel = (logLevel || '').toUpperCase();
+		if(specifiedLogLevel === this.$loggingLevels.info) {
+			let log = this.getConsoleLogFromLine(data);
+			if(log) {
+				if(log.tag) {
+					return `${log.tag}: ${log.message}`;
+				} else {
+					return log.message;
+				}
+			}
+
+			return null;
+		}
+
+		return data;
+	}
+
+	private getConsoleLogFromLine(lineText: string): any {
+		let acceptedTags = ["chromium", "Web Console", "JS"];
+		let match = lineText.match(AndroidLogFilter.LINE_REGEX) || lineText.match(AndroidLogFilter.API_LEVEL_23_LINE_REGEX);
+
+		if (match && acceptedTags.indexOf(match[1].trim()) !== -1) {
+			return { tag: match[1].trim(), message: match[2] };
+		}
+		let matchingTag = _.any(acceptedTags, (tag: string) => { return lineText.indexOf(tag) !== -1; });
+		return matchingTag ? { message: lineText } : null;
+	}
+}
+$injector.register("androidLogFilter", AndroidLogFilter);

--- a/mobile/device-log-provider.ts
+++ b/mobile/device-log-provider.ts
@@ -1,0 +1,19 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+export class DeviceLogProvider implements Mobile.IDeviceLogProvider {
+	constructor(private $logFilter: Mobile.ILogFilter,
+		private $logger: ILogger) { }
+
+	public logData(lineText: string, platform: string, deviceIdentifier: string): void {
+		let data = this.$logFilter.filterData(platform, lineText);
+		if(data) {
+			this.$logger.out(data);
+		}
+	}
+
+	public setLogLevel(logLevel: string, deviceIdentifier?: string): void {
+		this.$logFilter.loggingLevel = logLevel.toUpperCase();
+	}
+}
+$injector.register("deviceLogProvider", DeviceLogProvider);

--- a/mobile/ios/ios-log-filter.ts
+++ b/mobile/ios/ios-log-filter.ts
@@ -1,0 +1,20 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+export class IOSLogFilter implements Mobile.IPlatformLogFilter {
+	private static INFO_FILTER_REGEX = /^.*?(AppBuilder|Cordova|NativeScript).*?(<Notice>:.*?(CONSOLE LOG|JS ERROR).*?|<Warning>:.*?|<Error>:.*?)$/im;
+
+	constructor(private $loggingLevels: Mobile.ILoggingLevels) {}
+
+	public filterData(data: string, logLevel: string): string {
+		let specifiedLogLevel = (logLevel || '').toUpperCase();
+
+		if(specifiedLogLevel === this.$loggingLevels.info) {
+			let matchingInfoMessage = data.match(IOSLogFilter.INFO_FILTER_REGEX);
+			return matchingInfoMessage ? matchingInfoMessage[2] : null;
+		}
+
+		return data;
+	}
+}
+$injector.register("iOSLogFilter", IOSLogFilter);

--- a/mobile/log-filter.ts
+++ b/mobile/log-filter.ts
@@ -1,0 +1,48 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+export class LogFilter implements Mobile.ILogFilter {
+	private _loggingLevel: string = this.$loggingLevels.info;
+
+	constructor(private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $injector: IInjector,
+		private $loggingLevels: Mobile.ILoggingLevels) {}
+
+	public get loggingLevel(): string {
+		return this._loggingLevel;
+	}
+
+	public set loggingLevel(logLevel: string) {
+		if(this.verifyLogLevel(logLevel)) {
+			this._loggingLevel = logLevel;
+		}
+	}
+
+	public filterData(platform: string, data: string, logLevel?: string): string {
+		let deviceLogFilter = this.getDeviceLogFilterInstance(platform);
+		if(deviceLogFilter) {
+			return deviceLogFilter.filterData(data, logLevel || this.loggingLevel);
+		}
+
+		// In case the platform is not valid, just return the data without filtering.
+		return data;
+	}
+
+	private getDeviceLogFilterInstance(platform: string): Mobile.IPlatformLogFilter {
+		if(platform) {
+			if(platform.toLowerCase() === this.$devicePlatformsConstants.iOS.toLowerCase()) {
+				return this.$injector.resolve("iOSLogFilter");
+			} else if(platform.toLowerCase() ===  this.$devicePlatformsConstants.Android.toLowerCase()) {
+				return this.$injector.resolve("androidLogFilter");
+			}
+		}
+		return null;
+	}
+
+	private verifyLogLevel(logLevel: string): boolean {
+		let upperCaseLogLevel = (logLevel || '').toUpperCase();
+		return upperCaseLogLevel === this.$loggingLevels.info.toUpperCase() || upperCaseLogLevel === this.$loggingLevels.full.toUpperCase();
+	}
+
+}
+$injector.register("logFilter", LogFilter);

--- a/mobile/logging-levels.ts
+++ b/mobile/logging-levels.ts
@@ -1,0 +1,8 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+export class LoggingLevels implements Mobile.ILoggingLevels {
+	public info = "INFO";
+	public full = "FULL";
+};
+$injector.register("loggingLevels", LoggingLevels);

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -23,7 +23,8 @@ export class DevicesService implements Mobile.IDevicesService {
 		private $androidDeviceDiscovery: Mobile.IDeviceDiscovery,
 		private $staticConfig: Config.IStaticConfig,
 		private $messages: IMessages,
-		private $mobileHelper: Mobile.IMobileHelper) {
+		private $mobileHelper: Mobile.IMobileHelper,
+		private $deviceLogProvider: Mobile.IDeviceLogProvider) {
 		this.attachToDeviceDiscoveryEvents();
 	}
 
@@ -39,6 +40,13 @@ export class DevicesService implements Mobile.IDevicesService {
 	public getDevices(): Mobile.IDeviceInfo[] {
 		return this.getDeviceInstances().map(deviceInstance => deviceInstance.deviceInfo);
 	}
+
+	/* tslint:disable:no-unused-variable */
+	@exported("devicesService")
+	private setLogLevel(logLevel: string, deviceIdentifier?: string): void {
+		this.$deviceLogProvider.setLogLevel(logLevel, deviceIdentifier);
+	}
+	/* tslint:enable:no-unused-variable */
 
 	public getDeviceInstances(): Mobile.IDevice[] {
 		return _.values(this._devices);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {

--- a/test/unit-tests/android-log-filter.ts
+++ b/test/unit-tests/android-log-filter.ts
@@ -1,0 +1,133 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import { AndroidLogFilter } from "../../mobile/android/android-log-filter";
+import { LoggingLevels } from "../../mobile/logging-levels";
+import { Yok } from "../../yok";
+import * as assert from "assert";
+
+let androidApiLevel23TestData = [
+	{ input: '12-28 10:14:15.977    99    99 D Genymotion: Received Set Clipboard', output: null },
+	{ input: '12-28 10:14:31.303   779   790 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=com.telerik.app1/.TelerikCallbackActivity (has extras)} from uid 10008 on display 0', output: null },
+	{ input: '--------- beginning of main', output: null },
+	{ input: '12-28 10:14:31.314  3593  3593 I art     : Late-enabling -Xcheck:jni', output: null },
+	{ input: '12-28 10:14:31.348  3593  3593 W System  : ClassLoader referenced unknown path: /data/app/com.telerik.app1-1/lib/x86', output: null },
+	{ input: '12-28 10:14:31.450  3593  3593 V WebViewChromiumFactoryProvider: Binding Chromium to main looper Looper (main, tid 1) {bfa9d51}', output: null },
+	{ input: '12-28 10:14:31.450  3593  3593 I chromium: [INFO:library_loader_hooks.cc(108)] Chromium logging enabled: level = 0, default verbosity = 0',
+		output: 'chromium: [INFO:library_loader_hooks.cc(108)] Chromium logging enabled: level = 0, default verbosity = 0' },
+	{ input: '12-28 10:14:31.460  3593  3593 I BrowserStartupController: Initializing chromium process, singleProcess=true',
+		output: '12-28 10:14:31.460  3593  3593 I BrowserStartupController: Initializing chromium process, singleProcess=true' },
+	{ input: '12-28 10:14:31.486  3593  3613 W AudioManagerAndroid: Requires BLUETOOTH permission', output: null },
+	{ input: '12-28 10:14:31.544  3593  3593 D libEGL  : loaded /system/lib/egl/libEGL_emulation.so', output: null },
+	{ input: '12-28 10:14:31.555  3593  3593 D         : HostConnection::get() New Host Connection established 0xe99b30f0, tid 3593', output: null },
+	{ input: '12-28 10:14:31.631  3593  3593 D CordovaWebView: CordovaWebView is running on device made by: Genymotion', output: null },
+	{ input: '12-28 10:16:26.239  3659  3659 I chromium: [INFO:CONSOLE(1)] "Uncaught ReferenceError: start is not defined", source: file:///data/user/0/com.telerik.app1/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2/index.html (1)',
+		output: 'chromium: [INFO:CONSOLE(1)] "Uncaught ReferenceError: start is not defined", source: file:///data/user/0/com.telerik.app1/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2/index.html (1)' },
+	{ input: '12-28 10:16:49.267   779  1172 I ActivityManager: Start proc 3714:org.nativescript.appDebug1/u0a60 for activity org.nativescript.appDebug1/com.tns.NativeScriptActivity', output: null },
+	{ input: '12-28 10:16:49.316  3714  3714 I TNS.Native: NativeScript Runtime Version 1.5.1, commit c27e977f059e37b3f8230722a4687e16acf43a7f', output: null },
+	{ input: '12-28 10:16:49.710  3714  3714 V JS      : TAPPED: 42', output: 'JS: TAPPED: 42' },
+	{ input: '12-28 10:16:49.775  3714  3714 D NativeScriptActivity: NativeScriptActivity.onCreate called', output: null },
+	{ input: '12-28 10:16:49.795  3714  3714 I Web Console: Received Event: deviceready at file:///storage/emulated/0/Icenium/com.telerik.TestApp/js/index.js:48',
+		output: 'Web Console: Received Event: deviceready at file:///storage/emulated/0/Icenium/com.telerik.TestApp/js/index.js:48'}
+];
+
+let androidApiLevel22TestData = [
+	{ input: '--------- beginning of system', output: null },
+	{ input: 'D/Genymotion(   82): Received Ping', output: null },
+	{ input: '--------- beginning of main', output: null },
+	{ input: 'W/AudioTrack( 1804): AUDIO_OUTPUT_FLAG_FAST denied by client', output: null },
+	{ input: 'I/ActivityManager( 1804): START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=com.telerik.hybridApp/.TelerikCallbackActivity (has extras)} from uid 10039 on display 0', output: null },
+	{ input: 'I/ActivityManager( 1804): Start proc 2971:com.telerik.hybridApp/u0a60 for activity com.telerik.hybridApp/.TelerikCallbackActivity', output: null },
+	{ input: 'I/art     ( 2971): Late-enabling -Xcheck:jni', output: null },
+	{ input: 'D/        ( 1789): HostConnection::get() New Host Connection established 0xb68c9390, tid 2626', output: null },
+	{ input: 'I/CordovaLog( 2971): Changing log level to DEBUG(3)', output: null },
+	{ input: 'D/CordovaActivity( 2971): CordovaActivity.init()', output: null },
+	{ input: 'I/WebViewFactory( 2971): Loading com.android.webview version 39 (eng.buildbot-x86) (code 399997)', output: null },
+	{ input: 'I/LibraryLoader( 2971): Time to load native libraries: 24 ms (timestamps 2169-2193)', output: null },
+	{ input: 'I/LibraryLoader( 2971): Expected native library version number "",actual native library version number ""', output: null },
+	{ input: 'V/WebViewChromiumFactoryProvider( 2971): Binding Chromium to main looper Looper (main, tid 1) {18cd5cc2}', output: null },
+	{ input: 'I/LibraryLoader( 2971): Expected native library version number "",actual native library version number ""', output: null },
+	{ input: 'I/chromium( 2971): [INFO:library_loader_hooks.cc(104)] Chromium logging enabled: level = 0, default verbosity = 0',
+		output: 'chromium: [INFO:library_loader_hooks.cc(104)] Chromium logging enabled: level = 0, default verbosity = 0' },
+	{ input: 'I/BrowserStartupController( 2971): Initializing chromium process, singleProcess=true',
+		output: 'I/BrowserStartupController( 2971): Initializing chromium process, singleProcess=true' },
+	{ input: 'W/art     ( 2971): Attempt to remove local handle scope entry from IRT, ignoring', output: null },
+	{ input: 'W/AudioManagerAndroid( 2971): Requires BLUETOOTH permission', output: null },
+	{ input: 'W/chromium( 2971): [WARNING:resource_bundle.cc(304)] locale_file_path.empty()',
+		output: 'chromium: [WARNING:resource_bundle.cc(304)] locale_file_path.empty()' },
+	{ input: 'I/chromium( 2971): [INFO:aw_browser_main_parts.cc(65)] Load from apk succesful, fd=30 off=46184 len=3037',
+		output: 'chromium: [INFO:aw_browser_main_parts.cc(65)] Load from apk succesful, fd=30 off=46184 len=3037' },
+	{ input: 'I/chromium( 2971): [INFO:aw_browser_main_parts.cc(78)] Loading webviewchromium.pak from, fd:31 off:229484 len:1089587',
+		output: 'chromium: [INFO:aw_browser_main_parts.cc(78)] Loading webviewchromium.pak from, fd:31 off:229484 len:1089587' },
+	{ input: 'D/CordovaWebView( 2971): CordovaWebView is running on device made by: Genymotion', output: null },
+	{ input: 'D/CordovaWebViewClient( 2971): onPageStarted(file:///android_asset/www/index.html)', output: null },
+	{ input: 'D/CordovaActivity( 2971): onMessage(onPageStarted,file:///android_asset/www/index.html)', output: null },
+	{ input: 'D/CordovaWebView( 2971): >>> loadUrl(file:///data/data/com.telerik.hybridApp/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2/index.html)', output: null },
+	{ input: 'I/chromium( 2971): [INFO:CONSOLE(1)] "Uncaught ReferenceError: start is not defined", source: file:///data/data/com.telerik.hybridApp/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2/index.html (1)',
+		output: 'chromium: [INFO:CONSOLE(1)] "Uncaught ReferenceError: start is not defined", source: file:///data/data/com.telerik.hybridApp/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2/index.html (1)' },
+	{ input: 'D/CordovaWebView( 2971): The current URL is: file:///data/data/com.telerik.hybridApp/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2/index.html', output: null },
+	{ input: 'E/EGL_emulation( 1789): tid 1789: eglCreateSyncKHR(1209): error 0x3004 (EGL_BAD_ATTRIBUTE)', output: null },
+	{ input: 'V/JS      ( 3930): TAPPED: 42', output: 'JS: TAPPED: 42'},
+	{ input: 'I/Web Console(    4438): Received Event: deviceready at file:///storage/emulated/0/Icenium/com.telerik.TestApp/js/index.js:48',
+		output: 'Web Console: Received Event: deviceready at file:///storage/emulated/0/Icenium/com.telerik.TestApp/js/index.js:48'}
+];
+
+describe("androidLogFilter", () => {
+
+	let assertFiltering = (inputData: string, expectedOutput: string, logLevel?: string) => {
+		let testInjector = new Yok();
+		testInjector.register("loggingLevels", LoggingLevels);
+		let androidLogFilter = testInjector.resolve(AndroidLogFilter);
+		let filteredData = androidLogFilter.filterData(inputData, logLevel);
+		assert.deepEqual(filteredData, expectedOutput, `The actual result '${filteredData}' did NOT match expected output '${expectedOutput}'.`);
+	};
+
+	let logLevel = "INFO";
+
+	describe("filterData", () => {
+		describe("when log level is full", () => {
+			beforeEach(() => logLevel = "FULL");
+			it("when API level 23 or later is used", () => {
+				_.each(androidApiLevel23TestData, testData => {
+					assertFiltering(testData.input, testData.input, logLevel);
+				});
+			});
+
+			it("when API level 22 is used", () => {
+				_.each(androidApiLevel22TestData, testData => {
+					assertFiltering(testData.input, testData.input, logLevel);
+				});
+			});
+		});
+
+		describe("when log level is info", () => {
+			beforeEach(() => logLevel = "info");
+			it("when API level 23 or later is used", () => {
+				_.each(androidApiLevel23TestData, testData => {
+					assertFiltering(testData.input, testData.output, logLevel);
+				});
+			});
+
+			it("when API level 22 is used", () => {
+				_.each(androidApiLevel22TestData, testData => {
+					assertFiltering(testData.input, testData.output, logLevel);
+				});
+			});
+		});
+
+		describe("when log level is not specified", () => {
+			beforeEach(() => logLevel = "");
+			it("when API level 23 or later is used", () => {
+				_.each(androidApiLevel22TestData, testData => {
+					assertFiltering(testData.input, testData.input, null);
+				});
+			});
+
+			it("when API level 22 is used", () => {
+				_.each(androidApiLevel22TestData, testData => {
+					assertFiltering(testData.input, testData.input, null);
+				});
+			});
+		});
+	});
+});

--- a/test/unit-tests/appbuilder/device-log-provider.ts
+++ b/test/unit-tests/appbuilder/device-log-provider.ts
@@ -1,0 +1,152 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import { Yok } from "../../../yok";
+import * as assert from "assert";
+import { DeviceLogProvider } from "../../../appbuilder/device-log-provider";
+
+// $logFilter
+function createTestInjector(loggingLevel: string, emptyFilteredData?: boolean) {
+	let testInjector = new Yok();
+	testInjector.register("logFilter", {
+		loggingLevel: loggingLevel,
+		filterData: (platform: string, data: string, logLevel?: string) => {
+			return emptyFilteredData ? null : `${logLevel} ${data}`;
+		}
+	});
+
+	return testInjector;
+};
+
+describe("proton deviceLogProvider", () => {
+	let testInjector: IInjector,
+		deviceLogProvider: any = null,
+		testData = "testData",
+		infoLogLevel = "INFO",
+		fullLogLevel = "FULL",
+		filteredInfoData = `${infoLogLevel} ${testData}`,
+		filteredFullData = `${fullLogLevel} ${testData}`;
+
+	describe("logData", () => {
+		describe("when device identifier is not specified", () => {
+			it("logs INFO messages when logging level is default", () => {
+				testInjector = createTestInjector(infoLogLevel);
+				deviceLogProvider = testInjector.resolve(DeviceLogProvider);
+				let emittedData: string = 'some default value that should be changed';
+				deviceLogProvider.on("data", (deviceIdentifier: string, data: string) => {
+					emittedData = data;
+				});
+				deviceLogProvider.logData(testData, "platform");
+				assert.deepEqual(emittedData, filteredInfoData);
+			});
+
+			it("does not emit data when whole data is filtered", () => {
+				testInjector = createTestInjector(infoLogLevel, true);
+				deviceLogProvider = testInjector.resolve(DeviceLogProvider);
+				let emittedData: string = 'some default value that should NOT be changed';
+				deviceLogProvider.on("data", (deviceIdentifier: string, data: string) => {
+					emittedData = data;
+				});
+				deviceLogProvider.logData(testData, "platform");
+				assert.deepEqual(emittedData, 'some default value that should NOT be changed');
+			});
+		});
+
+		describe("when device identifier is specified", () => {
+			it("logs INFO messages when logging level is INFO", () => {
+				testInjector = createTestInjector(infoLogLevel);
+				deviceLogProvider = testInjector.resolve(DeviceLogProvider);
+				let emittedData: string = 'some default value that should be changed';
+				let expectedDeviceIdentifier: string = null;
+				deviceLogProvider.on("data", (deviceIdentifier: string, data: string) => {
+					emittedData = data;
+					expectedDeviceIdentifier = deviceIdentifier;
+				});
+				deviceLogProvider.logData(testData, "platform", "deviceId");
+				assert.deepEqual(emittedData, filteredInfoData);
+				assert.deepEqual(expectedDeviceIdentifier, "deviceId");
+			});
+
+			it("does not emit data when whole data is filtered", () => {
+				testInjector = createTestInjector(infoLogLevel, true);
+				deviceLogProvider = testInjector.resolve(DeviceLogProvider);
+				let emittedData: string = 'some default value that should NOT be changed';
+				let expectedDeviceIdentifier: string = null;
+				deviceLogProvider.on("data", (deviceIdentifier: string, data: string) => {
+					emittedData = data;
+					expectedDeviceIdentifier = deviceIdentifier;
+				});
+				deviceLogProvider.logData(testData, "platform");
+				assert.deepEqual(emittedData, 'some default value that should NOT be changed');
+				assert.deepEqual(expectedDeviceIdentifier, null);
+			});
+		});
+	});
+
+	describe("setLogLevel", () => {
+		it("changes logFilter's loggingLevel when device identifier is not specified", () => {
+			testInjector = createTestInjector(infoLogLevel);
+			deviceLogProvider = testInjector.resolve(DeviceLogProvider);
+			deviceLogProvider.setLogLevel(fullLogLevel);
+			let logFilter = testInjector.resolve("logFilter");
+			assert.deepEqual(logFilter.loggingLevel, fullLogLevel);
+		});
+
+		it("does not change logFilter's loggingLevel when device identifier is specified", () => {
+			testInjector = createTestInjector(infoLogLevel);
+			deviceLogProvider = testInjector.resolve(DeviceLogProvider);
+			deviceLogProvider.setLogLevel(fullLogLevel, "deviceID");
+			let logFilter = testInjector.resolve("logFilter");
+			assert.deepEqual(logFilter.loggingLevel, infoLogLevel);
+		});
+	});
+
+	describe("keeps correct log level for each device", () => {
+		beforeEach(() => {
+			testInjector = createTestInjector(infoLogLevel);
+			deviceLogProvider = testInjector.resolve(DeviceLogProvider);
+		});
+
+		it("emits full log level for specific deviceIdentifier and info for the rest of the devices", () => {
+			deviceLogProvider.setLogLevel(fullLogLevel, "device1");
+			let emittedData: string = 'some default value that should be changed';
+			let expectedDeviceIdentifier: string = null;
+			deviceLogProvider.on("data", (deviceIdentifier: string, data: string) => {
+				emittedData = data;
+				expectedDeviceIdentifier = deviceIdentifier;
+			});
+			deviceLogProvider.logData(testData, "platform", "device1");
+			assert.deepEqual(emittedData, filteredFullData);
+			assert.deepEqual(expectedDeviceIdentifier, "device1");
+			deviceLogProvider.logData(testData, "platform", "device2");
+			assert.deepEqual(emittedData, filteredInfoData);
+			assert.deepEqual(expectedDeviceIdentifier, "device2");
+			deviceLogProvider.logData(testData, "platform", "device1");
+			assert.deepEqual(emittedData, filteredFullData);
+			assert.deepEqual(expectedDeviceIdentifier, "device1");
+		});
+
+		it("emits info log level for all devices, when setLogLevel is called without identifier", () => {
+			deviceLogProvider.setLogLevel(fullLogLevel, "device1");
+			let emittedData: string = 'some default value that should be changed';
+			let expectedDeviceIdentifier: string = null;
+			deviceLogProvider.on("data", (deviceIdentifier: string, data: string) => {
+				emittedData = data;
+				expectedDeviceIdentifier = deviceIdentifier;
+			});
+			deviceLogProvider.logData(testData, "platform", "device1");
+			assert.deepEqual(emittedData, filteredFullData);
+			assert.deepEqual(expectedDeviceIdentifier, "device1");
+
+			// Reset log level for all devices
+			deviceLogProvider.setLogLevel(infoLogLevel);
+
+			deviceLogProvider.logData(testData, "platform", "device2");
+			assert.deepEqual(emittedData, filteredInfoData);
+			assert.deepEqual(expectedDeviceIdentifier, "device2");
+			deviceLogProvider.logData(testData, "platform", "device1");
+			assert.deepEqual(emittedData, filteredInfoData);
+			assert.deepEqual(expectedDeviceIdentifier, "device1");
+		});
+	});
+});

--- a/test/unit-tests/ios-log-filter.ts
+++ b/test/unit-tests/ios-log-filter.ts
@@ -1,0 +1,70 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import { IOSLogFilter } from "../../mobile/ios/ios-log-filter";
+import { LoggingLevels } from "../../mobile/logging-levels";
+import { Yok } from "../../yok";
+import * as assert from "assert";
+
+let iosTestData = [
+	{ input: 'Dec 29 08:46:04 Dragons-iPhone iaptransportd[65] <Warning>: CIapPortAppleIDBus: Auth timer timeout completed on pAIDBPort:0x135d09410, portID:01 downstream port', output: null },
+	{ input: 'Dec 29 08:46:06 Dragons-iPhone kernel[0] <Notice>: AppleARMPMUCharger: AppleUSBCableDetect 1', output: null },
+	{ input: 'Dec 29 08:47:24 Dragons-iPhone bird[131] <Error>: unable to determine evictable space: Error Domain=LibrarianErrorDomain Code=10 "The operation couldn’t be completed. (LibrarianErrorDomain error 10 - Unable to configure the collection.)" UserInfo=0x137528190 {NSDescription=Unable to configure the collection.}', output: null },
+	{ input: 'Dec 29 08:47:43 Dragons-iPhone syslog_relay[179] <Notice>: syslog_relay found the ASL prompt. Starting...', output: null },
+	{ input: 'Dec 29 08:48:47 Dragons-iPhone com.apple.xpc.launchd[1] (com.apple.WebKit.Networking.08B3A589-3D68-492A-BA8D-A812EC55FDEB[13306]) <Warning>: Service exited with abnormal code: 1', output: null },
+	{ input: 'Dec 29 08:48:47 Dragons-iPhone ReportCrash[13308] <Notice>: Saved report to /var/mobile/Library/Logs/CrashReporter/Cordova370_2015-12-29-084847_Dragons-iPhone.ips', output: null },
+	{ input: 'Dec 29 08:48:47 Dragons-iPhone com.apple.WebKit.Networking[13306] <Error>: Failed to obtain sandbox extension for path=/private/var/mobile/Containers/Data/Application/047BB8F2-B8C8-405F-A820-8719EE207E6F/Library/Caches/com.telerik.BlankJS. Errno:1', output: null },
+	{ input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: Apache Cordova native platform version 3.7.0 is starting.',
+		output: '<Warning>: Apache Cordova native platform version 3.7.0 is starting.' },
+	{ input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Notice>: Multi-tasking -> Device: YES, App: YES', output: null },
+	{ input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: Unlimited access to network resources',
+		output: '<Warning>: Unlimited access to network resources' },
+	{ input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: Finished load of: file:///var/mobile/Containers/Data/Application/0746156D-3C83-402E-8B4E-2B3063F42F76/Documents/index.html',
+		output: '<Warning>: Finished load of: file:///var/mobile/Containers/Data/Application/0746156D-3C83-402E-8B4E-2B3063F42F76/Documents/index.html' },
+	{ input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: ---------------------------------- LOG FROM MY APP',
+		output: '<Warning>: ---------------------------------- LOG FROM MY APP' },
+	{ input: 'Dec 29 08:50:31 Dragons-iPhone NativeScript143[13314] <Error>: assertion failed: 12F70: libxpc.dylib + 71768 [B870B51D-AA85-3686-A7D9-ACD48C5FE153]: 0x7d',
+		output: '<Error>: assertion failed: 12F70: libxpc.dylib + 71768 [B870B51D-AA85-3686-A7D9-ACD48C5FE153]: 0x7d' },
+	{ input: 'Dec 29 08:50:31 Dragons-iPhone Unknown[13314] <Error>:', output: null },
+	{ input: 'Dec 29 08:50:31 Dragons-iPhone locationd[57] <Notice>: Gesture EnabledForTopCLient: 0, EnabledInDaemonSettings: 0', output: null },
+	{ input: 'Dec 29 08:55:24 Dragons-iPhone NativeScript143[13323] <Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41',
+		output: '<Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41'},
+	{ input: 'Dec 29 08:55:24 Dragons-iPhone NativeScript143[13323] <Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41\n',
+		output: '<Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41'}
+];
+
+describe("iOSLogFilter", () => {
+
+	let assertFiltering = (inputData: string, expectedOutput: string, logLevel?: string) => {
+		let testInjector = new Yok();
+		testInjector.register("loggingLevels", LoggingLevels);
+		let androidLogFilter = testInjector.resolve(IOSLogFilter);
+		let filteredData = androidLogFilter.filterData(inputData, logLevel);
+		assert.deepEqual(filteredData, expectedOutput, `The actual result '${filteredData}' did NOT match expected output '${expectedOutput}'.`);
+	};
+
+	let logLevel = "INFO";
+
+	describe("filterData", () => {
+		it("when log level is full returns full data", () => {
+			logLevel = "FULL";
+			_.each(iosTestData, testData => {
+				assertFiltering(testData.input, testData.input, logLevel);
+			});
+		});
+
+		it("when log level is INFO filters data", () => {
+			logLevel = "INFO";
+			_.each(iosTestData, testData => {
+				assertFiltering(testData.input, testData.output, logLevel);
+			});
+		});
+
+		it("when log level is not specified returns full data", () => {
+			logLevel = null;
+			_.each(iosTestData, testData => {
+				assertFiltering(testData.input, testData.input);
+			});
+		});
+	});
+});

--- a/test/unit-tests/log-filter.ts
+++ b/test/unit-tests/log-filter.ts
@@ -1,0 +1,150 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import { LogFilter } from "../../mobile/log-filter";
+import { Yok } from "../../yok";
+import { DevicePlatformsConstants } from "../../mobile/device-platforms-constants";
+import { LoggingLevels } from "../../mobile/logging-levels";
+import * as assert from "assert";
+
+function createTestInjector(): IInjector {
+	let testInjector = new Yok();
+	testInjector.register("injector", testInjector);
+	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
+	testInjector.register("loggingLevels", LoggingLevels);
+	testInjector.register("logFilter", LogFilter);
+	testInjector.register("iOSLogFilter", {
+		filterData: (data: string, logLevel: string) => {
+			return `ios: ${data} ${logLevel}`;
+		}
+	});
+
+	testInjector.register("androidLogFilter", {
+		filterData: (data: string, logLevel: string) => {
+			return `android: ${data} ${logLevel}`;
+		}
+	});
+
+	return testInjector;
+}
+
+describe("logFilter", () => {
+	let testInjector: IInjector,
+		logFilter: Mobile.ILogFilter,
+		testData = "testData",
+		infoLogLevel = "INFO",
+		fullLogLevel = "FULL",
+		androidInfoTestData = `android: ${testData} ${infoLogLevel}`,
+		androidFullTestData = `android: ${testData} ${fullLogLevel}`,
+		iosInfoTestData = `ios: ${testData} ${infoLogLevel}`,
+		iosFullTestData = `ios: ${testData} ${fullLogLevel}`,
+		logLevel: string = null;
+
+	beforeEach(() => {
+		testInjector = createTestInjector();
+		logFilter = testInjector.resolve("logFilter");
+		logLevel = null;
+	});
+
+	describe("loggingLevel", () => {
+		it("verify default value is INFO", () => {
+			assert.deepEqual(logFilter.loggingLevel, infoLogLevel, "Default level should be INFO.");
+		});
+
+		it("sets default value to FULL", () => {
+			logFilter.loggingLevel = fullLogLevel;
+			assert.deepEqual(logFilter.loggingLevel, fullLogLevel, "Default level should be FULL.");
+		});
+
+		it("keeps default value to INFO when invalid value is passed", () => {
+			logFilter.loggingLevel = "invalidValue";
+			assert.deepEqual(logFilter.loggingLevel, infoLogLevel, "Default level should be INFO.");
+		});
+
+		it("keeps default value to INFO when falsey value is passed", () => {
+			logFilter.loggingLevel = null;
+			assert.deepEqual(logFilter.loggingLevel, infoLogLevel, "Default level should be INFO.");
+		});
+	});
+
+	describe("filterData", () => {
+		describe("when logLevel is not specified and default log level is not changed", () => {
+			it("returns same data when platform is not correct", () => {
+				let actualData = logFilter.filterData("invalidPlatform", testData);
+				assert.deepEqual(actualData, testData);
+			});
+
+			it("returns same data when platform is not passed", () => {
+				let actualData = logFilter.filterData(null, testData);
+				assert.deepEqual(actualData, testData);
+			});
+
+			it("returns correct data when platform is android", () => {
+				let actualData = logFilter.filterData("android", testData);
+				assert.deepEqual(actualData, androidInfoTestData);
+			});
+
+			it("returns correct data when platform is ios", () => {
+				let actualData = logFilter.filterData("ios", testData);
+				assert.deepEqual(actualData, iosInfoTestData);
+			});
+		});
+
+		describe("when logLevel is not specified and default log level is set to full", () => {
+			beforeEach( () => logFilter.loggingLevel = fullLogLevel );
+
+			it("returns same data when platform is not correct", () => {
+				let actualData = logFilter.filterData("invalidPlatform", testData);
+				assert.deepEqual(actualData, testData);
+			});
+
+			it("returns correct data when platform is android", () => {
+				let actualData = logFilter.filterData("android", testData);
+				assert.deepEqual(actualData, androidFullTestData);
+			});
+
+			it("returns correct data when platform is ios", () => {
+				let actualData = logFilter.filterData("ios", testData);
+				assert.deepEqual(actualData, iosFullTestData);
+			});
+		});
+
+		describe("when logLevel is INFO", () => {
+			beforeEach(() => logLevel = infoLogLevel);
+
+			it("returns same data when platform is not correct", () => {
+				let actualData = logFilter.filterData("invalidPlatform", testData, logLevel);
+				assert.deepEqual(actualData, testData, logLevel);
+			});
+
+			it("returns correct data when platform is android", () => {
+				let actualData = logFilter.filterData("android", testData, logLevel);
+				assert.deepEqual(actualData, androidInfoTestData);
+			});
+
+			it("returns correct data when platform is ios", () => {
+				let actualData = logFilter.filterData("ios", testData, logLevel);
+				assert.deepEqual(actualData, iosInfoTestData);
+			});
+		});
+
+		describe("when logLevel is FULL", () => {
+			beforeEach(() => logLevel = fullLogLevel);
+
+			it("returns same data when platform is not correct", () => {
+				let actualData = logFilter.filterData("invalidPlatform", testData, logLevel);
+				assert.deepEqual(actualData, testData, logLevel);
+			});
+
+			it("returns correct data when platform is android", () => {
+				let actualData = logFilter.filterData("android", testData, logLevel);
+				assert.deepEqual(actualData, androidFullTestData);
+			});
+
+			it("returns correct data when platform is ios", () => {
+				let actualData = logFilter.filterData("ios", testData, logLevel);
+				assert.deepEqual(actualData, iosFullTestData);
+			});
+		});
+	});
+});


### PR DESCRIPTION
* Add AndroidLogFilter - specific filtering for Android devices
* Add IOSLogFilter - specific filtering for iOS devices
* Add LogFilter class - common filtering logic. Resolves androidLogFilter or iOSLogFilter based on the input.
* Show full output when `<cli> device log` command is used.
* Add unit tests for androidLogFilter
* Add unit tests for iOSLogFilter
* Add unit tests for LogFilter
* Make sure isFuture method returns boolean.
* Expose setLogLevel method in devicesService (used for Proton)