### PR TITLE
Fix deploy on iOS devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.4.0
+Latest version: 0.4.1
 
-Release date: 2015, December 29
+Release date: 2016, January 08
 
 ### System Requirements
 

--- a/services/messages-service.ts
+++ b/services/messages-service.ts
@@ -3,6 +3,7 @@
 
 import * as util from "util";
 import * as path from "path";
+import * as fiberBootstrap from "../fiber-bootstrap";
 
 export class MessagesService implements IMessagesService {
 	private _pathsToMessageJsonFiles: string[] = null;
@@ -70,13 +71,15 @@ export class MessagesService implements IMessagesService {
 	}
 
 	private refreshMessageJsonContentsCache(): void {
-		this._messageJsonFilesContentsCache = [];
-		_.each(this.pathsToMessageJsonFiles, path => {
-			if (!this.$fs.exists(path).wait()) {
-				throw new Error("Message json file " + path + " does not exist.");
-			}
+		fiberBootstrap.run(() => {
+			this._messageJsonFilesContentsCache = [];
+			_.each(this.pathsToMessageJsonFiles, path => {
+				if (!this.$fs.exists(path).wait()) {
+					throw new Error("Message json file " + path + " does not exist.");
+				}
 
-			this._messageJsonFilesContentsCache.push(this.$fs.readJson(path).wait());
+				this._messageJsonFilesContentsCache.push(this.$fs.readJson(path).wait());
+			});
 		});
 	}
 


### PR DESCRIPTION
When we deploy on iOS devices, the first sent package sometimes receives error code 21. It turned out this error is not breaking the deployment, so ignore it once and continue deploying.
The error occurs only when we have parallel futures executing for device detection.

Also when error is raised during application starting, we reject the Promise for deploy on device. This is not correct, so ignore such errors and resolve the promise.

One fix to rule them all: http://teampulse.telerik.com/view#item/307776