### PR TITLE
Fix livesync on Android devices and Genymotion emulator

### DIFF
--- a/mobile/android/android-device-file-system.ts
+++ b/mobile/android/android-device-file-system.ts
@@ -45,10 +45,9 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 	public transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): IFuture<void> {
 		return (() => {
 			this.adb.executeCommand(["push", projectFilesPath, deviceAppData.deviceProjectRootPath]).wait();
-
-			let command = _.map(localToDevicePaths, (localToDevicePathData) => `"${localToDevicePathData.getDevicePath()}"`).join(" ");
+			let deviceFilePaths = _.map(localToDevicePaths, (localToDevicePathData) => `"${localToDevicePathData.getDevicePath()}"`).join(" ");
 			let commandsDeviceFilePath = this.$mobileHelper.buildDevicePath(deviceAppData.deviceProjectRootPath, "nativescript.commands.sh");
-			this.createFileOnDevice(commandsDeviceFilePath, command).wait();
+			this.createFileOnDevice(commandsDeviceFilePath, "chmod 0777 " + deviceFilePaths).wait();
 			this.adb.executeShellCommand([commandsDeviceFilePath]).wait();
 		}).future<void>()();
 	}

--- a/services/project-files-manager.ts
+++ b/services/project-files-manager.ts
@@ -36,7 +36,7 @@ export class ProjectFilesManager implements IProjectFilesManager {
 	}
 
 	public createLocalToDevicePaths(deviceAppData: Mobile.IDeviceAppData, projectFilesPath: string, files?: string[], excludedProjectDirsAndFiles?: string[]): Mobile.ILocalToDevicePathData[] {
-		files = files || this.getProjectFiles(projectFilesPath, excludedProjectDirsAndFiles);
+		files = files || this.getProjectFiles(projectFilesPath, excludedProjectDirsAndFiles, null, { enumerateDirectories: true});
 		let localToDevicePaths = _(files)
 			.map(projectFile => this.getProjectFileInfo(projectFile, deviceAppData.platform))
 			.filter(projectFileInfo => projectFileInfo.shouldIncludeFile)


### PR DESCRIPTION
On some Android devices the `android-runtime` cannot delete the files in `/data/local/tmp/<app id>/fullsync` directory.
The next time when the application is started, runtime reads the fullsync directory and replaces the real application with content of fullsync dir.
So the app does not start as it is not full app.
Fix two issues - first one is missing `chmod` command in the file that we are generating.
As we cannot spawn chmod of all files directly, due to some command line limitations, we are writing the command in a file, transfer the file on the device and execute it.
BUT, we've lost the command in this commit https://github.com/telerik/mobile-cli-lib/commit/6d52c6ab9b51aaac7b5fae7e4412c0f58737fcf1
In fact our file contains only list of files and when trying to execute it on the device, we receive error, but we have added parameter to `spawnFromEvent` not to throw. So the error is hidden.
Add the missing chmod, so the command can be executed successfully.

However this fixes the issues for some files, but when we have directories, we do not write them in the file, so android runtime does not have permissions to delete them and they remain in fullsync directory.
Fix this by including directories in the list of application files (not sure if this will not break something else).