### PR TITLE
Revert parallel execution of action on multiple devices

### DIFF
--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -216,7 +216,9 @@ export class DevicesService implements Mobile.IDevicesService {
 
 			let futures = _.map(sortedDevices, (device: Mobile.IDevice) => {
 				if (!canExecute || canExecute(device)) {
-					return action(device);
+					let future = action(device);
+					Future.settle(future);
+					return future;
 				} else {
 					return Future.fromResult();
 				}


### PR DESCRIPTION
Revert change applied in this commit - https://github.com/telerik/mobile-cli-lib/commit/065512bd01ccae6dfd4648244c0ee21bcf5abf19#diff-3afe2bc0eef11fb206a6cfb650f4057fL213
The idea was to speed up actions executed on multiple devices. However in our current code is not able to work this way.
For example `tns run android` is trying to execute multiple simultaneous builds and it fails. Same will happen with livesync in some cases.
The problem is with the action that's passed for each device. Until we fix the other code, let's keep the old behavior.