### PR TITLE
Fix detection of changed shasums

### DIFF
--- a/mobile/android/android-device-file-system.ts
+++ b/mobile/android/android-device-file-system.ts
@@ -79,8 +79,8 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 				// Create or update file hashes on device
 				let oldShasums = deviceHashService.getShasumsFromDevice().wait();
 				if (oldShasums) {
-					let changedShasums: any = _.omit(currentShasums, (hash: string, pathToFile: string) => !!_.find(oldShasums, h => hash === h));
-					this.$logger.trace(`Changed file hashes are: ${changedShasums}.`);
+					let changedShasums: any = _.omit(currentShasums, (hash: string, pathToFile: string) => !!_.find(oldShasums, (oldHash: string, oldPath: string) => pathToFile === oldPath && hash === oldHash));
+					this.$logger.trace("Changed file hashes are:", changedShasums);
 					filesToChmodOnDevice = [];
 					let futures = _(changedShasums)
 						.map((hash: string, filePath: string) => _.find(localToDevicePaths, ldp => ldp.getLocalPath() === filePath))


### PR DESCRIPTION
Currently we are validating only the shasum of the files in order to detect which one are changed and sync only them.
However this is not correct as the file may be on a different location, but without changing its size.
Also in case you copy some of your files, their shasums might be the same as the original file.
In case the original file is already synced, its hash size will be found in the "oldShasums" and the new file will not be copied.
Validate by using both path and hash.

Fix unit tests and add some new ones.