### PR TITLE
Fix livesync --watch

### DIFF
--- a/services/usb-livesync-service-base.ts
+++ b/services/usb-livesync-service-base.ts
@@ -6,6 +6,7 @@ import * as path from "path";
 import * as util from "util";
 import * as moment from "moment";
 import * as fiberBootstrap from "../fiber-bootstrap";
+import Future = require("fibers/future");
 let gaze = require("gaze");
 
 interface IProjectFileInfo {
@@ -344,8 +345,7 @@ export class UsbLiveSyncServiceBase implements IUsbLiveSyncServiceBase {
 	}
 
 	protected preparePlatformForSync(platform: string): IFuture<void> {
-		return null;
-		//Overridden in platform-specific services.
+		return Future.fromResult();
 	}
 
 	public static isFileExcluded(path: string, exclusionList: string[], projectDir: string): boolean {


### PR DESCRIPTION
`appbuilder livesync --watch` fails with error when file is saved. The problem is in code used for NS CLI, which returns null instead of future.