### PR TITLE
Fix livesync on multiple devices when app is not installed

### DIFF
--- a/services/livesync-service-base.ts
+++ b/services/livesync-service-base.ts
@@ -151,11 +151,10 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 			let projectFilesPath = data.projectFilesPath;
 
 			let packageFilePath: string = null;
-			let shouldRefreshApplication: boolean;
 
 			let action = (device: Mobile.IDevice) => {
 				return (() => {
-					shouldRefreshApplication = true;
+					let shouldRefreshApplication = true;
 					let deviceAppData = this.$deviceAppDataFactory.create(appIdentifier, this.$mobileHelper.normalizePlatformName(platform), device);
 					if (deviceAppData.isLiveSyncSupported().wait()) {
 						let platformLiveSyncService = this.resolvePlatformLiveSyncService(platform, device);
@@ -169,15 +168,15 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 							this.$logger.warn(`The application with id "${appIdentifier}" is not installed on device with identifier ${device.deviceInfo.identifier}.`);
 							if (!packageFilePath) {
 								packageFilePath = this.$liveSyncProvider.buildForDevice(device).wait();
-								device.applicationManager.reinstallApplication(appIdentifier, packageFilePath).wait();
-								if (device.applicationManager.canStartApplication()) {
-									device.applicationManager.startApplication(appIdentifier).wait();
-								}
+							}
+							device.applicationManager.reinstallApplication(appIdentifier, packageFilePath).wait();
+							if (device.applicationManager.canStartApplication()) {
+								device.applicationManager.startApplication(appIdentifier).wait();
+							}
 
-								if (platformLiveSyncService.afterInstallApplicationAction) {
-									let localToDevicePaths = this.$projectFilesManager.createLocalToDevicePaths(deviceAppData, projectFilesPath, filesToSync, data.excludedProjectDirsAndFiles);
-									platformLiveSyncService.afterInstallApplicationAction(deviceAppData, localToDevicePaths).wait();
-								}
+							if (platformLiveSyncService.afterInstallApplicationAction) {
+								let localToDevicePaths = this.$projectFilesManager.createLocalToDevicePaths(deviceAppData, projectFilesPath, filesToSync, data.excludedProjectDirsAndFiles);
+								platformLiveSyncService.afterInstallApplicationAction(deviceAppData, localToDevicePaths).wait();
 							}
 							shouldRefreshApplication =  false;
 						}


### PR DESCRIPTION
When you try to livesync on multiple devices and application is not installed on more than one, calling `tns livesync <platform>` installs the application only on one of them.
There's warning in the output that the application is not installed for each of the devices, but it is installed only on one of them.
The problem is the current logic that is executed for each device - as we want to build only one, in case the app is already built, we've skipped the install part for all devices except the first one.
So we have to build once, but install the built package on all devices where the app does not exist.