### PR TITLE
Fix childProcess arguments printing

### DIFF
--- a/child-process.ts
+++ b/child-process.ts
@@ -143,7 +143,7 @@ export class ChildProcess implements IChildProcess {
 	}
 
 	private getArgumentsAsQuotedString(args: string[]): string {
-		return args.map(argument => `"${argument}"`).join(" ");
+		return args && args.length && args.map(argument => `"${argument}"`).join(" ");
 	}
 }
 $injector.register("childProcess", ChildProcess);


### PR DESCRIPTION
In childProcess we print the arguments passed to a method. In case it does not have arguments, we our method for printing fails.
Fix the method by checking arguments before printing them.