### PR TITLE
Fix sync of platform specific and config specific files

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -485,6 +485,7 @@ interface ICommonOptions {
 	template: string;
 	var: Object;
 	default: Boolean;
+	release: boolean;
 }
 
 interface IYargArgv extends IDictionary<any> {
@@ -766,6 +767,26 @@ interface IProgressIndicator {
 	showProgressIndicator(future: IFuture<any>, timeout: number, options?: { surpressTrailingNewLine?: boolean }): IFuture<void>;
 }
 
+/**
+ * Describes project file that should be livesynced
+ */
+interface IProjectFileInfo {
+	/**
+	 * Full path to the file that has to be livesynced.
+	 */
+	filePath: string;
+
+	/**
+	 * Filename that will be transefered on the device. This is the original filename with stripped platform and configuration names.
+	 */
+	onDeviceFileName: string;
+
+	/**
+	 * Defines if the file should be included in the transfer. For example when device is Android, files that contain iOS in the name should not be synced.
+	 */
+	shouldIncludeFile: boolean;
+}
+
 interface IProjectFilesManager {
 	/**
 	 * Enumerates all files and directories from the specified project files path.
@@ -795,6 +816,20 @@ interface IProjectFilesProvider {
 	 * Performs local file path mapping
 	 */
 	mapFilePath(filePath: string, platform: string): string;
+
+	/**
+	 * Returns information about file in the project, that includes file's name on device after removing platform or configuration from the name.
+	 * @param {string} filePath Path to the project file.
+	 * @param {string} optional Platform for which to get the information.
+	 * @return {IProjectFileInfo}
+	 */
+	getProjectFileInfo(filePath: string, platform?: string): IProjectFileInfo;
+	/**
+	 * Parses file by removing platform or configuration from its name.
+	 * @param {string} filePath Path to the project file.
+	 * @return {string} Parsed file name or original file name in case it does not have platform/configuration in the filename.
+	 */
+	getPreparedFilePath(filePath: string): string;
 }
 
 interface ILiveSyncProvider {

--- a/options.ts
+++ b/options.ts
@@ -69,8 +69,9 @@ export class OptionsBase {
 			"emulator": { type: OptionType.Boolean },
 			"sdk": { type: OptionType.String },
 			"template": { type: OptionType.String },
-			var: {type: OptionType.Object},
-			default: {type: OptionType.Boolean},
+			"release": { type: OptionType.Boolean },
+			"var": {type: OptionType.Object},
+			"default": {type: OptionType.Boolean}
 		};
 	}
 

--- a/services/project-files-provider-base.ts
+++ b/services/project-files-provider-base.ts
@@ -1,0 +1,45 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import * as path from "path";
+import * as util from "util";
+
+export abstract class ProjectFilesProviderBase implements IProjectFilesProvider {
+	abstract isFileExcluded(filePath: string): boolean;
+	abstract mapFilePath(filePath: string, platform: string): string;
+
+	constructor(private $mobileHelper: Mobile.IMobileHelper,
+		private $options: ICommonOptions) {}
+
+	public getPreparedFilePath(filePath: string): string {
+		let projectFileInfo = this.getProjectFileInfo(filePath);
+		return path.join(path.dirname(filePath), projectFileInfo.onDeviceFileName);
+	}
+
+	public getProjectFileInfo(filePath: string, platform?: string): IProjectFileInfo {
+		let parsed = this.parseFile(filePath, this.$mobileHelper.platformNames, platform || "");
+		if (!parsed) {
+			parsed = this.parseFile(filePath, ["debug", "release"], this.$options.release ? "release" : "debug");
+		}
+
+		return parsed || {
+			filePath: filePath,
+			onDeviceFileName: path.basename(filePath),
+			shouldIncludeFile: true
+		};
+	}
+
+	private parseFile(filePath: string, validValues: string[], value: string): IProjectFileInfo {
+		let regex = util.format("^(.+?)[.](%s)([.].+?)$", validValues.join("|"));
+		let parsed = filePath.match(new RegExp(regex, "i"));
+		if (parsed) {
+			return {
+				filePath: filePath,
+				onDeviceFileName: path.basename(parsed[1] + parsed[3]),
+				shouldIncludeFile: parsed[2].toLowerCase() === value.toLowerCase()
+			};
+		}
+
+		return null;
+	}
+}

--- a/test/unit-tests/mobile/project-files-manager.ts
+++ b/test/unit-tests/mobile/project-files-manager.ts
@@ -14,6 +14,7 @@ import {ProjectFilesManager} from "../../../services/project-files-manager";
 import {Logger} from "../../../logger";
 import * as path from "path";
 import {Yok} from "../../../yok";
+import { ProjectFilesProviderBase } from "../../../services/project-files-provider-base";
 
 import temp = require("temp");
 temp.track();
@@ -92,7 +93,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("localToDevicePathDataFactory", LocalToDevicePathDataFactory);
 	testInjector.register("mobileHelper", MobileHelper);
 	testInjector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilitiesMock);
-	testInjector.register("projectFilesProvider", {});
+	testInjector.register("projectFilesProvider", ProjectFilesProviderBase);
 	testInjector.register("projectFilesManager", ProjectFilesManager);
 	testInjector.register("options", { });
 	testInjector.register("staticConfig", {

--- a/test/unit-tests/project-files-provider-base.ts
+++ b/test/unit-tests/project-files-provider-base.ts
@@ -1,0 +1,155 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import {Yok} from "../../yok";
+import { ProjectFilesProviderBase } from "../../services/project-files-provider-base";
+import {assert} from "chai";
+import * as path from "path";
+
+class ProjectFilesProvider extends ProjectFilesProviderBase {
+	constructor($mobileHelper: Mobile.IMobileHelper,
+		$options: ICommonOptions) {
+		super($mobileHelper, $options);
+	}
+
+	public isFileExcluded(filePath: string): boolean {
+		throw new Error("Testing ProjectFilesProviderBase should not test abstract member isFileExcluded.");
+	}
+
+	public mapFilePath(filePath: string, platform: string): string {
+		throw new Error("Testing ProjectFilesProviderBase should not test abstract member mapFilePath.");
+	}
+}
+
+function createTestInjector(): IInjector {
+	let testInjector = new Yok();
+	testInjector.register("mobileHelper", {
+		platformNames: ["Android", "iOS"]
+	});
+
+	testInjector.register("options", { release: false });
+
+	return testInjector;
+}
+
+describe("ProjectFilesProviderBase", () => {
+	let testInjector: IInjector,
+		projectFilesProviderBase: IProjectFilesProvider,
+		expectedFilePath = path.join("/test", "filePath.ts");
+
+	beforeEach(() => {
+		testInjector = createTestInjector();
+		projectFilesProviderBase = testInjector.resolve(ProjectFilesProvider);
+	});
+
+	describe("getPreparedFilePath", () => {
+		it("returns correct path, when fileName does not contain platforms", () => {
+			let filePath = "/test/filePath.ts",
+				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath);
+
+			assert.deepEqual(preparedPath, expectedFilePath);
+		});
+
+		it("returns correct path, when fileName contains android platform", () => {
+			let filePath = "/test/filePath.android.ts",
+				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath);
+
+			assert.deepEqual(preparedPath, expectedFilePath);
+		});
+
+		it("returns correct path, when fileName contains ios platform", () => {
+			let filePath = "/test/filePath.iOS.ts",
+				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath);
+
+			assert.deepEqual(preparedPath, expectedFilePath);
+		});
+
+		it("returns correct path, when fileName contains platform (case insensitive test)", () => {
+			let filePath = "/test/filePath.AnDroId.ts",
+				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath);
+
+			assert.deepEqual(preparedPath, expectedFilePath);
+		});
+
+		it("returns correct path, when fileName contains debug configuration", () => {
+			let filePath = "/test/filePath.debug.ts",
+				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath);
+
+			assert.deepEqual(preparedPath, expectedFilePath);
+		});
+
+		it("returns correct path, when fileName contains debug configuration (case insensitive test)", () => {
+			let filePath = "/test/filePath.DebUG.ts",
+				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath);
+
+			assert.deepEqual(preparedPath, expectedFilePath);
+		});
+
+		it("returns correct path, when fileName contains release configuration", () => {
+			let filePath = "/test/filePath.release.ts",
+				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath);
+
+			assert.deepEqual(preparedPath, expectedFilePath);
+		});
+	});
+
+	describe("getProjectFileInfo", () => {
+		let getExpectedProjectFileInfo = (filePath: string, shouldIncludeFile: boolean) => {
+			return {
+				filePath: filePath,
+				onDeviceFileName: path.basename(expectedFilePath),
+				shouldIncludeFile: shouldIncludeFile
+			};
+		};
+
+		it("process file without platforms in the name", () => {
+			let filePath = "/test/filePath.ts",
+				projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath);
+
+			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, true));
+		});
+
+		it("process file with android platform in the name", () => {
+			let filePath = "/test/filePath.android.ts",
+				projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android");
+
+			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, true));
+		});
+
+		it("process file with android platform in the name (case insensitive test)", () => {
+			let filePath = "/test/filePath.AndRoID.ts",
+				projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android");
+
+			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, true));
+		});
+
+		it("process file with iOS platform in the name", () => {
+			let filePath = "/test/filePath.ios.ts",
+				projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android");
+
+			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, false));
+		});
+
+		it("process file with debug configuration in the name", () => {
+			let filePath = "/test/filePath.debug.ts",
+				projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android");
+
+			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, true));
+		});
+
+		it("process file with release configuration in the name", () => {
+			let filePath = "/test/filePath.release.ts",
+				projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android");
+
+			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, false));
+		});
+
+		it("process file with release configuration in the name, shouldIncludeFile must be true when options.release is true", () => {
+			let filePath = "/test/filePath.release.ts";
+			testInjector.resolve("options").release = true;
+			let projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android");
+
+			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, true));
+		});
+	});
+});


### PR DESCRIPTION
Fix LiveSync of platform specific and configuration specific files by extracting logic for parsing filename and use it in NS CLI.
Add ProjectFilesProviderBase class that holds the logic, so it can still be used from ProjectFilesManager.

Add --release option to common options so when `tns livesync <platform> --release --watch` is used, the files will be processed correctly.
Add tests for the new ProjectFilesProviderBase class.