### PR TITLE
Introduce xcode-select-service

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -115,3 +115,4 @@ $injector.require("androidLogFilter", "./mobile/android/android-log-filter");
 $injector.require("iOSLogFilter", "./mobile/ios/ios-log-filter");
 
 $injector.require("projectFilesManager", "./services/project-files-manager");
+$injector.require("xcodeSelectService", "./services/xcode-select-service");

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -322,6 +322,24 @@ interface IHtmlHelpService {
 	openHelpForCommandInBrowser(commandName: string): IFuture<void>;
 }
 
+/**
+ * Used to talk to xcode-select command-line tool.
+ */
+interface IXcodeSelectService {
+	/**
+	 * Get the path to Contents directory inside Xcode.app.
+	 * With a default installation this path is /Applications/Xcode.app/Contents
+	 * @return {IFuture<string>}
+	 */
+	getContentsDirectoryPath(): IFuture<string>;
+	/**
+	 * Get the path to Developer directory inside Xcode.app.
+	 * With a default installation this path is /Applications/Xcode.app/Contents/Developer/
+	 * @return {IFuture<string>}
+	 */
+	getDeveloperDirectoryPath(): IFuture<string>;
+}
+
 interface ILiveSyncServiceBase {
 	/**
 	 * If platform parameter is specified returns it

--- a/services/xcode-select-service.ts
+++ b/services/xcode-select-service.ts
@@ -1,0 +1,36 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import * as path from "path";
+
+export class XcodeSelectService implements IXcodeSelectService {
+	constructor(private $childProcess: IChildProcess,
+		private $errors: IErrors,
+		private $hostInfo: IHostInfo) {
+	}
+
+	public getDeveloperDirectoryPath(): IFuture<string> {
+		return (() => {
+			if (!this.$hostInfo.isDarwin) {
+				this.$errors.failWithoutHelp("xcode-select is only available on Mac OS X.");
+			}
+
+			let childProcess = this.$childProcess.spawnFromEvent("xcode-select", ["-print-path"], "close", {}, { throwError: false }).wait(),
+				result = childProcess.stdout.trim();
+
+			if (!result) {
+				this.$errors.failWithoutHelp("Cannot find path to Xcode.app - make sure you've installed Xcode correctly.");
+			}
+
+			return result;
+		}).future<string>()();
+	}
+
+	public getContentsDirectoryPath(): IFuture<string> {
+		return (() => {
+			return path.join(this.getDeveloperDirectoryPath().wait(), "..");
+		}).future<string>()();
+	}
+}
+
+$injector.register("xcodeSelectService", XcodeSelectService);

--- a/test/unit-tests/xcode-select-service.ts
+++ b/test/unit-tests/xcode-select-service.ts
@@ -1,0 +1,104 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import {Yok} from "../../yok";
+import {XcodeSelectService} from "../../services/xcode-select-service";
+import {assert} from "chai";
+import * as path from "path";
+import Future = require("fibers/future");
+
+let executionStopped = false;
+
+function createTestInjector(config: { xcodeSelectStdout: string, isDarwin: boolean }): IInjector {
+	let testInjector = new Yok();
+	testInjector.register("childProcess", {
+		spawnFromEvent: (command: string, args: string[], event: string): IFuture<any> => Future.fromResult({
+			stdout: config.xcodeSelectStdout
+		})
+	});
+	testInjector.register("errors", {
+		failWithoutHelp: (message: string, ...args: any[]): void => { executionStopped=true; }
+	});
+
+	testInjector.register("hostInfo", {
+		isDarwin: config.isDarwin
+	});
+	testInjector.register("xcodeSelectService", XcodeSelectService);
+
+	return testInjector;
+}
+describe("xcode-select-service", () => {
+	let injector: IInjector,
+		service: IXcodeSelectService,
+		defaultXcodeSelectStdout = "/Applications/Xcode.app/Contents/Developer/";
+
+	beforeEach(() => {
+		executionStopped = false;
+	});
+
+	it("gets correct path to Developer directory on Mac OS X whitout whitespaces", () => {
+		injector = createTestInjector({ xcodeSelectStdout: "  /Applications/Xcode.app/Contents/Developer/  ", isDarwin: true });
+		service = injector.resolve("$xcodeSelectService");
+
+		assert.deepEqual(service.getDeveloperDirectoryPath().wait(), defaultXcodeSelectStdout, "xcode-select service should get correct trimmed  path to Developer directory on Mac OS X.");
+	});
+
+	it("gets correct path to Developer directory on Mac OS X whitout new lines", () => {
+		injector = createTestInjector({ xcodeSelectStdout: "\r\n/Applications/Xcode.app/Contents/Developer/\n", isDarwin: true });
+		service = injector.resolve("$xcodeSelectService");
+
+		assert.deepEqual(service.getDeveloperDirectoryPath().wait(), defaultXcodeSelectStdout, "xcode-select service should get correct trimmed  path to Developer directory on Mac OS X.");
+	});
+
+	it("gets correct path to Developer directory on Mac OS X", () => {
+		injector = createTestInjector({ xcodeSelectStdout: defaultXcodeSelectStdout, isDarwin: true });
+		service = injector.resolve("$xcodeSelectService");
+
+		assert.deepEqual(service.getDeveloperDirectoryPath().wait(), defaultXcodeSelectStdout, "xcode-select service should get correct path to Developer directory on Mac OS X.");
+	});
+
+	it("gets correct path to Contents directory on Mac OS X", () => {
+		// This path is constructed with path.join so that the tests are OS-agnostic
+		let expected = path.join("/Applications", "Xcode.app", "Contents");
+		injector = createTestInjector({ xcodeSelectStdout: defaultXcodeSelectStdout, isDarwin: true });
+		service = injector.resolve("$xcodeSelectService");
+
+		assert.deepEqual(service.getContentsDirectoryPath().wait(), expected, "xcode-select service should get correct path to Contents directory on Mac OS X.");
+	});
+
+	it("stops execution when trying to get Developer directory if not on Mac OS X", () => {
+		injector = createTestInjector({ xcodeSelectStdout: defaultXcodeSelectStdout, isDarwin: false });
+		service = injector.resolve("$xcodeSelectService");
+
+		service.getDeveloperDirectoryPath().wait();
+
+		assert.deepEqual(executionStopped, true, "xcode-select service should stop executon unless on Mac OS X.");
+	});
+
+	it("stops execution when trying to get Contents directory if not on Mac OS X", () => {
+		injector = createTestInjector({ xcodeSelectStdout: defaultXcodeSelectStdout, isDarwin: false });
+		service = injector.resolve("$xcodeSelectService");
+
+		service.getContentsDirectoryPath().wait();
+
+		assert.deepEqual(executionStopped, true, "xcode-select service should stop executon unless on Mac OS X.");
+	});
+
+	it("stops execution when Developer directory is empty on Mac OS X", () => {
+		injector = createTestInjector({ xcodeSelectStdout: "", isDarwin: true });
+		service = injector.resolve("$xcodeSelectService");
+
+		service.getDeveloperDirectoryPath().wait();
+
+		assert.deepEqual(executionStopped, true, "xcode-select service should stop executon when Developer directory is empty on Mac OS X.");
+	});
+
+	it("stops execution when Contents directory is empty on Mac OS X", () => {
+		injector = createTestInjector({ xcodeSelectStdout: "", isDarwin: true });
+		service = injector.resolve("$xcodeSelectService");
+
+		service.getContentsDirectoryPath().wait();
+
+		assert.deepEqual(executionStopped, true, "xcode-select service should stop executon when Contents directory is empty on Mac OS X.");
+	});
+});


### PR DESCRIPTION
Used to communicate with `xcode-select` command line tool.
Currently only used for getting the path to various subdirectories of Xcode.app but can be extended to invoke `switch` or even `install` if needed.

Ping @rosen-vladimirov 