### PR TITLE
Fix starting of emulator when no devices are attached

### DIFF
--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -385,11 +385,13 @@ export class DevicesService implements Mobile.IDevicesService {
 				this.$errors.failWithoutHelp("Unable to detect platform for which to start emulator.");
 			}
 			emulatorServices.startEmulator().wait();
+
 			if (this.$mobileHelper.isAndroidPlatform(this._platform)) {
-				this.$androidDeviceDiscovery.checkForDevices().wait();
+				this.$androidDeviceDiscovery.startLookingForDevices().wait();
 			} else if (this.$mobileHelper.isiOSPlatform(this._platform) && this.$hostInfo.isDarwin) {
-				this.$iOSSimulatorDiscovery.checkForDevices().wait();
+				this.$iOSSimulatorDiscovery.startLookingForDevices().wait();
 			}
+
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
When there are no devices attached, CLI should start emulator and execute the action on it.
For example calling `tns run android` when there are no devices attached, the devicesService should start emulator and run the application in it.

Currently this is not working as the startEmulator method is starting the instance and then calls method for device detection.
However the checkForDevices method is async and it does not guarantee when the devices will be detected.
Instead use startLookingForDevices which is synchronous.