### PR TITLE
Implement LiveSync for Proton and for NS apps

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
 	"files.exclude": {
 		"**/.git": true,
 		"**/.DS_Store": true,
-		//"**/*.js": { "when": "$(basename).ts"},
+		"**/*.js": { "when": "$(basename).ts"},
 		"**/*.js.map": true
 	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
 	"files.exclude": {
 		"**/.git": true,
 		"**/.DS_Store": true,
-		"**/*.js": { "when": "$(basename).ts"},
+		//"**/*.js": { "when": "$(basename).ts"},
 		"**/*.js.map": true
 	}
 }

--- a/appbuilder/appbuilder-bootstrap.ts
+++ b/appbuilder/appbuilder-bootstrap.ts
@@ -1,0 +1,14 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+require("../bootstrap");
+$injector.require("projectConstants", "./appbuilder/project-constants");
+$injector.require("projectFilesProvider", "./appbuilder/providers/project-files-provider");
+$injector.require("pathFilteringService", "./appbuilder/services/path-filtering");
+$injector.require("androidLiveSyncServiceLocator", "./appbuilder/services/livesync/android-livesync-service");
+$injector.require("iosLiveSyncServiceLocator", "./appbuilder/services/livesync/ios-livesync-service");
+$injector.require("deviceAppDataProvider", "./appbuilder/providers/device-app-data-provider");
+$injector.requirePublic("companionAppsService", "./appbuilder/services/livesync/companion-apps-service");
+$injector.require("nativeScriptProjectCapabilities", "./appbuilder/project/nativescript-project-capabilities");
+$injector.require("cordovaProjectCapabilities", "./appbuilder/project/cordova-project-capabilities");
+$injector.require("mobilePlatformsCapabilities", "./appbuilder/mobile-platforms-capabilities");

--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -8,26 +8,84 @@ interface IDeployHelper {
 	deploy(platform?: string): IFuture<void>;
 }
 
-interface ITargetFrameworkIdentifiers {
-	Cordova: string;
-	NativeScript: string;
-}
+declare module Project {
+	interface ITargetFrameworkIdentifiers {
+		Cordova: string;
+		NativeScript: string;
+	}
 
-interface IProjectConstants {
-	PROJECT_FILE: string;
-	PROJECT_IGNORE_FILE: string;
-	DEBUG_CONFIGURATION_NAME: string;
-	DEBUG_PROJECT_FILE_NAME: string;
-	RELEASE_CONFIGURATION_NAME: string;
-	RELEASE_PROJECT_FILE_NAME: string;
-	CORE_PLUGINS_PROPERTY_NAME: string;
-	CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME: string;
-	TARGET_FRAMEWORK_IDENTIFIERS: ITargetFrameworkIdentifiers;
-	APPIDENTIFIER_PROPERTY_NAME: string;
-	EXPERIMENTAL_TAG: string;
-	NATIVESCRIPT_APP_DIR_NAME: string;
-	IMAGE_DEFINITIONS_FILE_NAME: string;
-	PACKAGE_JSON_NAME: string;
+	interface IConstants {
+		PROJECT_FILE: string;
+		PROJECT_IGNORE_FILE: string;
+		DEBUG_CONFIGURATION_NAME: string;
+		DEBUG_PROJECT_FILE_NAME: string;
+		RELEASE_CONFIGURATION_NAME: string;
+		RELEASE_PROJECT_FILE_NAME: string;
+		CORE_PLUGINS_PROPERTY_NAME: string;
+		CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME: string;
+		TARGET_FRAMEWORK_IDENTIFIERS: ITargetFrameworkIdentifiers;
+		APPIDENTIFIER_PROPERTY_NAME: string;
+		EXPERIMENTAL_TAG: string;
+		NATIVESCRIPT_APP_DIR_NAME: string;
+		IMAGE_DEFINITIONS_FILE_NAME: string;
+		PACKAGE_JSON_NAME: string;
+	}
+
+	interface ICapabilities {
+		build: boolean;
+		buildCompanion: boolean;
+		deploy: boolean
+		simulate: boolean;
+		livesync: boolean;
+		livesyncCompanion: boolean;
+		updateKendo: boolean;
+		emulate: boolean;
+		publish: boolean;
+		uploadToAppstore: boolean;
+		canChangeFrameworkVersion: boolean;
+		imageGeneration: boolean;
+		wp8Supported: boolean;
+	}
+
+	interface IData extends IDictionary<any> {
+		ProjectName: string;
+		ProjectGuid: string;
+		projectVersion : number;
+		AppIdentifier: string;
+		DisplayName: string;
+		Author: string;
+		Description: string;
+		BundleVersion: string;
+		Framework: string;
+		FrameworkVersion: string;
+		CorePlugins: string[];
+		AndroidPermissions: string[];
+		DeviceOrientations: string[];
+		AndroidHardwareAcceleration: string;
+		AndroidVersionCode: string;
+		iOSStatusBarStyle: string;
+		iOSDeviceFamily: string[];
+		iOSBackgroundMode: string[];
+		iOSDeploymentTarget: string;
+		WP8ProductID: string;
+		WP8PublisherID: string;
+		WP8Publisher: string;
+		WP8TileTitle: string;
+		WP8Capabilities: string[];
+		WP8Requirements: string[];
+		WP8SupportedResolutions: string[];
+		WPSdk?: string;
+		WP8PackageIdentityName?: string;
+		WP8WindowsPublisherName?: string;
+		CordovaPluginVariables?: any;
+	}
+
+	interface IProjectBase {
+		projectDir: string;
+		getProjectDir(): IFuture<string>;
+		projectData: IData;
+		capabilities: ICapabilities;
+	}
 }
 
 interface IPathFilteringService {
@@ -48,60 +106,4 @@ interface IDeviceLiveSyncInfo {
 
 interface ICompanionAppsService {
 	getCompanionAppIdentifier(framework: string, platform: string): string;
-}
-
-interface IProjectCapabilities {
-	build: boolean;
-	buildCompanion: boolean;
-	deploy: boolean
-	simulate: boolean;
-	livesync: boolean;
-	livesyncCompanion: boolean;
-	updateKendo: boolean;
-	emulate: boolean;
-	publish: boolean;
-	uploadToAppstore: boolean;
-	canChangeFrameworkVersion: boolean;
-	imageGeneration: boolean;
-	wp8Supported: boolean;
-}
-
-interface IProjectData extends IDictionary<any> {
-	ProjectName: string;
-	ProjectGuid: string;
-	projectVersion : number;
-	AppIdentifier: string;
-	DisplayName: string;
-	Author: string;
-	Description: string;
-	BundleVersion: string;
-	Framework: string;
-	FrameworkVersion: string;
-	CorePlugins: string[];
-	AndroidPermissions: string[];
-	DeviceOrientations: string[];
-	AndroidHardwareAcceleration: string;
-	AndroidVersionCode: string;
-	iOSStatusBarStyle: string;
-	iOSDeviceFamily: string[];
-	iOSBackgroundMode: string[];
-	iOSDeploymentTarget: string;
-	WP8ProductID: string;
-	WP8PublisherID: string;
-	WP8Publisher: string;
-	WP8TileTitle: string;
-	WP8Capabilities: string[];
-	WP8Requirements: string[];
-	WP8SupportedResolutions: string[];
-	WPSdk?: string;
-	WP8PackageIdentityName?: string;
-	WP8WindowsPublisherName?: string;
-	CordovaPluginVariables?: any;
-}
-
-interface IProjectBase {
-	projectDir: string;
-	getProjectDir(): IFuture<string>;
-	projectData: IProjectData;
-	capabilities: IProjectCapabilities;
 }

--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -37,11 +37,15 @@ interface IPathFilteringService {
 }
 
 interface IProtonLiveSyncService {
-	livesync(platform: string, deviceIdentifiers: string[], projectDir: string, filePats: string[]): IFuture<void>;
+	livesync(deviceIdentifiers: IDeviceLiveSyncInfo[], projectDir: string, filePats: string[]): IFuture<void>;
 }
 
 interface IDeviceLiveSyncInfo {
 	deviceIdentifier: string;
 	syncToApp: boolean;
 	syncToCompanion: boolean;
+}
+
+interface ICompanionAppsService {
+	getCompanionAppIdentifier(framework: string, platform: string): string;
 }

--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -37,7 +37,7 @@ interface IPathFilteringService {
 }
 
 interface IProtonLiveSyncService {
-	livesync(deviceIdentifiers: IDeviceLiveSyncInfo[], projectDir: string, filePats: string[]): IFuture<void>;
+	livesync(deviceIdentifiers: IDeviceLiveSyncInfo[], projectDir: string, filePaths: string[]): IFuture<void>;
 }
 
 interface IDeviceLiveSyncInfo {
@@ -48,4 +48,60 @@ interface IDeviceLiveSyncInfo {
 
 interface ICompanionAppsService {
 	getCompanionAppIdentifier(framework: string, platform: string): string;
+}
+
+interface IProjectCapabilities {
+	build: boolean;
+	buildCompanion: boolean;
+	deploy: boolean
+	simulate: boolean;
+	livesync: boolean;
+	livesyncCompanion: boolean;
+	updateKendo: boolean;
+	emulate: boolean;
+	publish: boolean;
+	uploadToAppstore: boolean;
+	canChangeFrameworkVersion: boolean;
+	imageGeneration: boolean;
+	wp8Supported: boolean;
+}
+
+interface IProjectData extends IDictionary<any> {
+	ProjectName: string;
+	ProjectGuid: string;
+	projectVersion : number;
+	AppIdentifier: string;
+	DisplayName: string;
+	Author: string;
+	Description: string;
+	BundleVersion: string;
+	Framework: string;
+	FrameworkVersion: string;
+	CorePlugins: string[];
+	AndroidPermissions: string[];
+	DeviceOrientations: string[];
+	AndroidHardwareAcceleration: string;
+	AndroidVersionCode: string;
+	iOSStatusBarStyle: string;
+	iOSDeviceFamily: string[];
+	iOSBackgroundMode: string[];
+	iOSDeploymentTarget: string;
+	WP8ProductID: string;
+	WP8PublisherID: string;
+	WP8Publisher: string;
+	WP8TileTitle: string;
+	WP8Capabilities: string[];
+	WP8Requirements: string[];
+	WP8SupportedResolutions: string[];
+	WPSdk?: string;
+	WP8PackageIdentityName?: string;
+	WP8WindowsPublisherName?: string;
+	CordovaPluginVariables?: any;
+}
+
+interface IProjectBase {
+	projectDir: string;
+	getProjectDir(): IFuture<string>;
+	projectData: IProjectData;
+	capabilities: IProjectCapabilities;
 }

--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -1,0 +1,37 @@
+interface ILiveSyncDeviceAppData extends Mobile.IDeviceAppData {
+	liveSyncFormat: string;
+	encodeLiveSyncHostUri(hostUri: string): string;
+	getLiveSyncNotSupportedError(): string;
+}
+
+interface IDeployHelper {
+	deploy(platform?: string): IFuture<void>;
+}
+
+interface ITargetFrameworkIdentifiers {
+	Cordova: string;
+	NativeScript: string;
+}
+
+interface IProjectConstants {
+	PROJECT_FILE: string;
+	PROJECT_IGNORE_FILE: string;
+	DEBUG_CONFIGURATION_NAME: string;
+	DEBUG_PROJECT_FILE_NAME: string;
+	RELEASE_CONFIGURATION_NAME: string;
+	RELEASE_PROJECT_FILE_NAME: string;
+	CORE_PLUGINS_PROPERTY_NAME: string;
+	CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME: string;
+	TARGET_FRAMEWORK_IDENTIFIERS: ITargetFrameworkIdentifiers;
+	APPIDENTIFIER_PROPERTY_NAME: string;
+	EXPERIMENTAL_TAG: string;
+	NATIVESCRIPT_APP_DIR_NAME: string;
+	IMAGE_DEFINITIONS_FILE_NAME: string;
+	PACKAGE_JSON_NAME: string;
+}
+
+interface IPathFilteringService {
+	getRulesFromFile(file: string) : string[];
+	filterIgnoredFiles(files: string[], rules: string[], rootDir: string) :string[];
+	isFileExcluded(file: string, rules: string[], rootDir: string): boolean
+}

--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -35,3 +35,13 @@ interface IPathFilteringService {
 	filterIgnoredFiles(files: string[], rules: string[], rootDir: string) :string[];
 	isFileExcluded(file: string, rules: string[], rootDir: string): boolean
 }
+
+interface IProtonLiveSyncService {
+	livesync(platform: string, deviceIdentifiers: string[], projectDir: string, filePats: string[]): IFuture<void>;
+}
+
+interface IDeviceLiveSyncInfo {
+	deviceIdentifier: string;
+	syncToApp: boolean;
+	syncToCompanion: boolean;
+}

--- a/appbuilder/mobile-platforms-capabilities.ts
+++ b/appbuilder/mobile-platforms-capabilities.ts
@@ -1,0 +1,38 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+export class MobilePlatformsCapabilities implements Mobile.IPlatformsCapabilities {
+	private platformCapabilities: IDictionary<Mobile.IPlatformCapabilities>;
+
+	constructor(private $errors: IErrors) { }
+
+	public getPlatformNames(): string[]{
+		return _.keys(this.getAllCapabilities());
+	}
+
+	public getAllCapabilities(): IDictionary<Mobile.IPlatformCapabilities> {
+		this.platformCapabilities = this.platformCapabilities || {
+			iOS: {
+				wirelessDeploy: true,
+				cableDeploy: true,
+				companion: true,
+				hostPlatformsForDeploy: ["win32", "darwin"]
+			},
+			Android: {
+				wirelessDeploy: true,
+				cableDeploy: true,
+				companion: true,
+				hostPlatformsForDeploy: ["win32", "darwin", "linux"]
+			},
+			WP8: {
+				wirelessDeploy: true,
+				cableDeploy: false,
+				companion: true,
+				hostPlatformsForDeploy: ["win32"]
+			}
+		};
+
+		return this.platformCapabilities;
+	}
+}
+$injector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilities);

--- a/appbuilder/project-constants.ts
+++ b/appbuilder/project-constants.ts
@@ -1,7 +1,7 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-export class ProjectConstants implements IProjectConstants {
+export class ProjectConstants implements Project.IConstants {
 	public PROJECT_FILE = ".abproject";
 	public PROJECT_IGNORE_FILE = ".abignore";
 	public DEBUG_CONFIGURATION_NAME = "debug";

--- a/appbuilder/project-constants.ts
+++ b/appbuilder/project-constants.ts
@@ -1,0 +1,25 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+export class ProjectConstants implements IProjectConstants {
+	public PROJECT_FILE = ".abproject";
+	public PROJECT_IGNORE_FILE = ".abignore";
+	public DEBUG_CONFIGURATION_NAME = "debug";
+	public DEBUG_PROJECT_FILE_NAME = ".debug.abproject";
+	public RELEASE_CONFIGURATION_NAME = "release";
+	public RELEASE_PROJECT_FILE_NAME = ".release.abproject";
+	public CORE_PLUGINS_PROPERTY_NAME = "CorePlugins";
+	public CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME = "CordovaPluginVariables";
+	public APPIDENTIFIER_PROPERTY_NAME = "AppIdentifier";
+	public EXPERIMENTAL_TAG = "Experimental";
+	public NATIVESCRIPT_APP_DIR_NAME = "app";
+	public IMAGE_DEFINITIONS_FILE_NAME = 'image-definitions.json';
+	public PACKAGE_JSON_NAME = "package.json";
+
+	public TARGET_FRAMEWORK_IDENTIFIERS = {
+		Cordova: "Cordova",
+		NativeScript: "NativeScript"
+	};
+}
+
+$injector.register("projectConstants", ProjectConstants);

--- a/appbuilder/project/cordova-project-capabilities.ts
+++ b/appbuilder/project/cordova-project-capabilities.ts
@@ -1,7 +1,7 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
 
-export class CordovaProjectCapabilities implements IProjectCapabilities {
+export class CordovaProjectCapabilities implements Project.ICapabilities {
 	public get build(): boolean {
 		return true;
 	}

--- a/appbuilder/project/cordova-project-capabilities.ts
+++ b/appbuilder/project/cordova-project-capabilities.ts
@@ -1,0 +1,57 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+export class CordovaProjectCapabilities implements IProjectCapabilities {
+	public get build(): boolean {
+		return true;
+	}
+
+	public get buildCompanion(): boolean {
+		return true;
+	}
+
+	public get deploy(): boolean {
+		return true;
+	}
+
+	public get simulate(): boolean {
+		return true;
+	}
+
+	public get livesync(): boolean {
+		return true;
+	}
+
+	public get livesyncCompanion(): boolean {
+		return true;
+	}
+
+	public get updateKendo(): boolean {
+		return true;
+	}
+
+	public get emulate(): boolean {
+		return true;
+	}
+
+	public get publish(): boolean {
+		return false;
+	}
+
+	public get uploadToAppstore(): boolean {
+		return true;
+	}
+
+	public get canChangeFrameworkVersion(): boolean {
+		return true;
+	}
+
+	public get imageGeneration(): boolean {
+		return true;
+	}
+
+	public get wp8Supported(): boolean {
+		return true;
+	}
+}
+$injector.register("cordovaProjectCapabilities", CordovaProjectCapabilities);

--- a/appbuilder/project/nativescript-project-capabilities.ts
+++ b/appbuilder/project/nativescript-project-capabilities.ts
@@ -1,7 +1,7 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
 
-export class NativeScriptProjectCapabilities implements IProjectCapabilities {
+export class NativeScriptProjectCapabilities implements Project.ICapabilities {
 	public get build(): boolean {
 		return true;
 	}

--- a/appbuilder/project/nativescript-project-capabilities.ts
+++ b/appbuilder/project/nativescript-project-capabilities.ts
@@ -1,0 +1,57 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+export class NativeScriptProjectCapabilities implements IProjectCapabilities {
+	public get build(): boolean {
+		return true;
+	}
+
+	public get buildCompanion(): boolean {
+		return true;
+	}
+
+	public get deploy(): boolean {
+		return true;
+	}
+
+	public get simulate(): boolean {
+		return false;
+	}
+
+	public get livesync(): boolean {
+		return true;
+	}
+
+	public get livesyncCompanion(): boolean {
+		return true;
+	}
+
+	public get updateKendo(): boolean {
+		return false;
+	}
+
+	public get emulate(): boolean {
+		return true;
+	}
+
+	public get publish(): boolean {
+		return false;
+	}
+
+	public get uploadToAppstore(): boolean {
+		return true;
+	}
+
+	public get canChangeFrameworkVersion(): boolean {
+		return true;
+	}
+
+	public get imageGeneration(): boolean {
+		return true;
+	}
+
+	public get wp8Supported(): boolean {
+		return false;
+	}
+}
+$injector.register("nativeScriptProjectCapabilities", NativeScriptProjectCapabilities);

--- a/appbuilder/project/project-base.ts
+++ b/appbuilder/project/project-base.ts
@@ -3,19 +3,19 @@
 
 import Future = require("fibers/future");
 import * as path from "path";
-export class Project implements IProjectBase {
-	constructor(private $cordovaProjectCapabilities: IProjectCapabilities,
+export class Project implements Project.IProjectBase {
+	constructor(private $cordovaProjectCapabilities: Project.ICapabilities,
 		private $fs: IFileSystem,
 		private $logger: ILogger,
-		private $nativeScriptProjectCapabilities: IProjectCapabilities,
-		private $projectConstants: IProjectConstants) { }
+		private $nativeScriptProjectCapabilities: Project.ICapabilities,
+		private $projectConstants: Project.IConstants) { }
 
 	public projectDir: string;
 	public getProjectDir(): IFuture<string> {
 		return Future.fromResult(this.projectDir);
 	}
-	// TODO: Move IProjectData to common
-	public get projectData(): IProjectData {
+
+	public get projectData(): Project.IData {
 		if(this.projectDir) {
 			let projectFile = path.join(this.projectDir, this.$projectConstants.PROJECT_FILE);
 			let jsonContent = this.$fs.readJson(projectFile).wait();
@@ -26,7 +26,7 @@ export class Project implements IProjectBase {
 		return null;
 	}
 
-	public get capabilities(): IProjectCapabilities {
+	public get capabilities(): Project.ICapabilities {
 		let projectData = this.projectData;
 		if(projectData) {
 			if(projectData.Framework && projectData.Framework.toLowerCase() === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()) {

--- a/appbuilder/project/project-base.ts
+++ b/appbuilder/project/project-base.ts
@@ -1,0 +1,42 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import Future = require("fibers/future");
+import * as path from "path";
+export class Project implements IProjectBase {
+	constructor(private $cordovaProjectCapabilities: IProjectCapabilities,
+		private $fs: IFileSystem,
+		private $logger: ILogger,
+		private $nativeScriptProjectCapabilities: IProjectCapabilities,
+		private $projectConstants: IProjectConstants) { }
+
+	public projectDir: string;
+	public getProjectDir(): IFuture<string> {
+		return Future.fromResult(this.projectDir);
+	}
+	// TODO: Move IProjectData to common
+	public get projectData(): IProjectData {
+		if(this.projectDir) {
+			let projectFile = path.join(this.projectDir, this.$projectConstants.PROJECT_FILE);
+			let jsonContent = this.$fs.readJson(projectFile).wait();
+			this.$logger.trace("Project data is: ", jsonContent);
+			return jsonContent;
+		}
+
+		return null;
+	}
+
+	public get capabilities(): IProjectCapabilities {
+		let projectData = this.projectData;
+		if(projectData) {
+			if(projectData.Framework && projectData.Framework.toLowerCase() === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()) {
+				return this.$nativeScriptProjectCapabilities;
+			} else if(projectData.Framework && projectData.Framework.toLowerCase() === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()) {
+				return this.$cordovaProjectCapabilities;
+			}
+		}
+
+		return null;
+	}
+}
+$injector.register("project", Project);

--- a/appbuilder/proton-bootstrap.ts
+++ b/appbuilder/proton-bootstrap.ts
@@ -17,22 +17,7 @@ $injector.requirePublicClass("deviceEmitter", "./appbuilder/device-emitter");
 $injector.requirePublicClass("deviceLogProvider", "./appbuilder/device-log-provider");
 import {installUncaughtExceptionListener} from "../errors";
 installUncaughtExceptionListener();
-$injector.register("deviceAppDataProvider", {
-	createFactoryRules(): IDictionary<Mobile.IDeviceAppDataFactoryRule> {
-		return {
-				Android: {
-					vanilla: ""
-				},
-				iOS: {
-					vanilla: ""
-				},
-				WP8: {
-					vanilla: ""
-				}
-			};
-		}
-	}
-);
+
 $injector.register("emulatorSettingsService", {
 	canStart(platform: string): IFuture<boolean> {
 		return Future.fromResult(true);
@@ -73,5 +58,58 @@ class Project {
 
 		return null;
 	}
+
+	public get capabilities(): any {
+		let projectData = this.projectData;
+		if(projectData) {
+			if(projectData.Framework && projectData.Framework.toLowerCase() === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()) {
+				return {
+					build: true,
+					buildCompanion: true,
+					deploy: true,
+					simulate: false,
+					livesync: false,
+					livesyncCompanion: true,
+					updateKendo: false,
+					emulate: true,
+					publish: false,
+					uploadToAppstore: true,
+					canChangeFrameworkVersion: true,
+					imageGeneration: true,
+					wp8Supported: false
+				};
+			} else if(projectData.Framework && projectData.Framework.toLowerCase() === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()) {
+				return {
+					build: true,
+					buildCompanion: true,
+					deploy: true,
+					simulate: true,
+					livesync: true,
+					livesyncCompanion: true,
+					updateKendo: true,
+					emulate: true,
+					publish: false,
+					uploadToAppstore: true,
+					canChangeFrameworkVersion: true,
+					imageGeneration: true,
+					wp8Supported: true
+				};
+			}
+		}
+
+		return null;
+
+	}
 }
 $injector.register("project", Project);
+
+$injector.require("projectFilesProvider", "./appbuilder/providers/project-files-provider");
+$injector.require("pathFilteringService", "./appbuilder/services/path-filtering-service");
+
+$injector.requirePublic("liveSyncService", "./appbuilder/services/livesync/livesync-service");
+
+$injector.require("liveSyncProvider", "./appbuilder/providers/livesync-provider");
+$injector.require("androidLiveSyncServiceLocator", "./appbuilder/services/livesync/android-livesync-service");
+$injector.require("iosLiveSyncServiceLocator", "./appbuilder/services/livesync/ios-livesync-service");
+$injector.require("deviceAppDataProvider", "./appbuilder/providers/device-app-data-provider");
+

--- a/appbuilder/proton-bootstrap.ts
+++ b/appbuilder/proton-bootstrap.ts
@@ -45,3 +45,33 @@ $injector.register("emulatorSettingsService", {
 // When debugging uncomment the lines below and comment the line #6 (requiring logger).
 // $injector.require("logger", "./logger");
 // $injector.resolve("logger").setLevel("TRACE");
+
+// Mock as it is used in LiveSync logic to deploy on devices.
+// When called from Proton we'll not deploy on device, just livesync.
+$injector.register("deployHelper", {
+	deploy: (platform?: string) => Future.fromResult()
+});
+
+$injector.require("liveSyncProvider", "./appbuilder/providers/livesync-provider");
+$injector.require("projectConstants", "./appbuilder/project-constants");
+
+import * as path from "path";
+class Project {
+	constructor(private $projectConstants: IProjectConstants,
+	private $fs: IFileSystem) { }
+	public projectDir: string;
+	public getProjectDir(): IFuture<string> {
+		return Future.fromResult(this.projectDir);
+	}
+
+	public get projectData(): any {
+		if(this.projectDir) {
+			let projectFile = path.join(this.projectDir, this.$projectConstants.PROJECT_FILE);
+			let jsonContent = this.$fs.readJson(projectFile).wait();
+			return jsonContent;
+		}
+
+		return null;
+	}
+}
+$injector.register("project", Project);

--- a/appbuilder/proton-bootstrap.ts
+++ b/appbuilder/proton-bootstrap.ts
@@ -1,14 +1,13 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-require("../bootstrap");
+require("./appbuilder-bootstrap");
 $injector.require("messages", "./messages/messages");
-// $injector.require("logger", "./appbuilder/proton-logger");
+$injector.require("logger", "./appbuilder/proton-logger");
 
 import Future = require("fibers/future");
 import {OptionsBase} from "../options";
 $injector.require("staticConfig", "./appbuilder/proton-static-config");
-$injector.require("mobilePlatformsCapabilities", "./appbuilder/mobile-platforms-capabilities");
 $injector.register("config", {});
 // Proton will track the features and exceptions, so no need of analyticsService here.
 $injector.register("analyiticsService", {});
@@ -28,8 +27,8 @@ $injector.register("emulatorSettingsService", {
 });
 
 // When debugging uncomment the lines below and comment the line #6 (requiring logger).
-$injector.require("logger", "./logger");
-$injector.resolve("logger").setLevel("TRACE");
+// $injector.require("logger", "./logger");
+// $injector.resolve("logger").setLevel("TRACE");
 
 // Mock as it is used in LiveSync logic to deploy on devices.
 // When called from Proton we'll not deploy on device, just livesync.
@@ -37,77 +36,6 @@ $injector.register("deployHelper", {
 	deploy: (platform?: string) => Future.fromResult()
 });
 
-$injector.require("projectConstants", "./appbuilder/project-constants");
-
-import * as path from "path";
-class Project {
-	constructor(private $projectConstants: IProjectConstants,
-	private $fs: IFileSystem) { }
-	public projectDir: string;
-	public getProjectDir(): IFuture<string> {
-		return Future.fromResult(this.projectDir);
-	}
-
-	public get projectData(): any {
-		if(this.projectDir) {
-			let projectFile = path.join(this.projectDir, this.$projectConstants.PROJECT_FILE);
-			let jsonContent = this.$fs.readJson(projectFile).wait();
-			return jsonContent;
-		}
-
-		return null;
-	}
-
-	public get capabilities(): any {
-		let projectData = this.projectData;
-		if(projectData) {
-			if(projectData.Framework && projectData.Framework.toLowerCase() === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()) {
-				return {
-					build: true,
-					buildCompanion: true,
-					deploy: true,
-					simulate: false,
-					livesync: true,
-					livesyncCompanion: true,
-					updateKendo: false,
-					emulate: true,
-					publish: false,
-					uploadToAppstore: true,
-					canChangeFrameworkVersion: true,
-					imageGeneration: true,
-					wp8Supported: false
-				};
-			} else if(projectData.Framework && projectData.Framework.toLowerCase() === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()) {
-				return {
-					build: true,
-					buildCompanion: true,
-					deploy: true,
-					simulate: true,
-					livesync: true,
-					livesyncCompanion: true,
-					updateKendo: true,
-					emulate: true,
-					publish: false,
-					uploadToAppstore: true,
-					canChangeFrameworkVersion: true,
-					imageGeneration: true,
-					wp8Supported: true
-				};
-			}
-		}
-
-		return null;
-	}
-}
-$injector.register("project", Project);
-
-$injector.require("projectFilesProvider", "./appbuilder/providers/project-files-provider");
-$injector.require("pathFilteringService", "./appbuilder/services/path-filtering");
-
-$injector.requirePublic("liveSyncService", "./appbuilder/services/livesync/livesync-service");
-
 $injector.require("liveSyncProvider", "./appbuilder/providers/livesync-provider");
-$injector.require("androidLiveSyncServiceLocator", "./appbuilder/services/livesync/android-livesync-service");
-$injector.require("iosLiveSyncServiceLocator", "./appbuilder/services/livesync/ios-livesync-service");
-$injector.require("deviceAppDataProvider", "./appbuilder/providers/device-app-data-provider");
-$injector.requirePublic("companionAppsService", "./appbuilder/services/livesync/companion-apps-service");
+$injector.requirePublic("liveSyncService", "./appbuilder/services/livesync/livesync-service");
+$injector.require("project", "./appbuilder/project/project-base");

--- a/appbuilder/proton-bootstrap.ts
+++ b/appbuilder/proton-bootstrap.ts
@@ -3,14 +3,14 @@
 
 require("../bootstrap");
 $injector.require("messages", "./messages/messages");
-$injector.require("logger", "./appbuilder/proton-logger");
+// $injector.require("logger", "./appbuilder/proton-logger");
 
 import Future = require("fibers/future");
 import {OptionsBase} from "../options";
 $injector.require("staticConfig", "./appbuilder/proton-static-config");
-$injector.register("mobilePlatformsCapabilities", {});
+$injector.require("mobilePlatformsCapabilities", "./appbuilder/mobile-platforms-capabilities");
 $injector.register("config", {});
-// Proton will track the features and execptions, so no need of analyticsService here.
+// Proton will track the features and exceptions, so no need of analyticsService here.
 $injector.register("analyiticsService", {});
 $injector.register("options", $injector.resolve(OptionsBase, {options: {}, defaultProfileDir: ""}));
 $injector.requirePublicClass("deviceEmitter", "./appbuilder/device-emitter");
@@ -28,8 +28,8 @@ $injector.register("emulatorSettingsService", {
 });
 
 // When debugging uncomment the lines below and comment the line #6 (requiring logger).
-// $injector.require("logger", "./logger");
-// $injector.resolve("logger").setLevel("TRACE");
+$injector.require("logger", "./logger");
+$injector.resolve("logger").setLevel("TRACE");
 
 // Mock as it is used in LiveSync logic to deploy on devices.
 // When called from Proton we'll not deploy on device, just livesync.
@@ -37,7 +37,6 @@ $injector.register("deployHelper", {
 	deploy: (platform?: string) => Future.fromResult()
 });
 
-$injector.require("liveSyncProvider", "./appbuilder/providers/livesync-provider");
 $injector.require("projectConstants", "./appbuilder/project-constants");
 
 import * as path from "path";
@@ -68,7 +67,7 @@ class Project {
 					buildCompanion: true,
 					deploy: true,
 					simulate: false,
-					livesync: false,
+					livesync: true,
 					livesyncCompanion: true,
 					updateKendo: false,
 					emulate: true,
@@ -98,13 +97,12 @@ class Project {
 		}
 
 		return null;
-
 	}
 }
 $injector.register("project", Project);
 
 $injector.require("projectFilesProvider", "./appbuilder/providers/project-files-provider");
-$injector.require("pathFilteringService", "./appbuilder/services/path-filtering-service");
+$injector.require("pathFilteringService", "./appbuilder/services/path-filtering");
 
 $injector.requirePublic("liveSyncService", "./appbuilder/services/livesync/livesync-service");
 
@@ -112,4 +110,4 @@ $injector.require("liveSyncProvider", "./appbuilder/providers/livesync-provider"
 $injector.require("androidLiveSyncServiceLocator", "./appbuilder/services/livesync/android-livesync-service");
 $injector.require("iosLiveSyncServiceLocator", "./appbuilder/services/livesync/ios-livesync-service");
 $injector.require("deviceAppDataProvider", "./appbuilder/providers/device-app-data-provider");
-
+$injector.requirePublic("companionAppsService", "./appbuilder/services/livesync/companion-apps-service");

--- a/appbuilder/providers/appbuilder-livesync-provider-base.ts
+++ b/appbuilder/providers/appbuilder-livesync-provider-base.ts
@@ -1,0 +1,30 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import Future = require("fibers/future");
+
+export abstract class AppBuilderLiveSyncProviderBase implements ILiveSyncProvider {
+	constructor(private $androidLiveSyncServiceLocator: {factory: Function},
+		private $iosLiveSyncServiceLocator: {factory: Function}) { }
+
+	public get platformSpecificLiveSyncServices(): IDictionary<any> {
+		return {
+			android: (_device: Mobile.IDevice, $injector: IInjector): IPlatformLiveSyncService => {
+				return $injector.resolve(this.$androidLiveSyncServiceLocator.factory, {_device: _device});
+			},
+			ios: (_device: Mobile.IDevice, $injector: IInjector) => {
+				return $injector.resolve(this.$iosLiveSyncServiceLocator.factory, {_device: _device});
+			}
+		};
+	}
+
+	public abstract buildForDevice(device: Mobile.IDevice): IFuture<string>;
+
+	public preparePlatformForSync(platform: string): IFuture<void> {
+		return Future.fromResult();
+	}
+
+	public canExecuteFastSync(filePath: string): boolean {
+		return false;
+	}
+}

--- a/appbuilder/providers/device-app-data-provider.ts
+++ b/appbuilder/providers/device-app-data-provider.ts
@@ -1,7 +1,7 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
 
-import deviceAppDataBaseLib = require("../../mobile/device-app-data/device-app-data-base");
+import { DeviceAppDataBase } from "../../mobile/device-app-data/device-app-data-base";
 import Future = require("fibers/future");
 import querystring = require("querystring");
 import * as path from "path";
@@ -14,7 +14,7 @@ let CHECK_LIVESYNC_INTENT_NAME = "com.telerik.IsLiveSyncSupported";
 let IOS_PROJECT_PATH = "/Documents";
 let NATIVESCRIPT_ION_APP_IDENTIFIER = "com.telerik.NativeScript";
 
-export class AndroidAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+export class AndroidAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	private _deviceProjectRootPath: string = null;
 	private _liveSyncVersion: number;
 
@@ -79,7 +79,7 @@ export class AndroidAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase
 	}
 }
 
-export class AndroidCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+export class AndroidCompanionAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	constructor(_appIdentifier: string,
 		public device: Mobile.IDevice,
 		public platform: string) {
@@ -107,7 +107,7 @@ export class AndroidCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAp
 	}
 }
 
-export class AndroidNativeScriptCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+export class AndroidNativeScriptCompanionAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	constructor(_appIdentifier: string,
 		public device: Mobile.IDevice,
 		public platform: string) {
@@ -135,7 +135,7 @@ export class AndroidNativeScriptCompanionAppIdentifier extends deviceAppDataBase
 	}
 }
 
-export class IOSAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+export class IOSAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	private _deviceProjectRootPath: string = null;
 
 	constructor(_appIdentifier: string,
@@ -175,7 +175,7 @@ export class IOSAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase imp
 	}
 }
 
-export class IOSCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+export class IOSCompanionAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	constructor(public device: Mobile.IDevice,
 		public platform: string) {
 		super("com.telerik.Icenium");
@@ -202,7 +202,7 @@ export class IOSCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDat
 	}
 }
 
-export class IOSNativeScriptCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+export class IOSNativeScriptCompanionAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	constructor(public device: Mobile.IDevice,
 		public platform: string) {
 		super(NATIVESCRIPT_ION_APP_IDENTIFIER);
@@ -229,7 +229,7 @@ export class IOSNativeScriptCompanionAppIdentifier extends deviceAppDataBaseLib.
 	}
 }
 
-export class WP8CompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+export class WP8CompanionAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	constructor(public device: Mobile.IDevice,
 		public platform: string) {
 		super("{9155af5b-e7ed-486d-bc6b-35087fb59ecc}");
@@ -257,7 +257,7 @@ export class WP8CompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDat
 }
 
 export class DeviceAppDataProvider implements Mobile.IDeviceAppDataProvider {
-	constructor(private $project: Project.IProject) { }
+	constructor(private $project: any) { }
 
 	public createFactoryRules(): IDictionary<Mobile.IDeviceAppDataFactoryRule> {
 		let rules: IDictionary<IDictionary<Mobile.IDeviceAppDataFactoryRule>>= {

--- a/appbuilder/providers/device-app-data-provider.ts
+++ b/appbuilder/providers/device-app-data-provider.ts
@@ -3,14 +3,14 @@
 
 import { DeviceAppDataBase } from "../../mobile/device-app-data/device-app-data-base";
 import Future = require("fibers/future");
-import querystring = require("querystring");
+import * as querystring from "querystring";
 import * as path from "path";
-import util = require("util");
+import * as util from "util";
 
 const DEVICE_TMP_DIR_FORMAT_V2 = "/data/local/tmp/12590FAA-5EDD-4B12-856D-F52A0A1599F2/%s";
 const DEVICE_TMP_DIR_FORMAT_V3 = "/mnt/sdcard/Android/data/%s/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2";
 const CHECK_LIVESYNC_INTENT_NAME = "com.telerik.IsLiveSyncSupported";
-const IOS_PROJECT_PATH = "/Library/Application Support/12590FAA-5EDD-4B12-856D-F52A0A1599F2";
+const IOS_PROJECT_PATH = "/Library/Application Support/LiveSync";
 const IOS_NS_PROJECT_PATH = "/tmp/Application Support/LiveSync";
 
 export class AndroidAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
@@ -82,7 +82,7 @@ export class AndroidCompanionAppIdentifier extends DeviceAppDataBase implements 
 		public device: Mobile.IDevice,
 		public platform: string,
 		private $companionAppsService: ICompanionAppsService,
-		private $projectConstants: IProjectConstants) {
+		private $projectConstants: Project.IConstants) {
 		super($companionAppsService.getCompanionAppIdentifier($projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, platform));
 	}
 
@@ -112,7 +112,7 @@ export class AndroidNativeScriptCompanionAppIdentifier extends DeviceAppDataBase
 		public device: Mobile.IDevice,
 		public platform: string,
 		private $companionAppsService: ICompanionAppsService,
-		private $projectConstants: IProjectConstants) {
+		private $projectConstants: Project.IConstants) {
 		super($companionAppsService.getCompanionAppIdentifier($projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript, platform));
 	}
 
@@ -221,7 +221,7 @@ export class IOSCompanionAppIdentifier extends DeviceAppDataBase implements ILiv
 	constructor(public device: Mobile.IDevice,
 		public platform: string,
 		private $companionAppsService: ICompanionAppsService,
-		private $projectConstants: IProjectConstants) {
+		private $projectConstants: Project.IConstants) {
 		super($companionAppsService.getCompanionAppIdentifier($projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, platform));
 	}
 
@@ -250,7 +250,7 @@ export class IOSNativeScriptCompanionAppIdentifier extends DeviceAppDataBase imp
 	constructor(public device: Mobile.IDevice,
 		public platform: string,
 		private $companionAppsService: ICompanionAppsService,
-		private $projectConstants: IProjectConstants) {
+		private $projectConstants: Project.IConstants) {
 		super($companionAppsService.getCompanionAppIdentifier($projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript, platform));
 	}
 

--- a/appbuilder/providers/device-app-data-provider.ts
+++ b/appbuilder/providers/device-app-data-provider.ts
@@ -1,0 +1,293 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import deviceAppDataBaseLib = require("../../mobile/device-app-data/device-app-data-base");
+import Future = require("fibers/future");
+import querystring = require("querystring");
+import * as path from "path";
+import util = require("util");
+
+let ANDROID_PROJECT_PATH = "/mnt/sdcard/Icenium/";
+let DEVICE_TMP_DIR_FORMAT_V2 = "/data/local/tmp/12590FAA-5EDD-4B12-856D-F52A0A1599F2/%s";
+let DEVICE_TMP_DIR_FORMAT_V3 = "/mnt/sdcard/Android/data/%s/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2";
+let CHECK_LIVESYNC_INTENT_NAME = "com.telerik.IsLiveSyncSupported";
+let IOS_PROJECT_PATH = "/Documents";
+let NATIVESCRIPT_ION_APP_IDENTIFIER = "com.telerik.NativeScript";
+
+export class AndroidAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+	private _deviceProjectRootPath: string = null;
+	private _liveSyncVersion: number;
+
+	constructor(_appIdentifier: string,
+		public device: Mobile.IDevice,
+		public platform: string,
+		private $errors: IErrors,
+		private $deployHelper: IDeployHelper,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
+		super(_appIdentifier);
+	}
+
+	public get deviceProjectRootPath(): string {
+		if (!this._deviceProjectRootPath) {
+			let deviceTmpDirFormat = "";
+
+			let version = this.getLiveSyncVersion().wait();
+			if (version === 2) {
+				deviceTmpDirFormat = DEVICE_TMP_DIR_FORMAT_V2;
+			} else if (version === 3) {
+				deviceTmpDirFormat = DEVICE_TMP_DIR_FORMAT_V3;
+			} else {
+				this.$errors.failWithoutHelp(`Unsupported LiveSync version: ${version}`);
+			}
+
+			this._deviceProjectRootPath = this.getDeviceProjectRootPath(util.format(deviceTmpDirFormat, this.appIdentifier));
+		}
+
+		return this._deviceProjectRootPath;
+	}
+
+	public get liveSyncFormat(): string {
+		return null;
+	}
+
+	public encodeLiveSyncHostUri(hostUri: string): string {
+		return hostUri;
+	}
+
+	public getLiveSyncNotSupportedError(): string {
+		return `You can't LiveSync on device with id ${this.device.deviceInfo.identifier}! Deploy the app with LiveSync enabled and wait for the initial start up before LiveSyncing.`;
+	}
+
+	public isLiveSyncSupported(): IFuture<boolean> {
+		return (() => {
+			let isApplicationInstalled = this.device.applicationManager.isApplicationInstalled(this.appIdentifier).wait();
+			if (!isApplicationInstalled) {
+				this.$deployHelper.deploy(this.$devicePlatformsConstants.Android.toLowerCase()).wait();
+			}
+
+		 	return this.getLiveSyncVersion().wait() !== 0;
+		}).future<boolean>()();
+	}
+
+	private getLiveSyncVersion(): IFuture<number> {
+		return (() => {
+			if (!this._liveSyncVersion) {
+				this._liveSyncVersion = (<Mobile.IAndroidDevice>this.device).adb.sendBroadcastToDevice(CHECK_LIVESYNC_INTENT_NAME, {"app-id": this.appIdentifier}).wait();
+			}
+			return this._liveSyncVersion;
+		}).future<number>()();
+	}
+}
+
+export class AndroidCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+	constructor(_appIdentifier: string,
+		public device: Mobile.IDevice,
+		public platform: string) {
+		super("com.telerik.AppBuilder");
+	}
+
+	public get deviceProjectRootPath(): string {
+		return this.getDeviceProjectRootPath(path.join(ANDROID_PROJECT_PATH, this.appIdentifier));
+	}
+
+	public get liveSyncFormat(): string {
+		return "%s/Mist/MobilePackage/redirect?token=%s";
+	}
+
+	public encodeLiveSyncHostUri(hostUri: string): string {
+		return hostUri;
+	}
+
+	public getLiveSyncNotSupportedError(): string {
+		return `Cannot LiveSync changes to the companion app. The companion app is not installed on ${this.device.deviceInfo.identifier}.`;
+	}
+
+	public isLiveSyncSupported(): IFuture<boolean> {
+		return this.device.applicationManager.isApplicationInstalled(this.appIdentifier);
+	}
+}
+
+export class AndroidNativeScriptCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+	constructor(_appIdentifier: string,
+		public device: Mobile.IDevice,
+		public platform: string) {
+		super(NATIVESCRIPT_ION_APP_IDENTIFIER);
+	}
+
+	public get deviceProjectRootPath(): string {
+		return util.format(DEVICE_TMP_DIR_FORMAT_V3, this.appIdentifier);
+	}
+
+	public get liveSyncFormat(): string {
+		return "%s/Mist/MobilePackage/nsredirect?token=%s";
+	}
+
+	public encodeLiveSyncHostUri(hostUri: string): string {
+		return hostUri;
+	}
+
+	public getLiveSyncNotSupportedError(): string {
+		return `Cannot LiveSync changes to the NativeScript companion app. The NativeScript companion app is not installed on ${this.device.deviceInfo.identifier}.`;
+	}
+
+	public isLiveSyncSupported(): IFuture<boolean> {
+		return this.device.applicationManager.isApplicationInstalled(this.appIdentifier);
+	}
+}
+
+export class IOSAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+	private _deviceProjectRootPath: string = null;
+
+	constructor(_appIdentifier: string,
+		public device: Mobile.IDevice,
+		public platform: string,
+		private $iOSSimResolver: Mobile.IiOSSimResolver) {
+		super(_appIdentifier);
+	}
+
+	public get deviceProjectRootPath(): string {
+		if (!this._deviceProjectRootPath) {
+			if (this.device.isEmulator) {
+				let applicationPath = this.$iOSSimResolver.iOSSim.getApplicationPath(this.device.deviceInfo.identifier, this.appIdentifier);
+				this._deviceProjectRootPath = path.join(applicationPath, "www");
+			} else {
+				this._deviceProjectRootPath = IOS_PROJECT_PATH;
+			}
+		}
+
+		return this._deviceProjectRootPath;
+	}
+
+	get liveSyncFormat(): string {
+		return null;
+	}
+
+	encodeLiveSyncHostUri(hostUri: string): string {
+		return querystring.escape(hostUri);
+	}
+
+	getLiveSyncNotSupportedError(): string {
+		return "";
+	}
+
+	isLiveSyncSupported(): IFuture<boolean> {
+		return Future.fromResult(true);
+	}
+}
+
+export class IOSCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+	constructor(public device: Mobile.IDevice,
+		public platform: string) {
+		super("com.telerik.Icenium");
+	}
+
+	public get deviceProjectRootPath(): string {
+		return IOS_PROJECT_PATH;
+	}
+
+	public get liveSyncFormat(): string {
+		return "icenium://%s?LiveSyncToken=%s";
+	}
+
+	public encodeLiveSyncHostUri(hostUri: string): string {
+		return querystring.escape(hostUri);
+	}
+
+	public getLiveSyncNotSupportedError(): string {
+		return "";
+	}
+
+	public isLiveSyncSupported(): IFuture<boolean> {
+		return Future.fromResult(true);
+	}
+}
+
+export class IOSNativeScriptCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+	constructor(public device: Mobile.IDevice,
+		public platform: string) {
+		super(NATIVESCRIPT_ION_APP_IDENTIFIER);
+	}
+
+	public get deviceProjectRootPath(): string {
+		return IOS_PROJECT_PATH;
+	}
+
+	public get liveSyncFormat(): string {
+		return "nativescript://%s?LiveSyncToken=%s";
+	}
+
+	public encodeLiveSyncHostUri(hostUri: string): string {
+		return querystring.escape(hostUri);
+	}
+
+	public getLiveSyncNotSupportedError(): string {
+		return "";
+	}
+
+	public isLiveSyncSupported(): IFuture<boolean> {
+		return Future.fromResult(true);
+	}
+}
+
+export class WP8CompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
+	constructor(public device: Mobile.IDevice,
+		public platform: string) {
+		super("{9155af5b-e7ed-486d-bc6b-35087fb59ecc}");
+	}
+
+	public get deviceProjectRootPath(): string {
+		return ""; // this is used only on Android for Lollipop
+	}
+
+	public get liveSyncFormat(): string {
+		return "%s/Mist/MobilePackage/redirect?token=%s";
+	}
+
+	public encodeLiveSyncHostUri(hostUri: string): string {
+		return hostUri;
+	}
+
+	public isLiveSyncSupported(): IFuture<boolean> {
+		return Future.fromResult(true);
+	}
+
+	public getLiveSyncNotSupportedError(): string {
+		return "";
+	}
+}
+
+export class DeviceAppDataProvider implements Mobile.IDeviceAppDataProvider {
+	constructor(private $project: Project.IProject) { }
+
+	public createFactoryRules(): IDictionary<Mobile.IDeviceAppDataFactoryRule> {
+		let rules: IDictionary<IDictionary<Mobile.IDeviceAppDataFactoryRule>>= {
+			Cordova: {
+				Android: {
+					vanilla: AndroidAppIdentifier,
+					companion: AndroidCompanionAppIdentifier
+				},
+				iOS: {
+					vanilla: IOSAppIdentifier,
+					companion: IOSCompanionAppIdentifier
+				},
+				WP8: {
+					vanilla: "",
+					companion: WP8CompanionAppIdentifier
+				}
+			},
+			NativeScript: {
+				Android: {
+					vanilla: AndroidAppIdentifier,
+					companion: AndroidNativeScriptCompanionAppIdentifier
+				},
+				iOS: {
+					vanilla: IOSAppIdentifier,
+					companion: IOSNativeScriptCompanionAppIdentifier
+				}
+			}
+		};
+
+		return rules[this.$project.projectData.Framework];
+	}
+}
+$injector.register("deviceAppDataProvider", DeviceAppDataProvider);

--- a/appbuilder/providers/livesync-provider.ts
+++ b/appbuilder/providers/livesync-provider.ts
@@ -1,37 +1,16 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
 
-import Future = require("fibers/future");
+import { AppBuilderLiveSyncProviderBase } from "./appbuilder-livesync-provider-base";
 
-export class LiveSyncProvider implements ILiveSyncProvider {
-	constructor(private $androidLiveSyncServiceLocator: {factory: Function},
-		private $iosLiveSyncServiceLocator: {factory: Function},
-		private $buildService: Project.IBuildService,
-		private $devicesService: Mobile.IDevicesService,
-		private $options: IOptions) { }
-
-	public get platformSpecificLiveSyncServices(): IDictionary<any> {
-		return {
-			android: (_device: Mobile.IDevice, $injector: IInjector): IPlatformLiveSyncService => {
-				return $injector.resolve(this.$androidLiveSyncServiceLocator.factory, {_device: _device});
-			},
-			ios: (_device: Mobile.IDevice, $injector: IInjector) => {
-				return $injector.resolve(this.$iosLiveSyncServiceLocator.factory, {_device: _device});
-			}
-		};
-	}
+export class LiveSyncProvider extends AppBuilderLiveSyncProviderBase {
+	constructor($androidLiveSyncServiceLocator: {factory: Function},
+		$iosLiveSyncServiceLocator: {factory: Function}) {
+			super($androidLiveSyncServiceLocator, $iosLiveSyncServiceLocator);
+		}
 
 	public buildForDevice(device: Mobile.IDevice): IFuture<string> {
-		return this.$devicesService.isiOSSimulator(device) ? this.$buildService.buildForiOSSimulator(this.$options.saveTo, device)
-			: this.$buildService.buildForDeploy(this.$devicesService.platform, this.$options.saveTo, false, device);
-	}
-
-	public preparePlatformForSync(platform: string): IFuture<void> {
-		return Future.fromResult();
-	}
-
-	public canExecuteFastSync(filePath: string): boolean {
-		return false;
+		return Future.fromResult(null);
 	}
 }
 $injector.register("liveSyncProvider", LiveSyncProvider);

--- a/appbuilder/providers/livesync-provider.ts
+++ b/appbuilder/providers/livesync-provider.ts
@@ -1,7 +1,6 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
 
-import Future = require("fibers/future");
 import { AppBuilderLiveSyncProviderBase } from "./appbuilder-livesync-provider-base";
 
 export class LiveSyncProvider extends AppBuilderLiveSyncProviderBase {
@@ -11,7 +10,9 @@ export class LiveSyncProvider extends AppBuilderLiveSyncProviderBase {
 		}
 
 	public buildForDevice(device: Mobile.IDevice): IFuture<string> {
-		return Future.fromResult(null);
+		return (() => {
+			throw new Error(`Application is not installed on device ${device.deviceInfo.identifier}. Cannot LiveSync changes without installing the application before that.`);
+		}).future<string>()();
 	}
 }
 $injector.register("liveSyncProvider", LiveSyncProvider);

--- a/appbuilder/providers/livesync-provider.ts
+++ b/appbuilder/providers/livesync-provider.ts
@@ -1,0 +1,37 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import Future = require("fibers/future");
+
+export class LiveSyncProvider implements ILiveSyncProvider {
+	constructor(private $androidLiveSyncServiceLocator: {factory: Function},
+		private $iosLiveSyncServiceLocator: {factory: Function},
+		private $buildService: Project.IBuildService,
+		private $devicesService: Mobile.IDevicesService,
+		private $options: IOptions) { }
+
+	public get platformSpecificLiveSyncServices(): IDictionary<any> {
+		return {
+			android: (_device: Mobile.IDevice, $injector: IInjector): IPlatformLiveSyncService => {
+				return $injector.resolve(this.$androidLiveSyncServiceLocator.factory, {_device: _device});
+			},
+			ios: (_device: Mobile.IDevice, $injector: IInjector) => {
+				return $injector.resolve(this.$iosLiveSyncServiceLocator.factory, {_device: _device});
+			}
+		};
+	}
+
+	public buildForDevice(device: Mobile.IDevice): IFuture<string> {
+		return this.$devicesService.isiOSSimulator(device) ? this.$buildService.buildForiOSSimulator(this.$options.saveTo, device)
+			: this.$buildService.buildForDeploy(this.$devicesService.platform, this.$options.saveTo, false, device);
+	}
+
+	public preparePlatformForSync(platform: string): IFuture<void> {
+		return Future.fromResult();
+	}
+
+	public canExecuteFastSync(filePath: string): boolean {
+		return false;
+	}
+}
+$injector.register("liveSyncProvider", LiveSyncProvider);

--- a/appbuilder/providers/livesync-provider.ts
+++ b/appbuilder/providers/livesync-provider.ts
@@ -1,6 +1,7 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
 
+import Future = require("fibers/future");
 import { AppBuilderLiveSyncProviderBase } from "./appbuilder-livesync-provider-base";
 
 export class LiveSyncProvider extends AppBuilderLiveSyncProviderBase {

--- a/appbuilder/providers/project-files-provider.ts
+++ b/appbuilder/providers/project-files-provider.ts
@@ -1,0 +1,58 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import * as path from "path";
+import { ProjectFilesProviderBase } from "../../services/project-files-provider-base";
+
+export class ProjectFilesProvider extends ProjectFilesProviderBase {
+	private static IGNORE_FILE = ".abignore";
+	private static INTERNAL_NONPROJECT_FILES = [".ab", ProjectFilesProvider.IGNORE_FILE, ".*" + ProjectFilesProvider.IGNORE_FILE, "**/*.ipa", "**/*.apk", "**/*.xap"];
+	private _projectDir: string = null;
+	private get projectDir(): string {
+		if (!this._projectDir) {
+			let project: Project.IProject = this.$injector.resolve("project");
+			this._projectDir = project.getProjectDir().wait();
+		}
+
+		return this._projectDir;
+	}
+
+	constructor(private $pathFilteringService: IPathFilteringService,
+		private $projectConstants: Project.IProjectConstants,
+		private $injector: IInjector,
+		$mobileHelper: Mobile.IMobileHelper,
+		$options: ICommonOptions) {
+			super($mobileHelper, $options);
+		 }
+
+	public isFileExcluded(filePath: string): boolean {
+		let exclusionList = ProjectFilesProvider.INTERNAL_NONPROJECT_FILES.concat(this.getIgnoreFilesRules());
+		return this.$pathFilteringService.isFileExcluded(filePath, exclusionList, this.projectDir);
+	}
+
+	public mapFilePath(filePath: string, platform: string): string {
+		return filePath;
+	}
+
+	private ignoreFilesRules: string[] = null;
+	private getIgnoreFilesRules(): string[] {
+		if (!this.ignoreFilesRules) {
+			this.ignoreFilesRules = <string[]>_(this.ignoreFilesConfigurations)
+				.map(configFile => this.$pathFilteringService.getRulesFromFile(path.join(this.projectDir, configFile)))
+				.flatten()
+				.value();
+		}
+		return this.ignoreFilesRules;
+	}
+
+	private get ignoreFilesConfigurations(): string[] {
+		let configurations: string[] = [ ProjectFilesProvider.IGNORE_FILE ];
+		// unless release is explicitly set, we use debug config
+		let configFileName = "." +
+			(this.$options.release ? this.$projectConstants.RELEASE_CONFIGURATION_NAME : this.$projectConstants.DEBUG_CONFIGURATION_NAME) +
+			ProjectFilesProvider.IGNORE_FILE;
+		configurations.push(configFileName);
+		return configurations;
+	}
+}
+$injector.register("projectFilesProvider", ProjectFilesProvider);

--- a/appbuilder/providers/project-files-provider.ts
+++ b/appbuilder/providers/project-files-provider.ts
@@ -10,7 +10,7 @@ export class ProjectFilesProvider extends ProjectFilesProviderBase {
 	private _projectDir: string = null;
 	private get projectDir(): string {
 		if (!this._projectDir) {
-			let project: Project.IProject = this.$injector.resolve("project");
+			let project = this.$injector.resolve("project");
 			this._projectDir = project.getProjectDir().wait();
 		}
 
@@ -18,7 +18,7 @@ export class ProjectFilesProvider extends ProjectFilesProviderBase {
 	}
 
 	constructor(private $pathFilteringService: IPathFilteringService,
-		private $projectConstants: Project.IProjectConstants,
+		private $projectConstants: IProjectConstants,
 		private $injector: IInjector,
 		$mobileHelper: Mobile.IMobileHelper,
 		$options: ICommonOptions) {

--- a/appbuilder/providers/project-files-provider.ts
+++ b/appbuilder/providers/project-files-provider.ts
@@ -18,7 +18,7 @@ export class ProjectFilesProvider extends ProjectFilesProviderBase {
 	}
 
 	constructor(private $pathFilteringService: IPathFilteringService,
-		private $projectConstants: IProjectConstants,
+		private $projectConstants: Project.IConstants,
 		private $injector: IInjector,
 		$mobileHelper: Mobile.IMobileHelper,
 		$options: ICommonOptions) {

--- a/appbuilder/services/livesync/android-livesync-service.ts
+++ b/appbuilder/services/livesync/android-livesync-service.ts
@@ -5,11 +5,11 @@ import { AndroidLiveSyncService } from "../../../mobile/android/android-livesync
 import Future = require("fibers/future");
 
 export class AppBuilderAndroidLiveSyncService extends AndroidLiveSyncService implements IPlatformLiveSyncService {
-	constructor(private _device: Mobile.IDevice,
+	constructor(private _device: Mobile.IAndroidDevice,
 	 	$fs: IFileSystem,
 		$mobileHelper: Mobile.IMobileHelper,
 		private $options: ICommonOptions) {
-			super(<Mobile.IAndroidDevice>_device, $fs, $mobileHelper);
+			super(_device, $fs, $mobileHelper);
 		}
 
 	public refreshApplication(deviceAppData: Mobile.IDeviceAppData): IFuture<void> {

--- a/appbuilder/services/livesync/android-livesync-service.ts
+++ b/appbuilder/services/livesync/android-livesync-service.ts
@@ -1,0 +1,37 @@
+///<reference path="../../../.d.ts"/>
+"use strict";
+
+import androidLiveSyncServiceLib = require("../../../mobile/android/android-livesync-service");
+import Future = require("fibers/future");
+
+export class AndroidLiveSyncService extends androidLiveSyncServiceLib.AndroidLiveSyncService implements IPlatformLiveSyncService {
+	constructor(private _device: Mobile.IDevice,
+		private $config: IConfiguration,
+		private $errors: IErrors,
+	 	$fs: IFileSystem,
+		private $injector: IInjector,
+		$mobileHelper: Mobile.IMobileHelper,
+		private $options: IOptions,
+		private $project: Project.IProject,
+		private $server: Server.IServer) {
+			super(<Mobile.IAndroidDevice>_device, $fs, $mobileHelper);
+		}
+
+	public refreshApplication(deviceAppData: Mobile.IDeviceAppData): IFuture<void> {
+		return (() => {
+			let commands = [ this.liveSyncCommands.SyncFilesCommand() ];
+			if(this.$options.watch || this.$options.file) {
+				commands.push(this.liveSyncCommands.RefreshCurrentViewCommand());
+			} else {
+				commands.push(this.liveSyncCommands.ReloadStartViewCommand());
+			}
+
+			this.livesync(deviceAppData.appIdentifier, deviceAppData.deviceProjectRootPath, commands).wait();
+		}).future<void>()();
+	}
+
+	public removeFiles(): IFuture<void> {
+		return Future.fromResult();
+	}
+}
+$injector.register("androidLiveSyncServiceLocator", {factory: AndroidLiveSyncService});

--- a/appbuilder/services/livesync/android-livesync-service.ts
+++ b/appbuilder/services/livesync/android-livesync-service.ts
@@ -1,19 +1,14 @@
 ///<reference path="../../../.d.ts"/>
 "use strict";
 
-import androidLiveSyncServiceLib = require("../../../mobile/android/android-livesync-service");
+import { AndroidLiveSyncService } from "../../../mobile/android/android-livesync-service";
 import Future = require("fibers/future");
 
-export class AndroidLiveSyncService extends androidLiveSyncServiceLib.AndroidLiveSyncService implements IPlatformLiveSyncService {
+export class AppBuilderAndroidLiveSyncService extends AndroidLiveSyncService implements IPlatformLiveSyncService {
 	constructor(private _device: Mobile.IDevice,
-		private $config: IConfiguration,
-		private $errors: IErrors,
 	 	$fs: IFileSystem,
-		private $injector: IInjector,
 		$mobileHelper: Mobile.IMobileHelper,
-		private $options: IOptions,
-		private $project: Project.IProject,
-		private $server: Server.IServer) {
+		private $options: ICommonOptions) {
 			super(<Mobile.IAndroidDevice>_device, $fs, $mobileHelper);
 		}
 
@@ -34,4 +29,4 @@ export class AndroidLiveSyncService extends androidLiveSyncServiceLib.AndroidLiv
 		return Future.fromResult();
 	}
 }
-$injector.register("androidLiveSyncServiceLocator", {factory: AndroidLiveSyncService});
+$injector.register("androidLiveSyncServiceLocator", {factory: AppBuilderAndroidLiveSyncService});

--- a/appbuilder/services/livesync/companion-apps-service.ts
+++ b/appbuilder/services/livesync/companion-apps-service.ts
@@ -8,9 +8,8 @@ const APPBUILDER_ANDROID_COMPANION_APP_IDENTIFIER = "com.telerik.AppBuilder";
 const APPBUILDER_IOS_COMPANION_APP_IDENTIFIER = "com.telerik.Icenium";
 
 // TODO: Detect when companion app is installed on any device and raise event.
-// consider naming it CompanionAppService
 export class CompanionAppsService implements ICompanionAppsService {
-	constructor(private $projectConstants: IProjectConstants,
+	constructor(private $projectConstants: Project.IConstants,
 		private $mobileHelper: Mobile.IMobileHelper) { }
 
 	@exported("companionAppsService")

--- a/appbuilder/services/livesync/companion-apps-service.ts
+++ b/appbuilder/services/livesync/companion-apps-service.ts
@@ -1,0 +1,34 @@
+///<reference path="../../../.d.ts"/>
+"use strict";
+
+import { exported } from "../../../decorators";
+
+const NS_COMPANION_APP_IDENTIFIER = "com.telerik.NativeScript";
+const APPBUILDER_ANDROID_COMPANION_APP_IDENTIFIER = "com.telerik.AppBuilder";
+const APPBUILDER_IOS_COMPANION_APP_IDENTIFIER = "com.telerik.Icenium";
+
+// TODO: Detect when companion app is installed on any device and raise event.
+// consider naming it CompanionAppService
+export class CompanionAppsService implements ICompanionAppsService {
+	constructor(private $projectConstants: IProjectConstants,
+		private $mobileHelper: Mobile.IMobileHelper) { }
+
+	@exported("companionAppsService")
+	public getCompanionAppIdentifier(framework: string, platform: string): string {
+		let lowerCasedFramework = (framework || "").toLowerCase();
+		let lowerCasedPlatform = (platform || "").toLowerCase();
+
+		if (lowerCasedFramework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()) {
+			if(this.$mobileHelper.isAndroidPlatform(lowerCasedPlatform)) {
+				return APPBUILDER_ANDROID_COMPANION_APP_IDENTIFIER;
+			} else if(this.$mobileHelper.isiOSPlatform(lowerCasedPlatform)) {
+				return APPBUILDER_IOS_COMPANION_APP_IDENTIFIER;
+			}
+		} else if (lowerCasedFramework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()) {
+			return NS_COMPANION_APP_IDENTIFIER;
+		}
+
+		return null;
+	}
+}
+$injector.register("companionAppsService", CompanionAppsService);

--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -11,6 +11,11 @@ export class IOSLiveSyncService implements IPlatformLiveSyncService {
 	private get $project(): any {
 		return this.$injector.resolve("project");
 	}
+
+	private get $projectConstants(): IProjectConstants {
+		return this.$injector.resolve("projectConstants");
+	}
+
 	constructor(private _device: Mobile.IDevice,
 		private $fs: IFileSystem,
 		private $injector: IInjector,
@@ -54,7 +59,8 @@ export class IOSLiveSyncService implements IPlatformLiveSyncService {
 			} else {
 				this.device.fileSystem.deleteFile("/Library/Preferences/ServerInfo.plist", deviceAppData.appIdentifier);
 				let notificationProxyClient = this.$injector.resolve(iOSProxyServices.NotificationProxyClient, {device: this.device});
-				notificationProxyClient.postNotification("com.telerik.app.refreshWebView");
+				let notification = this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript ? "com.telerik.app.refreshWebView" : "com.telerik.app.refreshApp";
+				notificationProxyClient.postNotification(notification);
 				notificationProxyClient.closeSocket();
 			}
 

--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -8,12 +8,13 @@ import * as shell from "shelljs";
 let osenv = require("osenv");
 
 export class IOSLiveSyncService implements IPlatformLiveSyncService {
+	private get $project(): any {
+		return this.$injector.resolve("project");
+	}
 	constructor(private _device: Mobile.IDevice,
 		private $fs: IFileSystem,
 		private $injector: IInjector,
-		private $iOSSimResolver: Mobile.IiOSSimResolver,
 		private $logger: ILogger,
-		private $project: Project.IProject,
 		private $errors: IErrors) { }
 
 	private get device(): Mobile.IDevice {

--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -1,0 +1,67 @@
+///<reference path="../../../.d.ts"/>
+"use strict";
+
+import Future = require("fibers/future");
+import iOSProxyServices = require("../../../mobile/ios/device/ios-proxy-services");
+import * as path from "path";
+import * as shell from "shelljs";
+let osenv = require("osenv");
+
+export class IOSLiveSyncService implements IPlatformLiveSyncService {
+	constructor(private _device: Mobile.IDevice,
+		private $fs: IFileSystem,
+		private $injector: IInjector,
+		private $iOSSimResolver: Mobile.IiOSSimResolver,
+		private $logger: ILogger,
+		private $project: Project.IProject,
+		private $errors: IErrors) { }
+
+	private get device(): Mobile.IDevice {
+		return <Mobile.IiOSDevice>this._device;
+	}
+
+	public refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<void> {
+		return (() => {
+			if (this.device.isEmulator) {
+				let simulatorLogFilePath = path.join(osenv.home(), `/Library/Developer/CoreSimulator/Devices/${this.device.deviceInfo.identifier}/data/Library/Logs/system.log`);
+				let simulatorLogFileContent = this.$fs.readText(simulatorLogFilePath).wait() || "";
+
+				let simulatorCachePath = path.join(osenv.home(), `/Library/Developer/CoreSimulator/Devices/${this.device.deviceInfo.identifier}/data/Containers/Data/Application/`);
+				let regex = new RegExp(`^(?:.*?)${deviceAppData.appIdentifier}(?:.*?)${simulatorCachePath}(.*?)$`, "gm");
+
+				let guid = "";
+				while (true) {
+					let parsed = regex.exec(simulatorLogFileContent);
+					if (!parsed) {
+						break;
+					}
+					guid = parsed[1];
+				}
+
+				if (!guid) {
+					this.$errors.failWithoutHelp(`Unable to find application GUID for application ${deviceAppData.appIdentifier}. Make sure application is installed on Simulator.`);
+				}
+
+				let sourcePath = deviceAppData.deviceProjectRootPath;
+				let destinationPath = path.join(simulatorCachePath, guid, "Documents");
+
+				this.$logger.trace(`Transferring from ${sourcePath} to ${destinationPath}`);
+				shell.cp("-Rf", path.join(sourcePath, "*"), destinationPath);
+
+				let cfBundleExecutable = `${this.$project.projectData.Framework}${this.$project.projectData.FrameworkVersion.split(".").join("")}`;
+				this.device.applicationManager.restartApplication(deviceAppData.appIdentifier, cfBundleExecutable).wait();
+			} else {
+				this.device.fileSystem.deleteFile("/Library/Preferences/ServerInfo.plist", deviceAppData.appIdentifier);
+				let notificationProxyClient = this.$injector.resolve(iOSProxyServices.NotificationProxyClient, {device: this.device});
+				notificationProxyClient.postNotification("com.telerik.app.refreshWebView");
+				notificationProxyClient.closeSocket();
+			}
+
+		}).future<void>()();
+	}
+
+	public removeFiles(): IFuture<void> {
+		return Future.fromResult();
+	}
+}
+$injector.register("iosLiveSyncServiceLocator", {factory: IOSLiveSyncService});

--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -12,18 +12,15 @@ export class IOSLiveSyncService implements IPlatformLiveSyncService {
 		return this.$injector.resolve("project");
 	}
 
-	private get $projectConstants(): IProjectConstants {
-		return this.$injector.resolve("projectConstants");
-	}
-
-	constructor(private _device: Mobile.IDevice,
+	constructor(private _device: Mobile.IiOSDevice,
 		private $fs: IFileSystem,
 		private $injector: IInjector,
 		private $logger: ILogger,
-		private $errors: IErrors) { }
+		private $errors: IErrors,
+		private $projectConstants: Project.IConstants) { }
 
-	private get device(): Mobile.IDevice {
-		return <Mobile.IiOSDevice>this._device;
+	private get device(): Mobile.IiOSDevice {
+		return this._device;
 	}
 
 	public refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<void> {
@@ -59,7 +56,7 @@ export class IOSLiveSyncService implements IPlatformLiveSyncService {
 			} else {
 				this.device.fileSystem.deleteFile("/Library/Preferences/ServerInfo.plist", deviceAppData.appIdentifier);
 				let notificationProxyClient = this.$injector.resolve(iOSProxyServices.NotificationProxyClient, {device: this.device});
-				let notification = this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript ? "com.telerik.app.refreshWebView" : "com.telerik.app.refreshApp";
+				let notification = this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript ? "com.telerik.app.refreshApp" : "com.telerik.app.refreshWebView";
 				notificationProxyClient.postNotification(notification);
 				notificationProxyClient.closeSocket();
 			}

--- a/appbuilder/services/livesync/livesync-service.ts
+++ b/appbuilder/services/livesync/livesync-service.ts
@@ -1,0 +1,102 @@
+///<reference path="../../../.d.ts"/>
+"use strict";
+
+import { exportedPromise } from "../../../decorators";
+
+export class ProtonLiveSyncService implements IProtonLiveSyncService {
+	private excludedProjectDirsAndFiles = ["app_resources", "plugins", ".*.tmp", ".ab"];
+
+	private get $liveSyncServiceBase(): ILiveSyncServiceBase {
+		return this.$injector.resolve("liveSyncServiceBase");
+	}
+
+	constructor(private $devicesService: Mobile.IDevicesService,
+		private $errors: IErrors,
+		private $mobileHelper: Mobile.IMobileHelper,
+		private $options: ICommonOptions,
+		private $fs: IFileSystem,
+		private $injector: IInjector,
+		private $project: any,
+		private $logger: ILogger) { }
+
+	@exportedPromise("liveSyncService")
+	public livesync(deviceIdentifiers: IDeviceLiveSyncInfo[], projectDir: string, filePaths?: string[]): IFuture<void> {
+		return (() => {
+			this.$project.projectDir = projectDir;
+			let deviceInfos: any = _.map(deviceIdentifiers, d => {
+				let matchingDevice = _.find(this.$devicesService.getDeviceInstances(), device => device.deviceInfo.identifier === d.deviceIdentifier);
+				return _.extend(d, { device: matchingDevice });
+			});
+
+			let errors: Error[] = [];
+			// Group devices by platform. After that group each group by types of sync.
+			// Aggregate the errors and throw a single error in case any operation fails.
+			let groupedByPlatform = _.groupBy(deviceInfos, (d: any) => d.device.deviceInfo.platform.toLowerCase());
+			_.each(groupedByPlatform, (platformGroup: any[], platform: string) => {
+				let syncToApp = platformGroup.filter(plGr => !!plGr.syncToApp);
+				try {
+					this.liveSyncToApp(platform, syncToApp.map((s: any) => s.device), filePaths).wait();
+				} catch (err) {
+					this.$logger.trace(`Error while trying to livesync applications to devices: ${syncToApp.join(", ")}.`, err.message);
+					errors.push(err);
+				}
+
+				let syncToCompanion =  platformGroup.filter(plGr => !!plGr.syncToCompanion);
+				try {
+					this.liveSyncToCompanion(platform, syncToCompanion.map((s: any) => s.device), filePaths).wait();
+				} catch (err) {
+					this.$logger.trace(`Error while trying to livesync to companion app to devices: ${syncToCompanion.join(", ")}.`, err.message);
+					errors.push(err);
+				}
+			});
+
+			if(errors && errors.length) {
+				throw new Error(`Unable to livesync to specified devices. Errors are: ${errors.map(err => err.message)}`);
+			}
+		}).future<void>()();
+	}
+
+	private liveSyncToApp(platform: string, devices: Mobile.IDevice[], filePaths: string[]): IFuture<void> {
+		return (() => {
+			this.$options.companion = false;
+			if(!this.$project.capabilities.livesync) {
+				this.$errors.failWithoutHelp(`You cannot use LiveSync for ${this.$project.projectData.Framework} projects.`);
+			}
+
+			this.liveSyncCore(platform, devices, filePaths).wait();
+		}).future<void>()();
+	}
+
+	private liveSyncToCompanion(platform: string, devices: Mobile.IDevice[], filePaths: string[]): IFuture<void> {
+		return (() => {
+			this.$options.companion = true;
+
+			if(!this.$mobileHelper.getPlatformCapabilities(platform).companion) {
+				this.$errors.failWithoutHelp(`The Companion app is not available on ${platform} devices.`);
+			}
+
+			if(!this.$project.capabilities.livesyncCompanion) {
+				this.$errors.failWithoutHelp(`You cannot use LiveSync to Companion app for ${this.$project.projectData.Framework} projects.`);
+			}
+
+			this.liveSyncCore(platform, devices, filePaths).wait();
+		}).future<void>()();
+	}
+
+	private liveSyncCore(platform: string, devices: Mobile.IDevice[], filePaths: string[]): IFuture<void> {
+		return (() => {
+			let livesyncData: ILiveSyncData = {
+				platform: platform,
+				appIdentifier: this.$project.projectData.AppIdentifier,
+				projectFilesPath: this.$project.projectDir,
+				syncWorkingDirectory: this.$project.projectDir,
+				excludedProjectDirsAndFiles: this.excludedProjectDirsAndFiles,
+				canExecuteFastSync: false,
+				canExecute: (device: Mobile.IDevice) =>  device.deviceInfo.platform.toLowerCase() === platform.toLowerCase() && !!_.any(devices, d => d.deviceInfo.identifier === device.deviceInfo.identifier)
+			};
+
+			this.$liveSyncServiceBase.sync(livesyncData, filePaths).wait();
+		}).future<void>()();
+	}
+}
+$injector.register("liveSyncService", ProtonLiveSyncService);

--- a/appbuilder/services/livesync/livesync-service.ts
+++ b/appbuilder/services/livesync/livesync-service.ts
@@ -16,7 +16,7 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 		private $options: ICommonOptions,
 		private $fs: IFileSystem,
 		private $injector: IInjector,
-		private $project: any,
+		private $project: Project.IProjectBase,
 		private $logger: ILogger) { }
 
 	@exportedPromise("liveSyncService")

--- a/appbuilder/services/path-filtering.ts
+++ b/appbuilder/services/path-filtering.ts
@@ -1,0 +1,60 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+import minimatch = require("minimatch");
+
+export class PathFilteringService implements IPathFilteringService {
+
+	constructor(private $fs: IFileSystem) {	}
+
+	public getRulesFromFile(fullFilePath: string) : string[] {
+		let COMMENT_START = '#';
+		let rules: string[] = [];
+
+		try {
+			let fileContent = this.$fs.readText(fullFilePath).wait();
+			rules = _.reject(fileContent.split(/[\n\r]/),
+				(line: string) => line.length === 0 || line[0] === COMMENT_START);
+
+		} catch(e) {
+			if (e.code !== "ENOENT") { // file not found
+				throw e;
+			}
+		}
+
+		return rules;
+	}
+
+	public filterIgnoredFiles(files: string[], rules: string[], rootDir: string): string[]{
+		return _.reject(files, file => this.isFileExcluded(file, rules, rootDir));
+	}
+
+	public isFileExcluded(file: string, rules: string[], rootDir: string): boolean {
+		file = file.replace(rootDir, "").replace(new RegExp("^[\\\\|/]*"), "");
+		let fileMatched = true;
+		_.each(rules, rule => {
+			// minimatch treats starting '!' as pattern negation
+			// but we want the pattern matched and then do something else with the file
+			// therefore, we manually handle leading ! and \! and hide them from minimatch
+			let shouldInclude = rule[0] === '!';
+			if (shouldInclude) {
+				rule = rule.substr(1);
+				let ruleMatched = minimatch(file, rule, {nocase: true, dot: true});
+				if (ruleMatched) {
+					fileMatched = true;
+				}
+			} else {
+				let options = {nocase: true, nonegate: false, dot: true};
+				if (rule[0] === '\\' && rule[1] === '!') {
+					rule = rule.substr(1);
+					options.nonegate = true;
+				}
+				let ruleMatched = minimatch(file, rule, options);
+				fileMatched = fileMatched && !ruleMatched;
+			}
+		});
+
+		return !fileMatched;
+	}
+}
+
+$injector.register("pathFilteringService", PathFilteringService);

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -463,7 +463,7 @@ interface ILiveSyncServiceBase {
 	 * If watch option is not specified executes full sync
 	 * If watch option is specified executes partial sync
 	 */
-	sync(data: ILiveSyncData): IFuture<void>;
+	sync(data: ILiveSyncData, filePaths?: string[]): IFuture<void>;
 }
 
 interface ISyncBatch {
@@ -488,6 +488,11 @@ interface ILiveSyncData {
 	syncWorkingDirectory: string;
 	canExecuteFastSync?: boolean;
 	excludedProjectDirsAndFiles?: string[];
+	/**
+	 * Describes if the livesync action can be executed on specified device.
+	 * The method is called for each device.
+	 */
+	canExecute?(device: Mobile.IDevice): boolean;
 }
 
 interface IPlatformLiveSyncService {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES5",
+		"module": "commonjs",
+		"sourceMap": true,
+		"experimentalDecorators": true
+	},
+	"exclude": [
+		"node_modules",
+		"scratch",
+		"coverage"
+	]
+}


### PR DESCRIPTION
Move some files from icenium-cli to common lib, introduce new interfaces and implement
* Livesync for Proton - expose new method:
```JavaScript
require("mobile-cli-lib").liveSyncService.livesync(deviceLiveSyncInfos, pathToProject, filesToSync)
	.then(function(result) {
		console.log("Finished");
	}).catch(function(err) {
		console.log("Error: ", err);
		console.log(err.stack);
	})
```
* Expose method to get Companion app identifiers:
```JavaScript
var companionAppId = require("mobile-cli-lib").companionAppsService.getCompanionAppIdentifier(framework, platform));
```
* Introduce cable LiveSync for NativeScript applications