### PR TITLE
Fixed the autocomplete

### DIFF
--- a/services/auto-completion-service.ts
+++ b/services/auto-completion-service.ts
@@ -237,7 +237,7 @@ export class AutoCompletionService implements IAutoCompletionService {
 				if(doUpdate) {
 					let clientExecutableFileName = (this.$staticConfig.CLIENT_NAME_ALIAS || this.$staticConfig.CLIENT_NAME).toLowerCase();
 					let pathToExecutableFile = path.join(__dirname, `../../../bin/${clientExecutableFileName}.js`);
-					this.$childProcess.exec(`${process.argv[0]} ${pathToExecutableFile} completion >> ${filePath}`).wait();
+					this.$childProcess.exec(`"${process.argv[0]}" "${pathToExecutableFile}" completion >> "${filePath}"`).wait();
 					this.$fs.chmod(filePath, "0644").wait();
 				}
 			} catch(err) {


### PR DESCRIPTION
When path to node has spaces (C:\Program Files) the child process exec cannot run the command. Need to place it in "" to run it without errors.