### PR TITLE
Fix analytics tracking of users

### DIFF
--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -11,7 +11,7 @@ class AnalyticsCommand implements ICommand {
 		private humanReadableSettingName: string) { }
 
 	public allowedParameters = [new AnalyticsCommandParameter(this.$errors)];
-	public disableAnalyticsConsentCheck = true;
+	public disableAnalytics = true;
 
 	public execute(args: string[]): IFuture<void> {
 		return(() => {

--- a/commands/help.ts
+++ b/commands/help.ts
@@ -10,7 +10,6 @@ export class HelpCommand implements ICommand {
 		private $options: ICommonOptions) { }
 
 	public enableHooks = false;
-	public disableAnalyticsConsentCheck = true;
 	public canExecute(args: string[]): IFuture<boolean> {
 		return Future.fromResult(true);
 	}

--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -29,9 +29,11 @@ export class PostInstallCommand implements ICommand {
 			this.$htmlHelpService.generateHtmlPages().wait();
 
 			let doctorResult = this.$doctorService.printWarnings({ trackResult: false });
-			this.$analyticsService.track("InstallEnvironmentSetup", doctorResult ? "incorrect" : "correct").wait();
+			// Explicitly ask for confirmation of usage-reporting:
+			this.$analyticsService.checkConsent().wait();
 
 			this.$commandsService.tryExecuteCommand("autocomplete", []).wait();
+			this.$analyticsService.track("InstallEnvironmentSetup", doctorResult ? "incorrect" : "correct").wait();
 		}).future<void>()();
 	}
 }

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -236,7 +236,6 @@ interface IErrors {
 interface ICommandOptions {
 	disableAnalytics?: boolean;
 	enableHooks?: boolean;
-	disableAnalyticsConsentCheck?: boolean;
 	disableCommandHelpSuggestion?: boolean;
 }
 
@@ -319,10 +318,16 @@ interface IAnalyticsService {
 	checkConsent(): IFuture<void>;
 	trackFeature(featureName: string): IFuture<void>;
 	trackException(exception: any, message: string): IFuture<void>;
-	setStatus(settingName: string, enabled: boolean): IFuture<void>;
+	setStatus(settingName: string, enabled: boolean, doNotTrackSetting?: boolean): IFuture<void>;
 	getStatusMessage(settingName: string, jsonFormat: boolean, readableSettingName: string): IFuture<string>;
 	isEnabled(settingName: string): IFuture<boolean>;
 	track(featureName: string, featureValue: string): IFuture<void>;
+	/**
+	 * Tries to stop current eqatec monitor, clean it's state and remove the process.exit event handler.
+	 * @param {string|number} code - Exit code as the method is used for process.exit event handler.
+	 * @return void
+	 */
+	tryStopEqatecMonitor(code?: string|number): void;
 }
 
 interface IAllowEmpty {

--- a/helpers.ts
+++ b/helpers.ts
@@ -93,7 +93,7 @@ export function isInteractive(): boolean {
 }
 
 export function toBoolean(str: string) {
-	return str === "true";
+	return str && str.toLowerCase() === "true";
 }
 
 export function block(operation: () => void): void {

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -43,9 +43,7 @@ export class CommandsService implements ICommandsService {
 			if(command) {
 				if(!this.$staticConfig.disableAnalytics && !command.disableAnalytics) {
 					let analyticsService = this.$injector.resolve("analyticsService"); // This should be resolved here due to cyclic dependency
-					if(!command.disableAnalyticsConsentCheck) {
-						analyticsService.checkConsent().wait();
-					}
+					analyticsService.checkConsent().wait();
 					analyticsService.trackFeature(commandName).wait();
 				}
 				if(!this.$staticConfig.disableCommandHooks && (command.enableHooks === undefined || command.enableHooks === true)) {

--- a/test/unit-tests/analytics-service.ts
+++ b/test/unit-tests/analytics-service.ts
@@ -143,6 +143,7 @@ function createTestInjector(testScenario: ITestScenario): IInjector {
 describe("analytics-service", () => {
 	let baseTestScenario: ITestScenario;
 	let featureName = "unit tests feature";
+	let service: IAnalyticsService = null;
 
 	beforeEach(() => {
 		baseTestScenario = {
@@ -159,6 +160,14 @@ describe("analytics-service", () => {
 		savedSettingNamesAndValues = "";
 		isEqatecStopCalled = false;
 		lastUsedEqatecSettings = {};
+		service = null;
+	});
+
+	afterEach(() => {
+		// clean up the process.exit event handler
+		if(service) {
+			service.tryStopEqatecMonitor();
+		}
 	});
 
 	after(() => {
@@ -168,23 +177,25 @@ describe("analytics-service", () => {
 	describe("trackFeature", () => {
 		it("tracks feature when console is interactive", () => {
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.trackFeature(featureName).wait();
 			assert.isTrue(trackedFeatureNamesAndValues.indexOf(`CLI.${featureName}`) !== -1);
+			(<any>service).tryStopEqatecMonitor();
 		});
 
 		it("tracks feature when console is not interactive", () => {
 			baseTestScenario.isInteractive = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.trackFeature(featureName).wait();
 			assert.isTrue(trackedFeatureNamesAndValues.indexOf(`Non-interactive.${featureName}`) !== -1);
+			(<any>service).tryStopEqatecMonitor();
 		});
 
 		it("does not track feature when console is interactive and feature tracking is disabled", () => {
 			baseTestScenario.featureTracking = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.trackFeature(featureName).wait();
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
 		});
@@ -192,7 +203,7 @@ describe("analytics-service", () => {
 		it("does not track feature when console is not interactive and feature tracking is disabled", () => {
 			baseTestScenario.featureTracking = baseTestScenario.isInteractive = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.trackFeature(featureName).wait();
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
 		});
@@ -200,7 +211,7 @@ describe("analytics-service", () => {
 		it("does not track feature when console is interactive and feature tracking is enabled, but cannot make request", () => {
 			baseTestScenario.canDoRequest = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.trackFeature(featureName).wait();
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
 		});
@@ -208,7 +219,7 @@ describe("analytics-service", () => {
 		it("does not track feature when console is not interactive and feature tracking is enabled, but cannot make request", () => {
 			baseTestScenario.canDoRequest = baseTestScenario.isInteractive = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.trackFeature(featureName).wait();
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
 		});
@@ -216,7 +227,7 @@ describe("analytics-service", () => {
 		it("does not throw exception when eqatec start throws", () => {
 			baseTestScenario.shouldStartThrow = true;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.trackFeature(featureName).wait();
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
 		});
@@ -227,7 +238,7 @@ describe("analytics-service", () => {
 		let message = "Track Exception Msg";
 		it("tracks when all conditions are correct", () => {
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.trackException(exception, message).wait();
 			assert.isTrue(lastTrackedExceptionMsg.indexOf(message) !== -1);
 		});
@@ -235,7 +246,7 @@ describe("analytics-service", () => {
 		it("does not track when exception tracking is disabled", () => {
 			baseTestScenario.exceptionsTracking = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.trackException(exception, message).wait();
 			assert.deepEqual(lastTrackedExceptionMsg, "");
 		});
@@ -243,7 +254,7 @@ describe("analytics-service", () => {
 		it("does not track when feature tracking is enabled, but cannot make request", () => {
 			baseTestScenario.canDoRequest = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.trackException(exception, message).wait();
 			assert.deepEqual(lastTrackedExceptionMsg, "");
 		});
@@ -251,7 +262,7 @@ describe("analytics-service", () => {
 		it("does not throw exception when eqatec start throws", () => {
 			baseTestScenario.shouldStartThrow = true;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.trackException(exception, message).wait();
 			assert.deepEqual(lastTrackedExceptionMsg, "");
 		});
@@ -261,7 +272,7 @@ describe("analytics-service", () => {
 		let name = "unitTests";
 		it("tracks when all conditions are correct", () => {
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.track(name, featureName).wait();
 			assert.isTrue(trackedFeatureNamesAndValues.indexOf(`${name}.${featureName}`) !== -1);
 		});
@@ -269,7 +280,7 @@ describe("analytics-service", () => {
 		it("does not track when feature tracking is disabled", () => {
 			baseTestScenario.featureTracking = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.track(name, featureName).wait();
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
 		});
@@ -277,7 +288,7 @@ describe("analytics-service", () => {
 		it("does not track when feature tracking is enabled, but cannot make request", () => {
 			baseTestScenario.canDoRequest = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.track(name, featureName).wait();
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
 		});
@@ -285,7 +296,7 @@ describe("analytics-service", () => {
 		it("does not throw exception when eqatec start throws", () => {
 			baseTestScenario.shouldStartThrow = true;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.track(name, featureName).wait();
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
 		});
@@ -294,7 +305,7 @@ describe("analytics-service", () => {
 	describe("isEnabled", () => {
 		it("returns true when analytics status is enabled", () => {
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(service.isEnabled(staticConfig.ERROR_REPORT_SETTING_NAME).wait());
 			assert.isTrue(service.isEnabled(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME).wait());
@@ -303,7 +314,7 @@ describe("analytics-service", () => {
 		it("returns false when analytics status is disabled", () => {
 			baseTestScenario.exceptionsTracking = baseTestScenario.featureTracking = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isFalse(service.isEnabled(staticConfig.ERROR_REPORT_SETTING_NAME).wait());
 			assert.isFalse(service.isEnabled(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME).wait());
@@ -312,7 +323,7 @@ describe("analytics-service", () => {
 		it("returns false when analytics status is notConfirmed", () => {
 			baseTestScenario.exceptionsTracking = baseTestScenario.featureTracking = undefined;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isFalse(service.isEnabled(staticConfig.ERROR_REPORT_SETTING_NAME).wait());
 			assert.isFalse(service.isEnabled(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME).wait());
@@ -322,7 +333,7 @@ describe("analytics-service", () => {
 	describe("setStatus", () => {
 		it("sets correct status", () => {
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			service.setStatus(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, false).wait();
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME}.false`) !== -1);
@@ -331,7 +342,7 @@ describe("analytics-service", () => {
 		it("calls eqatec stop when all analytics trackings are disabled", () => {
 			baseTestScenario.exceptionsTracking = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			// start eqatec
 			service.trackFeature(featureName).wait();
@@ -343,7 +354,7 @@ describe("analytics-service", () => {
 
 		it("tracks that user had disabled feature tracking", () => {
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			service.setStatus(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, false).wait();
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME}.false`) !== -1);
@@ -352,7 +363,7 @@ describe("analytics-service", () => {
 
 		it("tracks that user had enabled feature tracking", () => {
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			service.setStatus(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, true).wait();
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME}.true`) !== -1);
@@ -361,7 +372,7 @@ describe("analytics-service", () => {
 
 		it("tracks that user had disabled exceptions tracking", () => {
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			service.setStatus(staticConfig.ERROR_REPORT_SETTING_NAME, false).wait();
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.ERROR_REPORT_SETTING_NAME}.false`) !== -1);
@@ -370,7 +381,7 @@ describe("analytics-service", () => {
 
 		it("tracks that user had enabled exceptions tracking", () => {
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			service.setStatus(staticConfig.ERROR_REPORT_SETTING_NAME, true).wait();
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.ERROR_REPORT_SETTING_NAME}.true`) !== -1);
@@ -381,7 +392,7 @@ describe("analytics-service", () => {
 	describe("getStatusMessage", () => {
 		it("returns correct string results when status is enabled", () => {
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			let expectedMsg = "Expected result";
 			assert.equal(`${expectedMsg} is enabled.`, service.getStatusMessage(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, false, expectedMsg).wait());
@@ -390,7 +401,7 @@ describe("analytics-service", () => {
 		it("returns correct string results when status is disabled", () => {
 			baseTestScenario.featureTracking = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			let expectedMsg = "Expected result";
 			assert.equal(`${expectedMsg} is disabled.`, service.getStatusMessage(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, false, expectedMsg).wait());
@@ -399,7 +410,7 @@ describe("analytics-service", () => {
 		it("returns correct string results when status is not confirmed", () => {
 			baseTestScenario.featureTracking = undefined;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			let expectedMsg = "Expected result";
 			assert.equal(`${expectedMsg} is disabled until confirmed.`, service.getStatusMessage(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, false, expectedMsg).wait());
@@ -407,7 +418,7 @@ describe("analytics-service", () => {
 
 		it("returns correct json results when status is enabled", () => {
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.deepEqual(JSON.stringify({ "enabled": true }), service.getStatusMessage(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, true, "").wait());
 		});
@@ -415,7 +426,7 @@ describe("analytics-service", () => {
 		it("returns correct json results when status is disabled", () => {
 			baseTestScenario.featureTracking = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.deepEqual(JSON.stringify({ "enabled": false }), service.getStatusMessage(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, true, "").wait());
 		});
@@ -423,7 +434,7 @@ describe("analytics-service", () => {
 		it("returns correct json results when status is not confirmed", () => {
 			baseTestScenario.featureTracking = undefined;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.deepEqual(JSON.stringify({ "enabled": null }), service.getStatusMessage(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, true, "").wait());
 		});
@@ -434,7 +445,7 @@ describe("analytics-service", () => {
 			baseTestScenario.featureTracking = undefined;
 			baseTestScenario.exceptionsTracking = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.checkConsent().wait();
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME}.true`) !== -1);
@@ -445,7 +456,7 @@ describe("analytics-service", () => {
 			baseTestScenario.prompterConfirmResult = false;
 			baseTestScenario.exceptionsTracking = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.checkConsent().wait();
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME}.false`) !== -1);
@@ -455,7 +466,7 @@ describe("analytics-service", () => {
 			baseTestScenario.featureTracking = false;
 			baseTestScenario.exceptionsTracking = undefined;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.checkConsent().wait();
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.ERROR_REPORT_SETTING_NAME}.true`) !== -1);
@@ -464,7 +475,7 @@ describe("analytics-service", () => {
 		it("do nothing when exception and feature tracking are already set", () => {
 			baseTestScenario.featureTracking = baseTestScenario.exceptionsTracking = true;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.checkConsent().wait();
 			assert.deepEqual(savedSettingNamesAndValues, "");
 		});
@@ -473,7 +484,7 @@ describe("analytics-service", () => {
 			baseTestScenario.canDoRequest = false;
 			baseTestScenario.featureTracking = baseTestScenario.exceptionsTracking = undefined;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.checkConsent().wait();
 			assert.deepEqual(savedSettingNamesAndValues, "");
 		});
@@ -482,7 +493,7 @@ describe("analytics-service", () => {
 			baseTestScenario.featureTracking = undefined;
 			baseTestScenario.exceptionsTracking = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.checkConsent().wait();
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(trackedFeatureNamesAndValues.indexOf(`Accept${staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME}.true`) !== -1);
@@ -493,7 +504,7 @@ describe("analytics-service", () => {
 			baseTestScenario.prompterConfirmResult = false;
 			baseTestScenario.exceptionsTracking = false;
 			let testInjector = createTestInjector(baseTestScenario);
-			let service: IAnalyticsService = testInjector.resolve("analyticsService");
+			service = testInjector.resolve("analyticsService");
 			service.checkConsent().wait();
 			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(trackedFeatureNamesAndValues.indexOf(`Accept${staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME}.false`) !== -1);
@@ -503,7 +514,6 @@ describe("analytics-service", () => {
 	describe("uses correct settings on different os-es", () => {
 		let name = "unitTests";
 		let testInjector: IInjector;
-		let service: IAnalyticsService;
 		let osType = os.type;
 		let osRelease = os.release;
 		let release = "1.0";


### PR DESCRIPTION
* Move tracking of environment setup at the end of post install. This way we'll first ask the users if they want to be tracked and after that track the InstallEnvironmentSetup only for the users who allowed us to track them.
* Explicitly call the check for analytics status on post-install. Currently the question was raised as we were calling autocomplete command. On each command we check if user had answered the question and if not - we ask him. Make the action more visible (in the code).
* When asking user if analytics tracking should be enabled, currently we start the analytics monitor before showing the question. This is incorrect as when the users does not answer immediately, we end up with very long sessions (for example user keeps the terminal opened and the question just stays there, the session never ends). Start the analytics monitor after user had answered.
* When the user answers the question, we track the answer and after that we persist the value in the user-settings. However when the sending takes more than expected, the user may press Ctrl + C, we may receive the data, but the setting will not be saved in the user settings. So next time when the user executes any command, we'll ask him again. Set the value in the user settings before tracking it. This way even if Ctrl + C is pressed, the value will be persisted.
* Add process.exit event handler which should stop the monitor. In many cases while tracking, we do not call `stop` of analytics monitor, so the sessions look like they are taking more than expected. Add event handler for process.exit and stop the monitor, in case it's been started.
* Fix unit tests to call the new method `tryStopEqatecMonitor` in order to remove process.exit event handlers attached by each test.
* Remove `disableAnalyticsConsentCheck` from ICommand. Looks like it's been used in a really strange way and I couldn't find it's real purpose. The property was used to prevent asking the user for confirmation when executing `help`, `usage-reporting` and `error-reporting` commands. This leads to incorrect behavior - when the user installs CLI with `--ignore-scripts` and executes `tns help` immediatley after that, CLI will track `help` command without asking.
* Track features and exceptions only when status of the properties is "enabled". Currently we track even if status is "not confirmed", but this is not correct. This way, CLI used for automation is always tracked.
* Disable error reporting when user says "no" for usage reporting. As the user does not want to be tracked, we should disable error reporting.
* Fix helpers method for converting string value to boolean. In case the string is "True" the method returned false, while it should be true.