### PR TITLE
Unmute stdout after prompter execution

### DIFF
--- a/prompter.ts
+++ b/prompter.ts
@@ -8,29 +8,13 @@ let MuteStream = require("mute-stream");
 
 export class Prompter implements IPrompter {
 	private ctrlcReader: readline.ReadLine;
+	private muteStreamInstance: any = null;
 
 	constructor() {
 		prompt.message = "";
 		prompt.delimiter = ":";
 		prompt.colors = false;
 		prompt.isDefaultValueEditable = true;
-
-		if (helpers.isInteractive()) {
-			process.stdin.setRawMode(true); // After setting rawMode to true, Ctrl+C doesn't work for non node.js events loop i.e device log command
-
-			// We need to create mute-stream and to pass it as output to ctrlcReader
-			// This will prevent the prompter to show the user's text twice on the console
-			let mutestream = new MuteStream();
-			mutestream.pipe(process.stdout);
-			mutestream.mute();
-
-			this.ctrlcReader = readline.createInterface(<any>{
-				input: process.stdin,
-				output: mutestream
-			});
-
-			this.ctrlcReader.on("SIGINT", () => process.exit());
-		}
 	}
 
 	public dispose() {
@@ -40,30 +24,38 @@ export class Prompter implements IPrompter {
 	}
 
 	public get(schemas: IPromptSchema[]): IFuture<any> {
-		let future = new Future;
-		if (!helpers.isInteractive()) {
-			if (_.any(schemas, s => !s.default)) {
-				future.throw(new Error("Console is not interactive and no default action specified."));
-			} else {
-				let result: any = {};
+		return (() => {
+			try {
+				this.muteStdout();
 
-				_.each(schemas, s => {
-					// Curly brackets needed because s.default() may return false and break the loop
-					result[s.name] = s.default();
-				});
+				let future = new Future;
+				if (!helpers.isInteractive()) {
+					if (_.any(schemas, s => !s.default)) {
+						future.throw(new Error("Console is not interactive and no default action specified."));
+					} else {
+						let result: any = {};
 
-				future.return(result);
-			}
-		} else {
-			prompt.prompt(schemas, (result: any) => {
-				if(result) {
-					future.return(result);
+						_.each(schemas, s => {
+							// Curly brackets needed because s.default() may return false and break the loop
+							result[s.name] = s.default();
+						});
+
+						future.return(result);
+					}
 				} else {
-					future.throw(new Error(`Unable to get result from prompt: ${result}`));
+					prompt.prompt(schemas, (result: any) => {
+						if(result) {
+							future.return(result);
+						} else {
+							future.throw(new Error(`Unable to get result from prompt: ${result}`));
+						}
+					});
 				}
-			});
-		}
-		return future;
+				return future.wait();
+			} finally {
+				this.unmuteStdout();
+			}
+		}).future<any>()();
 	}
 
 	public getPassword(prompt: string, options?: IAllowEmpty): IFuture<string> {
@@ -127,6 +119,36 @@ export class Prompter implements IPrompter {
 			let result = this.get([schema]).wait();
 			return result.prompt;
 		}).future<boolean>()();
+	}
+
+	private muteStdout(): void {
+		if (helpers.isInteractive()) {
+			process.stdin.setRawMode(true); // After setting rawMode to true, Ctrl+C doesn't work for non node.js events loop i.e device log command
+
+			// We need to create mute-stream and to pass it as output to ctrlcReader
+			// This will prevent the prompter to show the user's text twice on the console
+			this.muteStreamInstance = new MuteStream();
+			this.muteStreamInstance.pipe(process.stdout);
+			this.muteStreamInstance.mute();
+
+			this.ctrlcReader = readline.createInterface(<any>{
+				input: process.stdin,
+				output: this.muteStreamInstance
+			});
+
+			this.ctrlcReader.on("SIGINT", () => process.exit());
+		}
+	}
+
+	private unmuteStdout(): void {
+		if (helpers.isInteractive()) {
+			process.stdin.setRawMode(false);
+			if(this.muteStreamInstance) {
+				this.muteStreamInstance.unmute();
+				this.muteStreamInstance = null;
+				this.dispose();
+			}
+		}
 	}
 }
 $injector.register("prompter", Prompter);


### PR DESCRIPTION
In order to prevent double printing of stdout data, CLI mutes the stdout. However this is done in prompter constructor, so every class, that depends on the prompter, automatically mutes the stdout.
Basically CLI mutes the stdout on almost all commands. This causes issues when `tns plugin add` command is used and the plugin wants to prompt the user for something on postinstall.
Fix this by calling mute exactly before prompting the user and calling unmute immediately after user sends his answer.