### PR TITLE
Move additional files in .ab folder

### DIFF
--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -29,6 +29,8 @@ declare module Project {
 		NATIVESCRIPT_APP_DIR_NAME: string;
 		IMAGE_DEFINITIONS_FILE_NAME: string;
 		PACKAGE_JSON_NAME: string;
+		ADDITIONAL_FILE_DISPOSITION: string;
+		ADDITIONAL_FILES_DIRECTORY: string;
 	}
 
 	interface ICapabilities {

--- a/appbuilder/project-constants.ts
+++ b/appbuilder/project-constants.ts
@@ -15,6 +15,8 @@ export class ProjectConstants implements Project.IConstants {
 	public NATIVESCRIPT_APP_DIR_NAME = "app";
 	public IMAGE_DEFINITIONS_FILE_NAME = 'image-definitions.json';
 	public PACKAGE_JSON_NAME = "package.json";
+	public ADDITIONAL_FILE_DISPOSITION = "AdditionalFile";
+	public ADDITIONAL_FILES_DIRECTORY = ".ab";
 
 	public TARGET_FRAMEWORK_IDENTIFIERS = {
 		Cordova: "Cordova",


### PR DESCRIPTION
When building the project with --download the configuration files for all platforms should be downloaded in .ab folder