### PR TITLE
 Add warn for new versions

### DIFF
--- a/commands/doctor.ts
+++ b/commands/doctor.ts
@@ -18,7 +18,7 @@ export class DoctorCommand implements ICommand {
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
-			let warningsPrinted = this.$doctorService.printWarnings();
+			let warningsPrinted = this.$doctorService.printWarnings().wait();
 			if (warningsPrinted) {
 				let client = this.$staticConfig.CLIENT_NAME_ALIAS || this.$staticConfig.CLIENT_NAME;
 				this.$logger.out(`These warnings are just used to help the ${client} maintainers with debugging if you file an issue.`.bold

--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -28,7 +28,7 @@ export class PostInstallCommand implements ICommand {
 
 			this.$htmlHelpService.generateHtmlPages().wait();
 
-			let doctorResult = this.$doctorService.printWarnings({ trackResult: false });
+			let doctorResult = this.$doctorService.printWarnings({ trackResult: false }).wait();
 			// Explicitly ask for confirmation of usage-reporting:
 			this.$analyticsService.checkConsent().wait();
 

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -724,9 +724,9 @@ interface IDoctorService {
 	/**
 	 * Verifies the host OS configuration and prints warnings to the users
 	 * @param configOptions: defines if the result should be tracked by Analytics
-	 * @returns {boolean} true if at least one warning was printed
+	 * @returns {IFuture<boolean>} true if at least one warning was printed
 	 */
-	printWarnings(configOptions?: { trackResult: boolean }): boolean;
+	printWarnings(configOptions?: { trackResult: boolean }): IFuture<boolean>;
 }
 
 interface IUtils {
@@ -1012,4 +1012,22 @@ interface ILiveSyncProvider {
 	 * Checks if the specified file can be fast synced.
 	 */
 	canExecuteFastSync(filePath: string, platform?: string): boolean;
+}
+
+/**
+ * Describes imformation about the version of component
+ */
+interface IVersionInformation {
+	/**
+	 * Component name.
+	 */
+	componentName: string;
+	/**
+	 * The current version of the component if available.
+	 */
+	currentVersion?: string;
+	/**
+	 * The latest available version of the component.
+	 */
+	latestVersion: string;
 }

--- a/helpers.ts
+++ b/helpers.ts
@@ -166,13 +166,13 @@ export function trimSymbol(str: string, symbol: string) {
 }
 
 // TODO: Use generic for predicatе predicate: (element: T|T[]) when TypeScript support this.
-export function getFuturesResults<T>(futures: IFuture<T|T[]>[], predicate: (element: any) => boolean): T[] {
+export function getFuturesResults<T>(futures: IFuture<T | T[]>[], predicate: (element: any) => boolean): T[] {
 	Future.wait(futures);
 	return _(futures)
-			.map(f => f.get())
-			.filter(predicate)
-			.flatten<T>()
-			.value();
+		.map(f => f.get())
+		.filter(predicate)
+		.flatten<T>()
+		.value();
 }
 
 export function appendZeroesToVersion(version: string, requiredVersionLength: number): string {
@@ -237,7 +237,7 @@ export function hook(commandName: string) {
 }
 
 export function isFuture(candidateFuture: any): boolean {
-	return !!(candidateFuture && typeof(candidateFuture.wait) === "function");
+	return !!(candidateFuture && typeof (candidateFuture.wait) === "function");
 }
 
 export function whenAny<T>(...futures: IFuture<T>[]): IFuture<IFuture<T>> {
@@ -310,13 +310,13 @@ export function annotate(fn: any) {
 		fnText: string,
 		argDecl: string[];
 
-	if(typeof fn === "function") {
-		if(!($inject = fn.$inject) || $inject.name !== fn.name) {
+	if (typeof fn === "function") {
+		if (!($inject = fn.$inject) || $inject.name !== fn.name) {
 			$inject = { args: [], name: "" };
 			fnText = fn.toString().replace(STRIP_COMMENTS, '');
 			argDecl = fnText.match(FN_NAME_AND_ARGS);
 			$inject.name = argDecl[1];
-			if(fn.length) {
+			if (fn.length) {
 				argDecl[2].split(FN_ARG_SPLIT).forEach((arg) => {
 					arg.replace(FN_ARG, (all, underscore, name) => $inject.args.push(name));
 				});


### PR DESCRIPTION
When executing tns doctor outside of project if the nativescript cli needs update it will print information for the available update.
If tns doctor is executed in project it will check the installed runtimes versions and the nativescript core modules version and print information if an update is needed.
Add tns info command to display versions information for NativeScript CLI, core modules and runtimes.