### PR TITLE
Change LiveSync directory for iOS NativeScript

### DIFF
--- a/appbuilder/providers/device-app-data-provider.ts
+++ b/appbuilder/providers/device-app-data-provider.ts
@@ -11,7 +11,6 @@ const DEVICE_TMP_DIR_FORMAT_V2 = "/data/local/tmp/12590FAA-5EDD-4B12-856D-F52A0A
 const DEVICE_TMP_DIR_FORMAT_V3 = "/mnt/sdcard/Android/data/%s/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2";
 const CHECK_LIVESYNC_INTENT_NAME = "com.telerik.IsLiveSyncSupported";
 const IOS_PROJECT_PATH = "/Library/Application Support/LiveSync";
-const IOS_NS_PROJECT_PATH = "/tmp/Application Support/LiveSync";
 
 export class AndroidAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	private _deviceProjectRootPath: string = null;
@@ -193,7 +192,7 @@ export class IOSNativeScriptAppIdentifier extends DeviceAppDataBase implements I
 				let applicationPath = this.$iOSSimResolver.iOSSim.getApplicationPath(this.device.deviceInfo.identifier, this.appIdentifier);
 				this._deviceProjectRootPath = path.join(applicationPath, "app");
 			} else {
-				this._deviceProjectRootPath = IOS_NS_PROJECT_PATH;
+				this._deviceProjectRootPath = IOS_PROJECT_PATH;
 			}
 		}
 

--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -1,7 +1,6 @@
 ///<reference path="../../../.d.ts"/>
 "use strict";
 
-import Future = require("fibers/future");
 import iOSProxyServices = require("../../../mobile/ios/device/ios-proxy-services");
 import * as path from "path";
 import * as shell from "shelljs";
@@ -64,8 +63,12 @@ export class IOSLiveSyncService implements IPlatformLiveSyncService {
 		}).future<void>()();
 	}
 
-	public removeFiles(): IFuture<void> {
-		return Future.fromResult();
+	public removeFiles(appIdentifier: string, localToDevicePaths:  Mobile.ILocalToDevicePathData[]): IFuture<void> {
+		return (() => {
+			localToDevicePaths
+				.map(localToDevicePath => localToDevicePath.getDevicePath())
+				.forEach(deviceFilePath => this.device.fileSystem.deleteFile(deviceFilePath, appIdentifier));
+		}).future<void>()();
 	}
 }
 $injector.register("iosLiveSyncServiceLocator", {factory: IOSLiveSyncService});


### PR DESCRIPTION
Change LiveSync directory for NativeScript projects on iOS devices to be the place where ios runtime will use as entry point.