### PR TITLE
Fix livesync issues when app is not installed on device

### DIFF
--- a/appbuilder/providers/device-app-data-provider.ts
+++ b/appbuilder/providers/device-app-data-provider.ts
@@ -212,7 +212,7 @@ export class IOSNativeScriptAppIdentifier extends DeviceAppDataBase implements I
 	}
 
 	isLiveSyncSupported(): IFuture<boolean> {
-		return this.device.applicationManager.isApplicationInstalled(this.appIdentifier);
+		return Future.fromResult(true);
 	}
 }
 

--- a/services/livesync-service-base.ts
+++ b/services/livesync-service-base.ts
@@ -38,6 +38,7 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 
 	public sync(data: ILiveSyncData, filePaths?: string[]): IFuture<void> {
 		return (() => {
+			console.log("SYNC CALLED");
 			this.syncCore(data, filePaths).wait();
 
 			if (this.$options.watch) {
@@ -182,7 +183,7 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 						}
 
 						// Not installed application
-						if (!device.applicationManager.isApplicationInstalled(appIdentifier).wait()) {
+						if (!device.applicationManager.isApplicationInstalled(appIdentifier).wait() && !this.$options.companion) {
 							this.$logger.warn(`The application with id "${appIdentifier}" is not installed on device with identifier ${device.deviceInfo.identifier}.`);
 							if (!packageFilePath) {
 								packageFilePath = this.$liveSyncProvider.buildForDevice(device).wait();


### PR DESCRIPTION
* Fix LiveSync issue for NativeScript iOS projects, when application is not installed on device and `$ appbuilder livesync ios` is called - this should install the application. Instead it does nothing.
* Fix LiveSync to companion app when application is not installed on device. Currently it was trying to install the application instead of sending the app to companion.