### PR TITLE
Fix LiveSync for iOS Simulator

### DIFF
--- a/appbuilder/providers/device-app-data-provider.ts
+++ b/appbuilder/providers/device-app-data-provider.ts
@@ -6,11 +6,7 @@ import Future = require("fibers/future");
 import * as querystring from "querystring";
 import * as path from "path";
 import * as util from "util";
-
-const DEVICE_TMP_DIR_FORMAT_V2 = "/data/local/tmp/12590FAA-5EDD-4B12-856D-F52A0A1599F2/%s";
-const DEVICE_TMP_DIR_FORMAT_V3 = "/mnt/sdcard/Android/data/%s/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2";
-const CHECK_LIVESYNC_INTENT_NAME = "com.telerik.IsLiveSyncSupported";
-const IOS_PROJECT_PATH = "/Library/Application Support/LiveSync";
+import { LiveSyncConstants } from "../../mobile/constants";
 
 export class AndroidAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	private _deviceProjectRootPath: string = null;
@@ -31,9 +27,9 @@ export class AndroidAppIdentifier extends DeviceAppDataBase implements ILiveSync
 
 			let version = this.getLiveSyncVersion().wait();
 			if (version === 2) {
-				deviceTmpDirFormat = DEVICE_TMP_DIR_FORMAT_V2;
+				deviceTmpDirFormat = LiveSyncConstants.DEVICE_TMP_DIR_FORMAT_V2;
 			} else if (version === 3) {
-				deviceTmpDirFormat = DEVICE_TMP_DIR_FORMAT_V3;
+				deviceTmpDirFormat = LiveSyncConstants.DEVICE_TMP_DIR_FORMAT_V3;
 			} else {
 				this.$errors.failWithoutHelp(`Unsupported LiveSync version: ${version}`);
 			}
@@ -69,7 +65,7 @@ export class AndroidAppIdentifier extends DeviceAppDataBase implements ILiveSync
 	private getLiveSyncVersion(): IFuture<number> {
 		return (() => {
 			if (!this._liveSyncVersion) {
-				this._liveSyncVersion = (<Mobile.IAndroidDevice>this.device).adb.sendBroadcastToDevice(CHECK_LIVESYNC_INTENT_NAME, {"app-id": this.appIdentifier}).wait();
+				this._liveSyncVersion = (<Mobile.IAndroidDevice>this.device).adb.sendBroadcastToDevice(LiveSyncConstants.CHECK_LIVESYNC_INTENT_NAME, {"app-id": this.appIdentifier}).wait();
 			}
 			return this._liveSyncVersion;
 		}).future<number>()();
@@ -86,7 +82,7 @@ export class AndroidCompanionAppIdentifier extends DeviceAppDataBase implements 
 	}
 
 	public get deviceProjectRootPath(): string {
-		return this.getDeviceProjectRootPath(util.format(DEVICE_TMP_DIR_FORMAT_V3, this.appIdentifier));
+		return this.getDeviceProjectRootPath(util.format(LiveSyncConstants.DEVICE_TMP_DIR_FORMAT_V3, this.appIdentifier));
 	}
 
 	public get liveSyncFormat(): string {
@@ -116,7 +112,7 @@ export class AndroidNativeScriptCompanionAppIdentifier extends DeviceAppDataBase
 	}
 
 	public get deviceProjectRootPath(): string {
-		return util.format(DEVICE_TMP_DIR_FORMAT_V3, this.appIdentifier);
+		return util.format(LiveSyncConstants.DEVICE_TMP_DIR_FORMAT_V3, this.appIdentifier);
 	}
 
 	public get liveSyncFormat(): string {
@@ -152,7 +148,7 @@ export class IOSAppIdentifier extends DeviceAppDataBase implements ILiveSyncDevi
 				let applicationPath = this.$iOSSimResolver.iOSSim.getApplicationPath(this.device.deviceInfo.identifier, this.appIdentifier);
 				this._deviceProjectRootPath = path.join(applicationPath, "www");
 			} else {
-				this._deviceProjectRootPath = IOS_PROJECT_PATH;
+				this._deviceProjectRootPath = LiveSyncConstants.IOS_PROJECT_PATH;
 			}
 		}
 
@@ -190,9 +186,9 @@ export class IOSNativeScriptAppIdentifier extends DeviceAppDataBase implements I
 		if (!this._deviceProjectRootPath) {
 			if (this.device.isEmulator) {
 				let applicationPath = this.$iOSSimResolver.iOSSim.getApplicationPath(this.device.deviceInfo.identifier, this.appIdentifier);
-				this._deviceProjectRootPath = path.join(applicationPath, "app");
+				this._deviceProjectRootPath = applicationPath;
 			} else {
-				this._deviceProjectRootPath = IOS_PROJECT_PATH;
+				this._deviceProjectRootPath = LiveSyncConstants.IOS_PROJECT_PATH;
 			}
 		}
 
@@ -225,7 +221,7 @@ export class IOSCompanionAppIdentifier extends DeviceAppDataBase implements ILiv
 	}
 
 	public get deviceProjectRootPath(): string {
-		return IOS_PROJECT_PATH;
+		return LiveSyncConstants.IOS_PROJECT_PATH;
 	}
 
 	public get liveSyncFormat(): string {
@@ -254,7 +250,7 @@ export class IOSNativeScriptCompanionAppIdentifier extends DeviceAppDataBase imp
 	}
 
 	public get deviceProjectRootPath(): string {
-		return IOS_PROJECT_PATH;
+		return LiveSyncConstants.IOS_PROJECT_PATH;
 	}
 
 	public get liveSyncFormat(): string {

--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -5,6 +5,7 @@ import iOSProxyServices = require("../../../mobile/ios/device/ios-proxy-services
 import * as path from "path";
 import * as shell from "shelljs";
 let osenv = require("osenv");
+import { LiveSyncConstants } from "../../../mobile/constants";
 
 export class IOSLiveSyncService implements IPlatformLiveSyncService {
 	private get $project(): any {
@@ -45,7 +46,7 @@ export class IOSLiveSyncService implements IPlatformLiveSyncService {
 				}
 
 				let sourcePath = deviceAppData.deviceProjectRootPath;
-				let destinationPath = path.join(simulatorCachePath, guid, "Documents");
+				let destinationPath = path.join(simulatorCachePath, guid, LiveSyncConstants.IOS_PROJECT_PATH);
 
 				this.$logger.trace(`Transferring from ${sourcePath} to ${destinationPath}`);
 				shell.cp("-Rf", path.join(sourcePath, "*"), destinationPath);

--- a/mobile/constants.ts
+++ b/mobile/constants.ts
@@ -12,3 +12,10 @@ export let ERROR_NO_DEVICES = "Cannot find connected devices. Reconnect any conn
 
 export let UNREACHABLE_STATUS = "Unreachable";
 export let CONNECTED_STATUS = "Connected";
+
+export class LiveSyncConstants {
+	static DEVICE_TMP_DIR_FORMAT_V2 = "/data/local/tmp/12590FAA-5EDD-4B12-856D-F52A0A1599F2/%s";
+	static DEVICE_TMP_DIR_FORMAT_V3 = "/mnt/sdcard/Android/data/%s/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2";
+	static CHECK_LIVESYNC_INTENT_NAME = "com.telerik.IsLiveSyncSupported";
+	static IOS_PROJECT_PATH = "/Library/Application Support/LiveSync";
+}


### PR DESCRIPTION
Fix LiveSync for iOS Simulator by changing:
* Root Project Path for NativeScript applications, which was incorrectly including "app" dir.
* Fix path where we copy files to be the iOS LiveSync Dir (/Library/Application Support/LiveSync) - for Cordova projects, the LiveSync plugin automatically gets all files from bundle to this directory, so next time when CLI livesyncs to simulator, we place the new files in the bundle. LiveSync plugin will not pull these changes in the LiveSync dir, so we have to do it manually.

Move LiveSync constants in the constants file.