### PR TITLE
Add application changed events

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,38 @@ interface IDeviceInfo {
 }
 ```
 
+### Module companionAppsService
+> Stability 2 - Stable
+
+`companionAppsService` gives access to companion apps identifiers.
+
+* `getAllCompanionAppIdentifiers`: returns all companion app identifiers in a JSON object, where the top level keys are frameworks (cordova and nativescript) and inner keys are platforms (android, ios, wp8).
+Sample usage:
+```JavaScript
+var companionAppIdentifiers = require("mobile-cli-lib").companionAppsService.getAllCompanionAppIdentifiers();
+```
+Result object is something like:
+```JSON
+{
+	'cordova': {
+		'android': 'android.cordova.companion.app.identifier',
+		'ios': 'ios.cordova.companion.app.identifier',
+		'wp8': 'wp8.cordova.companion.app.identifier'
+	},
+	'nativescript': {
+		'android': 'android.nativescript.companion.app.identifier',
+		'ios': 'ios.nativescript.companion.app.identifier',
+		'wp8': null
+	}
+}
+```
+
+* `getCompanionAppIdentifier(framework: string, platform: string): string` - returns companion app identifier for specified framework and platform.
+Sample usage:
+```JavaScript
+var companionAppIdentifiers = require("mobile-cli-lib").companionAppsService.getCompanionAppIdentifier("cordova", "android");
+```
+
 ### Module deviceEmitter
 > Stability 2 - Stable
 
@@ -240,12 +272,44 @@ require("mobile-cli-lib").deviceEmitter.on("deviceLost",  function(deviceInfoDat
 });
 ```
 
-* `deviceLogData` - Raised when attached device sends reports any information. This is the output of `adb logcat` for Android devices. For iOS this is the `iOS SysLog`.
+* `deviceLogData` - Raised when attached device reports any information. This is the output of `adb logcat` for Android devices. For iOS this is the `iOS SysLog`.
 The event is raised for any device that reports data. The callback function has two arguments - `deviceIdentifier` and `reportedData`. <br/><br/>
 Sample usage:
 ```JavaScript
 require("mobile-cli-lib").deviceEmitter.on("deviceLogData",  function(identifier, reportedData) {
 	console.log("Device " + identifier + " reports: " + reportedData);
+});
+```
+
+* `applicationInstalled` - Raised when application is installed on a device. The callback has two arguments - `deviceIdentifier` and `applicationIdentifier`. <br/><br/>
+Sample usage:
+```JavaScript
+require("mobile-cli-lib").deviceEmitter.on("applicationInstalled",  function(identifier, applicationIdentifier) {
+	console.log("Application " + applicationIdentifier  + " has been installed on device with id: " + identifier);
+});
+```
+
+* `applicationUninstalled` - Raised when application is removed from device. The callback has two arguments - `deviceIdentifier` and `applicationIdentifier`. <br/><br/>
+Sample usage:
+```JavaScript
+require("mobile-cli-lib").deviceEmitter.on("applicationUninstalled",  function(identifier, applicationIdentifier) {
+	console.log("Application " + applicationIdentifier  + " has been uninstalled from device with id: " + identifier);
+});
+```
+
+* `companionAppInstalled` - Raised when application is removed from device. The callback has two arguments - `deviceIdentifier` and `framwork`. <br/><br/>
+Sample usage:
+```JavaScript
+require("mobile-cli-lib").deviceEmitter.on("companionAppInstalled",  function(identifier, framwework) {
+	console.log("Companion app for " + framework  + " has been installed on device with id: " + identifier);
+});
+```
+
+* `companionAppUninstalled` - Raised when application is removed from device. The callback has two arguments - `deviceIdentifier` and `framwork`. <br/><br/>
+Sample usage:
+```JavaScript
+require("mobile-cli-lib").deviceEmitter.on("companionAppUninstalled",  function(identifier, framwework) {
+	console.log("Companion app for " + framework  + " has been uninstalled from device with id: " + identifier);
 });
 ```
 

--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -120,6 +120,22 @@ interface IDeviceLiveSyncInfo {
 	syncToCompanion: boolean;
 }
 
+/**
+ * Describes information about Telerik Companion Apps.
+ */
 interface ICompanionAppsService {
+	/**
+	 * Returns application identifier of the companion app for specified platform and framework.
+	 * @param {string} framework The framework for which Companion app identfier should be checked. Valid values are cordova and nativescript
+	 * @param {string} platform The device platform. Valid values are android, ios and wp8.
+	 * @return {string} Companion appIdentifier or null.
+	 */
 	getCompanionAppIdentifier(framework: string, platform: string): string;
+
+	/**
+	 * Returns all companion application identifiers in a dictionary where the top level keys are framwork identifiers.
+	 * For each framework there are three values, specified in a dictionary. The keys of the dictionary are platforms (android, ios and wp8).
+	 * @return {string} Companion appIdentifier or null.
+	 */
+	getAllCompanionAppIdentifiers(): IDictionary<IStringDictionary>;
 }

--- a/appbuilder/device-emitter.ts
+++ b/appbuilder/device-emitter.ts
@@ -8,38 +8,53 @@ class DeviceEmitter extends EventEmitter {
 		private $iOSDeviceDiscovery: Mobile.IDeviceDiscovery,
 		private $iOSSimulatorDiscovery: Mobile.IDeviceDiscovery,
 		private $devicesService: Mobile.IDevicesService,
-		private $deviceLogProvider: EventEmitter) {
+		private $deviceLogProvider: EventEmitter,
+		private $companionAppsService: ICompanionAppsService,
+		private $projectConstants: Project.IConstants,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
 		super();
+	}
+
+	private _companionAppIdentifiers: IDictionary<IStringDictionary>;
+	private get companionAppIdentifiers(): IDictionary<IStringDictionary> {
+		if(!this._companionAppIdentifiers) {
+			this._companionAppIdentifiers = this.$companionAppsService.getAllCompanionAppIdentifiers();
+		}
+
+		return this._companionAppIdentifiers;
 	}
 
 	public initialize(): IFuture<void> {
 		return (() => {
 			this.$androidDeviceDiscovery.ensureAdbServerStarted().wait();
-			this.$androidDeviceDiscovery.on("deviceFound", (data: Mobile.IDevice) => {
-				this.emit("deviceFound", data.deviceInfo);
-				data.openDeviceLogStream();
+			this.$androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+				this.emit("deviceFound", device.deviceInfo);
+				this.attachApplicationChangedHandlers(device);
+				device.openDeviceLogStream();
 			});
 
-			this.$androidDeviceDiscovery.on("deviceLost", (data: Mobile.IDevice) => {
-				this.emit("deviceLost", data.deviceInfo);
+			this.$androidDeviceDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+				this.emit("deviceLost", device.deviceInfo);
 			});
 
-			this.$iOSDeviceDiscovery.on("deviceFound", (data: Mobile.IDevice) => {
-				this.emit("deviceFound", data.deviceInfo);
-				data.openDeviceLogStream();
+			this.$iOSDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+				this.emit("deviceFound", device.deviceInfo);
+				this.attachApplicationChangedHandlers(device);
+				device.openDeviceLogStream();
 			});
 
-			this.$iOSDeviceDiscovery.on("deviceLost", (data: Mobile.IDevice) => {
-				this.emit("deviceLost", data.deviceInfo);
+			this.$iOSDeviceDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+				this.emit("deviceLost", device.deviceInfo);
 			});
 
-			this.$iOSSimulatorDiscovery.on("deviceFound", (data: Mobile.IDevice) => {
-				this.emit("deviceFound", data.deviceInfo);
-				data.openDeviceLogStream();
+			this.$iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+				this.emit("deviceFound", device.deviceInfo);
+				device.openDeviceLogStream();
+				this.attachApplicationChangedHandlers(device);
 			});
 
-			this.$iOSSimulatorDiscovery.on("deviceLost", (data: Mobile.IDevice) => {
-				this.emit("deviceLost", data.deviceInfo);
+			this.$iOSSimulatorDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+				this.emit("deviceLost", device.deviceInfo);
 			});
 
 			this.$devicesService.initialize({skipInferPlatform: true}).wait();
@@ -48,6 +63,29 @@ class DeviceEmitter extends EventEmitter {
 				this.emit('deviceLogData', identifier, data.toString());
 			});
 		}).future<void>()();
+	}
+
+	private attachApplicationChangedHandlers(device: Mobile.IDevice): void {
+		device.applicationManager.on("applicationInstalled", (applicationName: string) => {
+			this.emit("applicationInstalled", device.deviceInfo.identifier, applicationName);
+			this.checkCompanionAppChanged(device, applicationName, "companionAppInstalled");
+		});
+
+		device.applicationManager.on("applicationUninstalled", (applicationName: string) => {
+			this.emit("applicationUninstalled", device.deviceInfo.identifier, applicationName);
+			this.checkCompanionAppChanged(device, applicationName, "companionAppUninstalled");
+		});
+	}
+
+	private checkCompanionAppChanged(device: Mobile.IDevice, applicationName: string, eventName: string): void {
+		let devicePlatform = device.deviceInfo.platform.toLowerCase();
+		_.each(this.companionAppIdentifiers, (platformsCompanionAppIdentifiers: IStringDictionary, framework: string) => {
+			if(applicationName === platformsCompanionAppIdentifiers[devicePlatform]) {
+				this.emit(eventName, device.deviceInfo.identifier, framework);
+				// break each
+				return false;
+			}
+		});
 	}
 }
 $injector.register("deviceEmitter", DeviceEmitter);

--- a/appbuilder/providers/device-app-data-provider.ts
+++ b/appbuilder/providers/device-app-data-provider.ts
@@ -272,8 +272,10 @@ export class IOSNativeScriptCompanionAppIdentifier extends DeviceAppDataBase imp
 
 export class WP8CompanionAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	constructor(public device: Mobile.IDevice,
-		public platform: string) {
-		super("{9155af5b-e7ed-486d-bc6b-35087fb59ecc}");
+		public platform: string,
+		private $companionAppsService: ICompanionAppsService,
+		private $projectConstants: Project.IConstants) {
+		super($companionAppsService.getCompanionAppIdentifier($projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, platform));
 	}
 
 	public get deviceProjectRootPath(): string {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -181,7 +181,7 @@ declare module Mobile {
 		full: string;
 	}
 
-	interface IDeviceApplicationManager {
+	interface IDeviceApplicationManager extends NodeJS.EventEmitter {
 		getInstalledApplications(): IFuture<string[]>;
 		isApplicationInstalled(appIdentifier: string): IFuture<boolean>;
 		installApplication(packageFilePath: string): IFuture<void>;
@@ -191,6 +191,7 @@ declare module Mobile {
 		stopApplication(appIdentifier: string): IFuture<void>;
 		restartApplication(appIdentifier: string, bundleExecutable?: string): IFuture<void>;
 		canStartApplication(): boolean;
+		checkForApplicationUpdates(): IFuture<void>;
 	}
 
 	interface IDeviceFileSystem {

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -1,7 +1,11 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-export abstract class ApplicationManagerBase {
+import { EventEmitter } from "events";
+
+export abstract class ApplicationManagerBase extends EventEmitter implements Mobile.IDeviceApplicationManager {
+	private lastInstalledApplications: string[];
+
 	public reinstallApplication(appIdentifier: string, packageFilePath: string): IFuture<void> {
 		return (() => {
 			this.uninstallApplication(appIdentifier).wait();
@@ -23,9 +27,29 @@ export abstract class ApplicationManagerBase {
 		}).future<boolean>()();
 	}
 
+	public checkForApplicationUpdates(): IFuture<void> {
+		return (() => {
+			let newInstalledApplications = this.getInstalledApplications().wait();
+			let previouslyInstalledApplications = this.lastInstalledApplications || [];
+
+			_(newInstalledApplications)
+				.difference(previouslyInstalledApplications)
+				.each(application => this.emit("applicationInstalled", application))
+				.value();
+
+			_(previouslyInstalledApplications)
+				.difference(newInstalledApplications)
+				.each(application => this.emit("applicationUninstalled", application))
+				.value();
+
+			this.lastInstalledApplications = newInstalledApplications;
+		}).future<void>()();
+	}
+
 	public abstract installApplication(packageFilePath: string): IFuture<void>;
 	public abstract uninstallApplication(appIdentifier: string): IFuture<void>;
 	public abstract startApplication(appIdentifier: string): IFuture<void>;
 	public abstract stopApplication(appIdentifier: string): IFuture<void>;
 	public abstract getInstalledApplications(): IFuture<string[]>;
+	public abstract canStartApplication(): boolean;
 }

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -146,13 +146,31 @@ export class DevicesService implements Mobile.IDevicesService {
 							// This code could be faster, by using Future.wait([...]), but it turned out this is breaking iOS deployment on Mac
 							// It's causing error 21 when deploying on some iOS devices during transfer of the first package.
 							this.$iOSDeviceDiscovery.checkForDevices().wait();
+						} catch (err) {
+							this.$logger.trace("Error while checking for new iOS devices.", err);
+						}
+
+						try {
 							this.$androidDeviceDiscovery.checkForDevices().wait();
+						} catch (err) {
+							this.$logger.trace("Error while checking for new Android devices.", err);
+						}
+
+						try {
 							if (this.$hostInfo.isDarwin) {
 								this.$iOSSimulatorDiscovery.checkForDevices().wait();
 							}
 						} catch (err) {
-							this.$logger.trace("Error while checking for new devices.", err);
+							this.$logger.trace("Error while checking for new iOS Simulators.", err);
 						}
+
+						_.each(this._devices, device => {
+							try {
+								device.applicationManager.checkForApplicationUpdates().wait();
+							} catch (err) {
+								this.$logger.trace(`Error checking for application updates on device ${device.deviceInfo.identifier}.`, err);
+							}
+						});
 					});
 				}, DevicesService.DEVICE_LOOKING_INTERVAL).unref();
 			} else if(this.$mobileHelper.isiOSPlatform(this._platform)) {


### PR DESCRIPTION
Add events which are raised when applications are installed/uninstalled on devices.
DeviceEmitter will raise:
* `applicationInstalled` when app is installed on device. Passed params are device identifier and application identifier.
* `applicationUninstalled` when app is removed from device. Passed params are device identifier and application identifier.
* `companionAppInstalled` when one of the companion apps is installed on device. Passed params are device identifier and framework (cordova or nativescript).
* `companionAppUninstalled` when one of the companion apps is removed from. Passed params are device identifier and framework (cordova or nativescript).

Add new public method to companionAppsService:
`getAllCompanionAppIdentifiers` - returns JSON object with all companion app identifiers.

Update README with all the latest changes.