### PR TITLE
Add Android debug bridge result handler

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -79,6 +79,7 @@ $injector.require("androidDeviceDiscovery", "./mobile/mobile-core/android-device
 $injector.require("iOSDevice", "./mobile/ios/device/ios-device");
 $injector.require("iOSDeviceProductNameMapper", "./mobile/ios/ios-device-product-name-mapper");
 $injector.require("androidDevice", "./mobile/android/android-device");
+$injector.require("androidDebugBridgeResultHandler", "./mobile/android/android-debug-bridge-result-handler");
 $injector.require("logcatHelper", "./mobile/android/logcat-helper");
 $injector.require("iOSSimResolver", "./mobile/ios/simulator/ios-sim-resolver");
 

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -79,6 +79,7 @@ $injector.require("androidDeviceDiscovery", "./mobile/mobile-core/android-device
 $injector.require("iOSDevice", "./mobile/ios/device/ios-device");
 $injector.require("iOSDeviceProductNameMapper", "./mobile/ios/ios-device-product-name-mapper");
 $injector.require("androidDevice", "./mobile/android/android-device");
+$injector.require("adb", "./mobile/android/android-debug-bridge");
 $injector.require("androidDebugBridgeResultHandler", "./mobile/android/android-debug-bridge-result-handler");
 $injector.require("logcatHelper", "./mobile/android/logcat-helper");
 $injector.require("iOSSimResolver", "./mobile/ios/simulator/ios-sim-resolver");

--- a/commands/help.ts
+++ b/commands/help.ts
@@ -1,6 +1,7 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
+import * as androidDebugBridgePath from "../mobile/android/android-debug-bridge";
 import Future = require("fibers/future");
 
 export class HelpCommand implements ICommand {

--- a/commands/help.ts
+++ b/commands/help.ts
@@ -1,7 +1,6 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-import * as androidDebugBridgePath from "../mobile/android/android-debug-bridge";
 import Future = require("fibers/future");
 
 export class HelpCommand implements ICommand {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -212,12 +212,19 @@ declare module Mobile {
 		createFileOnDevice?(deviceFilePath: string, fileContent: string): IFuture<void>;
 	}
 
+	interface IAndroidDebugBridgeCommandOptions {
+		fromEvent?: string,
+		returnChildProcess?: boolean,
+		treatErrorsAsWarnings?: boolean,
+		childProcessOptions?: any
+	}
+
 	interface IAndroidDebugBridge {
-		executeCommand(args: string[], fromEvent?: string): IFuture<any>;
+		executeCommand(args: string[], options?: IAndroidDebugBridgeCommandOptions): IFuture<any>;
 	}
 
 	interface IDeviceAndroidDebugBridge extends IAndroidDebugBridge {
-		executeShellCommand(args: string[], fromEvent?: string): IFuture<any>;
+		executeShellCommand(args: string[], options?: IAndroidDebugBridgeCommandOptions): IFuture<any>;
 		sendBroadcastToDevice(action: string, extras?: IStringDictionary): IFuture<number>;
 	}
 
@@ -573,6 +580,6 @@ declare module Mobile {
 		 * @param {IAndroidDebugBridgeError[]} errors The Android debug bridge result errors.
 		 * @return {void}.
 		 */
-		handleErrors(errors: IAndroidDebugBridgeError[]): void;
+		handleErrors(errors: IAndroidDebugBridgeError[], treatErrorsAsWarnings?: boolean): void;
 	}
 }

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -240,7 +240,7 @@ declare module Mobile {
 	interface IDevicesService {
 		hasDevices: boolean;
 		deviceCount: number;
-		execute(action: (device: Mobile.IDevice) => IFuture<void>, canExecute?: (dev: Mobile.IDevice) => boolean, options?: {allowNoDevices?: boolean}): IFuture<void>;
+		execute(action: (device: Mobile.IDevice) => IFuture<void>, canExecute?: (dev: Mobile.IDevice) => boolean, options?: { allowNoDevices?: boolean }): IFuture<void>;
 		initialize(data?: IDevicesServicesInitializationOptions): IFuture<void>;
 		platform: string;
 		getDevices(): Mobile.IDeviceInfo[];
@@ -289,11 +289,11 @@ declare module Mobile {
 		stringGetLength(theString: NodeBuffer): number;
 		dictionaryGetCount(theDict: NodeBuffer): number;
 		createCFString(str: string): NodeBuffer;
-		dictToPlistEncoding(dict: {[key: string]: {}}, format: number): NodeBuffer;
+		dictToPlistEncoding(dict: { [key: string]: {} }, format: number): NodeBuffer;
 		dictFromPlistEncoding(str: NodeBuffer): NodeBuffer;
 		dictionaryGetTypeID(): number;
 		stringGetTypeID(): number;
-		dataGetTypeID():  number;
+		dataGetTypeID(): number;
 		numberGetTypeID(): number;
 		booleanGetTypeID(): number;
 		arrayGetTypeID(): number;
@@ -335,7 +335,7 @@ declare module Mobile {
 		afcFileRefRead(afcConnection: NodeBuffer, afcFileRef: number, buffer: NodeBuffer, byteLength: NodeBuffer): number;
 		afcRemovePath(afcConnection: NodeBuffer, path: string): number;
 		afcDirectoryOpen(afcConnection: NodeBuffer, path: string, afcDirectory: NodeBuffer): number;
-		afcDirectoryRead(afcConnection: NodeBuffer, afcdirectory: NodeBuffer,  name: NodeBuffer): number;
+		afcDirectoryRead(afcConnection: NodeBuffer, afcdirectory: NodeBuffer, name: NodeBuffer): number;
 		afcDirectoryClose(afcConnection: NodeBuffer, afcdirectory: NodeBuffer): number;
 		isDataReceivingCompleted(reply: IDictionary<any>): boolean;
 		setLogLevel(logLevel: number): number;
@@ -375,7 +375,7 @@ declare module Mobile {
 	}
 
 	interface ILocalToDevicePathDataFactory {
-		create(fileName: string, localProjectRootPath: string, onDeviceFileName: string, deviceProjectRootPath: string):  Mobile.ILocalToDevicePathData;
+		create(fileName: string, localProjectRootPath: string, onDeviceFileName: string, deviceProjectRootPath: string): Mobile.ILocalToDevicePathData;
 	}
 
 	interface IiOSSocketResponseData {
@@ -388,10 +388,10 @@ declare module Mobile {
 	interface IiOSDeviceSocket {
 		receiveMessage(): IFuture<IiOSSocketResponseData>;
 		readSystemLog(action: (data: string) => void): void;
-		sendMessage(message: {[key: string]: {}}, format?: number): void;
+		sendMessage(message: { [key: string]: {} }, format?: number): void;
 		sendMessage(message: string): void;
-		sendAll? (data: NodeBuffer): void;
-		receiveAll? (callback: (data: NodeBuffer) => void): void;
+		sendAll?(data: NodeBuffer): void;
+		receiveAll?(callback: (data: NodeBuffer) => void): void;
 		exchange(message: IDictionary<any>): IFuture<IiOSSocketResponseData>;
 		close(): void;
 	}
@@ -517,7 +517,7 @@ declare module Mobile {
 		/**
 		 * Computes the shasums of localToDevicePaths and changes the content of hash file on device
 		 */
-		uploadHashFileToDevice(data: IStringDictionary|Mobile.ILocalToDevicePathData[]): IFuture<void>;
+		uploadHashFileToDevice(data: IStringDictionary | Mobile.ILocalToDevicePathData[]): IFuture<void>;
 		/**
 		 * Computes the shasums of localToDevicePaths and updates hash file on device
 		 */
@@ -532,5 +532,44 @@ declare module Mobile {
 		 * @return {IFuture<boolean>} boolean True if file exists and false otherwise.
 		 */
 		doesShasumFileExistsOnDevice(): IFuture<boolean>;
+	}
+
+	/**
+	 * Describes information for Android debug bridge error.
+	 */
+	interface IAndroidDebugBridgeError {
+		/**
+		 * Name of the error.
+		 */
+		name: string;
+
+		/**
+		 * Description of the error.
+		 */
+		description: string;
+
+		/**
+		 * Returned result code.
+		 */
+		resultCode: number;
+	}
+
+	/**
+	 * Describes logic for handling Android debug bridge result.
+	 */
+	interface IAndroidDebugBridgeResultHandler {
+		/**
+		 * Checks the Android debug bridge result for errors.
+		 * @param {string} adbResult The Android debug bridge result.
+		 * @return {string} The errors found in the Android debug bridge result.
+		 */
+		checkForErrors(adbResult: any): IAndroidDebugBridgeError[];
+
+		/**
+		 * Handles the Android debug bridge result errors.
+		 * @param {IAndroidDebugBridgeError[]} errors The Android debug bridge result errors.
+		 * @return {void}.
+		 */
+		handleErrors(errors: IAndroidDebugBridgeError[]): void;
 	}
 }

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -95,7 +95,7 @@ declare module Mobile {
 	}
 
 	interface IAndroidDevice extends IDevice {
-		adb: Mobile.IAndroidDebugBridge;
+		adb: Mobile.IDeviceAndroidDebugBridge;
 	}
 
 	interface IiOSDevice extends IDevice {
@@ -213,8 +213,11 @@ declare module Mobile {
 	}
 
 	interface IAndroidDebugBridge {
-		executeCommand(args: string[]): IFuture<any>;
-		executeShellCommand(args: string[]): IFuture<any>;
+		executeCommand(args: string[], fromEvent?: string): IFuture<any>;
+	}
+
+	interface IDeviceAndroidDebugBridge extends IAndroidDebugBridge {
+		executeShellCommand(args: string[], fromEvent?: string): IFuture<any>;
 		sendBroadcastToDevice(action: string, extras?: IStringDictionary): IFuture<number>;
 	}
 

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -6,7 +6,7 @@ import { LiveSyncConstants } from "../../mobile/constants";
 
 export class AndroidApplicationManager extends ApplicationManagerBase {
 
-	constructor(private adb: Mobile.IAndroidDebugBridge,
+	constructor(private adb: Mobile.IDeviceAndroidDebugBridge,
 		private identifier: string,
 		private $staticConfig: Config.IStaticConfig,
 		private $options: ICommonOptions,

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -33,7 +33,8 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 	}
 
 	public uninstallApplication(appIdentifier: string): IFuture<void> {
-		return this.adb.executeShellCommand(["pm", "uninstall", `${appIdentifier}`]);
+		// Need to set the treatErrorsAsWarnings to true because when using tns run command if the application is not installed on the device it will throw error
+		return this.adb.executeShellCommand(["pm", "uninstall", `${appIdentifier}`], {treatErrorsAsWarnings: true});
 	}
 
 	public startApplication(appIdentifier: string): IFuture<void> {

--- a/mobile/android/android-debug-bridge-result-handler.ts
+++ b/mobile/android/android-debug-bridge-result-handler.ts
@@ -1,0 +1,255 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+import {EOL} from "os";
+
+export class AndroidDebugBridgeResultHandler implements Mobile.IAndroidDebugBridgeResultHandler {
+	private static ANDROID_DEBUG_BRIDGE_ERRORS: Mobile.IAndroidDebugBridgeError[] = [
+		{
+			name: "INSTALL_FAILED_ALREADY_EXISTS",
+			description: "The package is already installed.",
+			resultCode: -1
+		}, {
+			name: "INSTALL_FAILED_INVALID_APK",
+			description: "The package archive file is invalid.",
+			resultCode: -2
+		}, {
+			name: "INSTALL_FAILED_INVALID_URI",
+			description: "The URI passed in is invalid.",
+			resultCode: -3
+		}, {
+			name: "INSTALL_FAILED_INSUFFICIENT_STORAGE",
+			description: "The package manager service found that the device didn't have enough storage space to install the app.",
+			resultCode: -4
+		}, {
+			name: "INSTALL_FAILED_DUPLICATE_PACKAGE",
+			description: "A package is already installed with the same name.",
+			resultCode: -5
+		}, {
+			name: "INSTALL_FAILED_NO_SHARED_USER",
+			description: "The requested shared user does not exist.",
+			resultCode: -6
+		}, {
+			name: "INSTALL_FAILED_UPDATE_INCOMPATIBLE",
+			description: "A previously installed package of the same name has a different signature than the new package (and the old package's data was not removed).",
+			resultCode: -7
+		}, {
+			name: "INSTALL_FAILED_SHARED_USER_INCOMPATIBLE",
+			description: "The new package is requested a shared user which is already installed on the device and does not have matching signature.",
+			resultCode: -8
+		}, {
+			name: "INSTALL_FAILED_MISSING_SHARED_LIBRARY",
+			description: "The new package uses a shared library that is not available.",
+			resultCode: -9
+		}, {
+			name: "INSTALL_FAILED_REPLACE_COULDNT_DELETE",
+			description: "The new package uses a shared library that is not available.",
+			resultCode: -10
+		}, {
+			name: "INSTALL_FAILED_DEXOPT",
+			description: "The new package failed while optimizing and validating its dex files, either because there was not enough storage or the validation failed.",
+			resultCode: -11
+		}, {
+			name: "INSTALL_FAILED_OLDER_SDK",
+			description: "The new package failed because the current SDK version is older than that required by the package.",
+			resultCode: -12
+		}, {
+			name: "INSTALL_FAILED_CONFLICTING_PROVIDER",
+			description: "The new package failed because it contains a content provider with the same authority as a provider already installed in the system.",
+			resultCode: -13
+		}, {
+			name: "INSTALL_FAILED_NEWER_SDK",
+			description: "The new package failed because the current SDK version is newer than that required by the package.",
+			resultCode: -14
+		}, {
+			name: "INSTALL_FAILED_TEST_ONLY",
+			description: "The new package failed because it has specified that it is a test-only package and the caller has not supplied the #INSTALL_ALLOW_TEST flag.",
+			resultCode: -15
+		}, {
+			name: "INSTALL_FAILED_CPU_ABI_INCOMPATIBLE",
+			description: "The package being installed contains native code, but none that is compatible with the device's CPU_ABI.",
+			resultCode: -16
+		}, {
+			name: "INSTALL_FAILED_MISSING_FEATURE",
+			description: "The new package uses a feature that is not available.",
+			resultCode: -17
+		}, {
+			name: "INSTALL_FAILED_CONTAINER_ERROR",
+			description: "A secure container mount point couldn't be accessed on external media.",
+			resultCode: -18
+		}, {
+			name: "INSTALL_FAILED_INVALID_INSTALL_LOCATION",
+			description: "The new package couldn't be installed in the specified install location.",
+			resultCode: -19
+		}, {
+			name: "INSTALL_FAILED_MEDIA_UNAVAILABLE",
+			description: "The new package couldn't be installed in the specified install location because the media is not available.",
+			resultCode: -20
+		}, {
+			name: "INSTALL_FAILED_VERIFICATION_TIMEOUT",
+			description: "The new package couldn't be installed because the verification timed out.",
+			resultCode: -21
+		}, {
+			name: "INSTALL_FAILED_VERIFICATION_FAILURE",
+			description: "The new package couldn't be installed because the verification did not succeed.",
+			resultCode: -22
+		}, {
+			name: "INSTALL_FAILED_PACKAGE_CHANGED",
+			description: "The package changed from what the calling program expected.",
+			resultCode: -23
+		}, {
+			name: "INSTALL_FAILED_UID_CHANGED",
+			description: "The new package is assigned a different UID than it previously held.",
+			resultCode: -24
+		}, {
+			name: "INSTALL_FAILED_VERSION_DOWNGRADE",
+			description: "The new package has an older version code than the currently installed package.",
+			resultCode: -25
+		}, {
+			name: "INSTALL_FAILED_PERMISSION_MODEL_DOWNGRADE",
+			description: "The new package has target SDK low enough to not support runtime permissions.",
+			resultCode: -26
+		}, {
+			name: "INSTALL_PARSE_FAILED_NOT_APK",
+			description: "The parser was given a path that is not a file, or does not end with the expected '.apk' extension.",
+			resultCode: -100
+		}, {
+			name: "INSTALL_PARSE_FAILED_BAD_MANIFEST",
+			description: "The parser was unable to retrieve the AndroidManifest.xml file.",
+			resultCode: -101
+		}, {
+			name: "INSTALL_PARSE_FAILED_UNEXPECTED_EXCEPTION",
+			description: "The parser encountered an unexpected exception.",
+			resultCode: -102
+		}, {
+			name: "INSTALL_PARSE_FAILED_NO_CERTIFICATES",
+			description: "The parser did not find any certificates in the .apk.",
+			resultCode: -103
+		}, {
+			name: "INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES",
+			description: "The parser found inconsistent certificates on the files in the .apk.",
+			resultCode: -104
+		}, {
+			name: "INSTALL_PARSE_FAILED_CERTIFICATE_ENCODING",
+			description: "the parser encountered a CertificateEncodingException in one of the files in the .apk.",
+			resultCode: -105
+		}, {
+			name: "INSTALL_PARSE_FAILED_BAD_PACKAGE_NAME",
+			description: "The parser encountered a bad or missing package name in the manifest.",
+			resultCode: -106
+		}, {
+			name: "INSTALL_PARSE_FAILED_BAD_SHARED_USER_ID",
+			description: "The parser encountered a bad shared user id name in the manifest.",
+			resultCode: -107
+		}, {
+			name: "INSTALL_PARSE_FAILED_MANIFEST_MALFORMED",
+			description: "The parser encountered some structural problem in the manifest.",
+			resultCode: -108
+		}, {
+			name: "INSTALL_PARSE_FAILED_MANIFEST_EMPTY",
+			description: "The parser did not find any actionable tags (instrumentation or application) in the manifest.",
+			resultCode: -109
+		}, {
+			name: "INSTALL_FAILED_INTERNAL_ERROR",
+			description: "The system failed to install the package because of system issues.",
+			resultCode: -110
+		}, {
+			name: "INSTALL_FAILED_USER_RESTRICTED",
+			description: "The system failed to install the package because the user is restricted from installing apps.",
+			resultCode: -111
+		}, {
+			name: "INSTALL_FAILED_DUPLICATE_PERMISSION",
+			description: "The system failed to install the package because it is attempting to define a permission that is already defined by some existing package.",
+			resultCode: -112
+		}, {
+			name: "INSTALL_FAILED_NO_MATCHING_ABIS",
+			description: "The system failed to install the package because its packaged native code did not match any of the ABIs supported by the system.",
+			resultCode: -113
+		}, {
+			name: "NO_NATIVE_LIBRARIES ",
+			description: "The package being processed did not contain any native code.",
+			resultCode: -114
+		}, {
+			name: "INSTALL_FAILED_ABORTED",
+			description: "The instalation failed because it was aborted.",
+			resultCode: -115
+		}, {
+			name: "DELETE_FAILED_INTERNAL_ERROR",
+			description: "The system failed to delete the package for an unspecified reason.",
+			resultCode: -1
+		}, {
+			name: "DELETE_FAILED_DEVICE_POLICY_MANAGER",
+			description: "The system failed to delete the package because it is the active DevicePolicy manager.",
+			resultCode: -2
+		}, {
+			name: "DELETE_FAILED_USER_RESTRICTED",
+			description: "The system failed to delete the package since the user is restricted.",
+			resultCode: -3
+		}, {
+			name: "DELETE_FAILED_OWNER_BLOCKED",
+			description: "The system failed to delete the package because a profile or device owner has marked the package as uninstallable.",
+			resultCode: -4
+		}, {
+			name: "DELETE_FAILED_ABORTED",
+			description: "The delete failed because it was aborted.",
+			resultCode: -5
+		}, {
+			name: "MOVE_FAILED_INSUFFICIENT_STORAGE",
+			description: "The package hasn't been successfully moved by the system because of insufficient memory on specified media.",
+			resultCode: -1
+		}, {
+			name: "MOVE_FAILED_DOESNT_EXIST",
+			description: "The specified package doesn't exist.",
+			resultCode: -2
+		}, {
+			name: "MOVE_FAILED_SYSTEM_PACKAGE",
+			description: "The specified package cannot be moved since its a system package.",
+			resultCode: -3
+		}, {
+			name: "MOVE_FAILED_FORWARD_LOCKED",
+			description: "The specified package cannot be moved since its forward locked.",
+			resultCode: -4
+		}, {
+			name: "MOVE_FAILED_INVALID_LOCATION",
+			description: "The specified package cannot be moved to the specified location.",
+			resultCode: -5
+		}, {
+			name: "MOVE_FAILED_INTERNAL_ERROR",
+			description: "The specified package cannot be moved to the specified location.",
+			resultCode: -6
+		}, {
+			name: "MOVE_FAILED_OPERATION_PENDING",
+			description: "The specified package already has an operation pending in the PackageHandler queue.",
+			resultCode: -7
+		}
+	];
+
+	constructor(private $logger: ILogger,
+		private $errors: IErrors) { }
+
+	public checkForErrors(adbResult: any): Mobile.IAndroidDebugBridgeError[] {
+		let errors: Mobile.IAndroidDebugBridgeError[] = [];
+
+		_.each(AndroidDebugBridgeResultHandler.ANDROID_DEBUG_BRIDGE_ERRORS, (error: Mobile.IAndroidDebugBridgeError) => {
+			if (adbResult.stdout.indexOf(error.name) >= 0 ||
+				adbResult.stderr.indexOf(error.name) >= 0) {
+				errors.push(error);
+			}
+		});
+
+		return errors;
+	}
+
+	public handleErrors(errors: Mobile.IAndroidDebugBridgeError[]): void {
+		_.each(errors, (error: Mobile.IAndroidDebugBridgeError) => {
+			this.$logger.trace(`Error name: ${error.name} result code: ${error.resultCode}`);
+		});
+
+		let errorMessages = _(errors).map((error: Mobile.IAndroidDebugBridgeError) => error.description)
+			.join(EOL)
+			.toString();
+
+		this.$errors.failWithoutHelp(errorMessages);
+	}
+}
+
+$injector.register("androidDebugBridgeResultHandler", AndroidDebugBridgeResultHandler);

--- a/mobile/android/android-debug-bridge.ts
+++ b/mobile/android/android-debug-bridge.ts
@@ -1,28 +1,26 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
 
-import {EOL} from "os";
-
 interface IComposeCommandResult {
 	command: string;
 	args: string[];
 }
 
 export class AndroidDebugBridge implements Mobile.IAndroidDebugBridge {
-	constructor(private identifier: string,
-		private $childProcess: IChildProcess,
-		private $errors: IErrors,
-		private $logger: ILogger,
-		private $staticConfig: Config.IStaticConfig,
-		private $androidDebugBridgeResultHandler: Mobile.IAndroidDebugBridgeResultHandler) { }
+	constructor(protected $childProcess: IChildProcess,
+		protected $errors: IErrors,
+		protected $logger: ILogger,
+		protected $staticConfig: Config.IStaticConfig,
+		protected $androidDebugBridgeResultHandler: Mobile.IAndroidDebugBridgeResultHandler) { }
 
-	public executeCommand(args: string[]): IFuture<any> {
+	public executeCommand(args: string[], fromEvent?: string): IFuture<any> {
 		return (() => {
+			let event = fromEvent || "close";
 			let command = this.composeCommand(args).wait();
 			// If adb -s <invalid device id> install <smth> is executed the childProcess won't get any response
 			// because the adb will be waiting for valid device and will not send close or exit event.
 			// For example `adb -s <invalid device id> install <smth>` throws error 'error: device \'030939f508e6c773\' not found\r\n' exitCode 4294967295
-			let result: any = this.$childProcess.spawnFromEvent(command.command, command.args, "close", undefined, { throwError: false }).wait();
+			let result: any = this.$childProcess.spawnFromEvent(command.command, command.args, event, undefined, { throwError: false }).wait();
 
 			let errors = this.$androidDebugBridgeResultHandler.checkForErrors(result);
 
@@ -34,44 +32,18 @@ export class AndroidDebugBridge implements Mobile.IAndroidDebugBridge {
 		}).future<any>()();
 	}
 
-	public executeShellCommand(args: string[]): IFuture<any> {
-		return (() => {
-			args.unshift("shell");
-			let shellCommand = this.composeCommand(args).wait();
-			let result: any = this.$childProcess.spawnFromEvent(shellCommand.command, shellCommand.args, "close", undefined, { throwError: false }).wait();
-
-			let errors = this.$androidDebugBridgeResultHandler.checkForErrors(result);
-
-			if (errors && errors.length > 0) {
-				this.$androidDebugBridgeResultHandler.handleErrors(errors);
-			}
-
-			return result.stdout;
-		}).future<any>()();
-	}
-
-	public sendBroadcastToDevice(action: string, extras: IStringDictionary = {}): IFuture<number> {
-		return (() => {
-			let broadcastCommand = ["am", "broadcast", "-a", `${action}`];
-			_.each(extras, (value, key) => broadcastCommand.push("-e", key, value));
-
-			let result = this.executeShellCommand(broadcastCommand).wait();
-			this.$logger.trace(`Broadcast result ${result} from ${broadcastCommand}`);
-
-			let match = result.match(/Broadcast completed: result=(\d+)/);
-			if (match) {
-				return +match[1];
-			}
-
-			this.$errors.failWithoutHelp("Unable to broadcast to android device:\n%s", result);
-		}).future<number>()();
-	}
-
-	private composeCommand(params: string[]): IFuture<IComposeCommandResult> {
+	protected composeCommand(params: string[], identifier?: string): IFuture<IComposeCommandResult> {
 		return (() => {
 			let command = this.$staticConfig.getAdbFilePath().wait();
-			let args: string[] = ["-s", `${this.identifier}`].concat(params);
+			let deviceIdentifier: string[] = [];
+			if (identifier) {
+				deviceIdentifier = ["-s", `${identifier}`];
+			}
+
+			let args: string[] = deviceIdentifier.concat(params);
 			return { command, args };
 		}).future<IComposeCommandResult>()();
 	}
 }
+
+$injector.register("adb", AndroidDebugBridge);

--- a/mobile/android/android-debug-bridge.ts
+++ b/mobile/android/android-debug-bridge.ts
@@ -1,6 +1,8 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
 
+import {EOL} from "os";
+
 interface IComposeCommandResult {
 	command: string;
 	args: string[];
@@ -11,14 +13,24 @@ export class AndroidDebugBridge implements Mobile.IAndroidDebugBridge {
 		private $childProcess: IChildProcess,
 		private $errors: IErrors,
 		private $logger: ILogger,
-		private $staticConfig: Config.IStaticConfig) { }
+		private $staticConfig: Config.IStaticConfig,
+		private $androidDebugBridgeResultHandler: Mobile.IAndroidDebugBridgeResultHandler) { }
 
 	public executeCommand(args: string[]): IFuture<any> {
 		return (() => {
 			let command = this.composeCommand(args).wait();
-			// TODO: Remove throwError when adb output parse is implemented.
+			// If adb -s <invalid device id> install <smth> is executed the childProcess won't get any response
+			// because the adb will be waiting for valid device and will not send close or exit event.
 			// For example `adb -s <invalid device id> install <smth>` throws error 'error: device \'030939f508e6c773\' not found\r\n' exitCode 4294967295
-			return this.$childProcess.spawnFromEvent(command.command, command.args, "close", undefined, {throwError: false}).wait().stdout;
+			let result: any = this.$childProcess.spawnFromEvent(command.command, command.args, "close", undefined, { throwError: false }).wait();
+
+			let errors = this.$androidDebugBridgeResultHandler.checkForErrors(result);
+
+			if (errors && errors.length > 0) {
+				this.$androidDebugBridgeResultHandler.handleErrors(errors);
+			}
+
+			return result.stdout;
 		}).future<any>()();
 	}
 
@@ -26,14 +38,22 @@ export class AndroidDebugBridge implements Mobile.IAndroidDebugBridge {
 		return (() => {
 			args.unshift("shell");
 			let shellCommand = this.composeCommand(args).wait();
-			return this.$childProcess.spawnFromEvent(shellCommand.command, shellCommand.args, "close", undefined, {throwError: false}).wait().stdout;
+			let result: any = this.$childProcess.spawnFromEvent(shellCommand.command, shellCommand.args, "close", undefined, { throwError: false }).wait();
+
+			let errors = this.$androidDebugBridgeResultHandler.checkForErrors(result);
+
+			if (errors && errors.length > 0) {
+				this.$androidDebugBridgeResultHandler.handleErrors(errors);
+			}
+
+			return result.stdout;
 		}).future<any>()();
 	}
 
 	public sendBroadcastToDevice(action: string, extras: IStringDictionary = {}): IFuture<number> {
 		return (() => {
 			let broadcastCommand = ["am", "broadcast", "-a", `${action}`];
-			_.each(extras, (value,key) => broadcastCommand.push("-e", key, value));
+			_.each(extras, (value, key) => broadcastCommand.push("-e", key, value));
 
 			let result = this.executeShellCommand(broadcastCommand).wait();
 			this.$logger.trace(`Broadcast result ${result} from ${broadcastCommand}`);

--- a/mobile/android/android-device-file-system.ts
+++ b/mobile/android/android-device-file-system.ts
@@ -9,7 +9,7 @@ import Future = require("fibers/future");
 export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 	private _deviceHashServices = Object.create(null);
 
-	constructor(private adb: Mobile.IAndroidDebugBridge,
+	constructor(private adb: Mobile.IDeviceAndroidDebugBridge,
 		private identifier: string,
 		private $fs: IFileSystem,
 		private $logger: ILogger,

--- a/mobile/android/android-device-hash-service.ts
+++ b/mobile/android/android-device-hash-service.ts
@@ -12,7 +12,7 @@ export class AndroidDeviceHashService implements Mobile.IAndroidDeviceHashServic
 	private _hashFileLocalPath: string = null;
 	private _tempDir: string = null;
 
-	constructor(private adb: Mobile.IAndroidDebugBridge,
+	constructor(private adb: Mobile.IDeviceAndroidDebugBridge,
 		private appIdentifier: string,
 		private $fs: IFileSystem,
 		private $mobileHelper: Mobile.IMobileHelper) { }

--- a/mobile/android/android-device.ts
+++ b/mobile/android/android-device.ts
@@ -1,7 +1,7 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
 
-import * as androidDebugBridgePath from "./android-debug-bridge";
+import {DeviceAndroidDebugBridge} from "./device-android-debug-bridge";
 import * as applicationManagerPath from "./android-application-manager";
 import * as fileSystemPath from "./android-device-file-system";
 import * as constants from "../constants";
@@ -19,7 +19,7 @@ interface IAdbDeviceStatusInfo {
 }
 
 export class AndroidDevice implements Mobile.IAndroidDevice {
-	public adb: Mobile.IAndroidDebugBridge;
+	public adb: Mobile.IDeviceAndroidDebugBridge;
 	public applicationManager: Mobile.IDeviceApplicationManager;
 	public fileSystem: Mobile.IDeviceFileSystem;
 	public deviceInfo: Mobile.IDeviceInfo;
@@ -63,7 +63,7 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 		private $mobileHelper: Mobile.IMobileHelper,
 		private $injector: IInjector) {
 
-		this.adb = this.$injector.resolve(androidDebugBridgePath.AndroidDebugBridge, { identifier: this.identifier });
+		this.adb = this.$injector.resolve(DeviceAndroidDebugBridge, { identifier: this.identifier });
 		this.applicationManager = this.$injector.resolve(applicationManagerPath.AndroidApplicationManager, { adb: this.adb, identifier: this.identifier });
 		this.fileSystem = this.$injector.resolve(fileSystemPath.AndroidDeviceFileSystem, { adb: this.adb, identifier: this.identifier });
 

--- a/mobile/android/device-android-debug-bridge.ts
+++ b/mobile/android/device-android-debug-bridge.ts
@@ -18,21 +18,9 @@ export class DeviceAndroidDebugBridge extends AndroidDebugBridge implements Mobi
 		super($childProcess, $errors, $logger, $staticConfig, $androidDebugBridgeResultHandler);
 	}
 
-	public executeShellCommand(args: string[], fromEvent?: string): IFuture<any> {
-		return (() => {
-			let event = fromEvent || "close";
-			args.unshift("shell");
-			let shellCommand = this.composeCommand(args).wait();
-			let result: any = this.$childProcess.spawnFromEvent(shellCommand.command, shellCommand.args, event, undefined, { throwError: false }).wait();
-
-			let errors = this.$androidDebugBridgeResultHandler.checkForErrors(result);
-
-			if (errors && errors.length > 0) {
-				this.$androidDebugBridgeResultHandler.handleErrors(errors);
-			}
-
-			return result.stdout;
-		}).future<any>()();
+	public executeShellCommand(args: string[], options?: Mobile.IAndroidDebugBridgeCommandOptions): IFuture<any> {
+		args.unshift("shell");
+		return super.executeCommand(args, options);
 	}
 
 	public sendBroadcastToDevice(action: string, extras: IStringDictionary = {}): IFuture<number> {

--- a/mobile/android/device-android-debug-bridge.ts
+++ b/mobile/android/device-android-debug-bridge.ts
@@ -1,0 +1,58 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import {AndroidDebugBridge} from "./android-debug-bridge";
+
+interface IComposeCommandResult {
+	command: string;
+	args: string[];
+}
+
+export class DeviceAndroidDebugBridge extends AndroidDebugBridge implements Mobile.IDeviceAndroidDebugBridge {
+	constructor(private identifier: string,
+		protected $childProcess: IChildProcess,
+		protected $errors: IErrors,
+		protected $logger: ILogger,
+		protected $staticConfig: Config.IStaticConfig,
+		protected $androidDebugBridgeResultHandler: Mobile.IAndroidDebugBridgeResultHandler) {
+		super($childProcess, $errors, $logger, $staticConfig, $androidDebugBridgeResultHandler);
+	}
+
+	public executeShellCommand(args: string[], fromEvent?: string): IFuture<any> {
+		return (() => {
+			let event = fromEvent || "close";
+			args.unshift("shell");
+			let shellCommand = this.composeCommand(args).wait();
+			let result: any = this.$childProcess.spawnFromEvent(shellCommand.command, shellCommand.args, event, undefined, { throwError: false }).wait();
+
+			let errors = this.$androidDebugBridgeResultHandler.checkForErrors(result);
+
+			if (errors && errors.length > 0) {
+				this.$androidDebugBridgeResultHandler.handleErrors(errors);
+			}
+
+			return result.stdout;
+		}).future<any>()();
+	}
+
+	public sendBroadcastToDevice(action: string, extras: IStringDictionary = {}): IFuture<number> {
+		return (() => {
+			let broadcastCommand = ["am", "broadcast", "-a", `${action}`];
+			_.each(extras, (value, key) => broadcastCommand.push("-e", key, value));
+
+			let result = this.executeShellCommand(broadcastCommand).wait();
+			this.$logger.trace(`Broadcast result ${result} from ${broadcastCommand}`);
+
+			let match = result.match(/Broadcast completed: result=(\d+)/);
+			if (match) {
+				return +match[1];
+			}
+
+			this.$errors.failWithoutHelp("Unable to broadcast to android device:\n%s", result);
+		}).future<number>()();
+	}
+
+	protected composeCommand(params: string[]): IFuture<IComposeCommandResult> {
+		return super.composeCommand(params, this.identifier);
+	}
+}


### PR DESCRIPTION
The android debug bridge result handler checks if there are any errors after executing adb command.
Errors are copied from https://github.com/android/platform_frameworks_base/blob/master/core/java/android/content/pm/PackageManager.java and the handler checks if the result contains any of the errors.

The non-device Android debug bridge must be separated from the device-specific Android debug bridge. Non-device Android debug bridge can be injected through constructor and the device-specific Android debug bridge can be resolved using the $injector. This way the device-specific Android debug bridge will be unique for each device.

The adb commands should be executed through the custom adb wrapper to use the error handling.