### PR TITLE
Introduce `hooks` option

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -648,6 +648,7 @@ interface ICommonOptions {
 	default: Boolean;
 	release: boolean;
 	count: number;
+	hooks: boolean;
 }
 
 interface IYargArgv extends IDictionary<any> {

--- a/options.ts
+++ b/options.ts
@@ -72,7 +72,8 @@ export class OptionsBase {
 			"release": { type: OptionType.Boolean, alias: "r" },
 			"var": { type: OptionType.Object },
 			"default": { type: OptionType.Boolean },
-			"count": { type: OptionType.Number }
+			"count": { type: OptionType.Number },
+			"hooks": { type: OptionType.Boolean, default: true }
 		};
 	}
 

--- a/services/hooks-service.ts
+++ b/services/hooks-service.ts
@@ -24,7 +24,8 @@ export class HooksService implements IHooksService {
 		private $config: Config.IConfig,
 		private $staticConfig: Config.IStaticConfig,
 		private $injector: IInjector,
-		private $projectHelper: IProjectHelper) { }
+		private $projectHelper: IProjectHelper,
+		private $options: ICommonOptions) { }
 
 	private initialize(): void {
 		this.cachedHooks = {};
@@ -61,7 +62,7 @@ export class HooksService implements IHooksService {
 
 	private executeHooks(hookName: string, traceMessage: string, hookArguments?: IDictionary<any>): IFuture<void> {
 		return (() => {
-			if (this.$config.DISABLE_HOOKS) {
+			if (this.$config.DISABLE_HOOKS || !this.$options.hooks) {
 				return;
 			}
 


### PR DESCRIPTION
When `--no-hooks` is passed on command line, the hooks will not be executed.