### PR TITLE
Move logic for getting Xcode version to xcode-select-service

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -455,6 +455,11 @@ interface IXcodeSelectService {
 	 * @return {IFuture<string>}
 	 */
 	getDeveloperDirectoryPath(): IFuture<string>;
+	/**
+	 * Get version of the currently used Xcode.
+	 * @return {IFuture<IVersionData>}
+	 */
+	getXcodeVersion(): IFuture<IVersionData>;
 }
 
 interface ILiveSyncServiceBase {
@@ -1012,4 +1017,10 @@ interface ILiveSyncProvider {
 	 * Checks if the specified file can be fast synced.
 	 */
 	canExecuteFastSync(filePath: string, platform?: string): boolean;
+}
+
+interface IVersionData {
+	major: string;
+	minor: string;
+	patch: string;
 }


### PR DESCRIPTION
The logic is now used more than once and has to be extracted to a common place. Add test.
Ping @rosen-vladimirov 