### PR TITLE
Gather information about xcodeproj ruby gem's location

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -567,6 +567,8 @@ interface ISysInfoData {
 	javacVersion: string;
 	/** pod version string, as returned by `pod --version` **/
 	cocoapodVer: string;
+	/** xcodeproj gem location, as returned by `which gem xcodeproj` **/
+	xcodeprojGemLocation: string;
 }
 
 interface ISysInfo {

--- a/sys-info-base.ts
+++ b/sys-info-base.ts
@@ -53,6 +53,7 @@ export class SysInfoBase implements ISysInfo {
 
 				res.nodeGypVer = this.exec("node-gyp -v");
 				res.xcodeVer = this.$hostInfo.isDarwin ? this.exec("xcodebuild -version") : null;
+				res.xcodeprojGemLocation = this.$hostInfo.isDarwin ? this.exec("gem which xcodeproj") : null;
 				res.itunesInstalled = this.$iTunesValidator.getError().wait() === null;
 
 				res.cocoapodVer = this.getCocoapodVersion();


### PR DESCRIPTION
This gem is a dependency of CocoaPods but users may not want to install or use CocoaPods. However this gem is crucial for performing local builds for the iOS platform.

Ping @rosen-vladimirov for a quick review