### PR TITLE
Hide npm preuninstall errors

### DIFF
--- a/verify-node-version.ts
+++ b/verify-node-version.ts
@@ -3,12 +3,14 @@
 
 "use strict";
 import {EOL} from "os";
+import * as semver from "semver";
 
 // These versions cannot be used with CLI due to bugs in the node itself.
 // We are absolutely sure we cannot work with them, so inform the user if he is trying to use any of them and exit the process.
 let versionsCausingFailure = ["0.10.34", "4.0.0", "4.2.0", "5.0.0"];
 
 export function verifyNodeVersion(supportedVersionsRange: string): void {
+	// The colors module should not be assigned to variable because the lint task will fail for not used variable.
 	require("colors");
 	let nodeVer = process.version.substr(1);
 
@@ -17,7 +19,7 @@ export function verifyNodeVersion(supportedVersionsRange: string): void {
 		process.exit(1);
 	}
 
-	let checkSatisfied = require("semver").satisfies(nodeVer, supportedVersionsRange);
+	let checkSatisfied = semver.satisfies(nodeVer, supportedVersionsRange);
 	if (!checkSatisfied) {
 		console.log(`${EOL}Support for node.js ${nodeVer} is not verified. This CLI might not install or run properly.${EOL}`.yellow.bold);
 	}


### PR DESCRIPTION
Due to issue in npm versions 3.0, 3.5.1, 3.7.3 (may be more 3.x versions) the NativeScript node_modules are removed before the preuninstall script is executed and it fails.
The issue is logged in the npm repository: https://github.com/npm/npm/issues/8806 but it is not fixed in version 3.1.1 as commented in the discusion.