### PR TITLE
Track sessions count per analytics project

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -360,16 +360,18 @@ interface IAnalyticsSettingsService {
 	getPrivacyPolicyLink(): string;
 	/**
 	 * Gets current user sessions count.
+	 * @param {string} projectName The analytics project id for which the counter should be taken.
 	 * @return {number} Number of user sessions.
 	 */
-	getUserSessionsCount(): IFuture<number>;
+	getUserSessionsCount(projectName: string): IFuture<number>;
 
 	/**
 	 * Set the number of user sessions.
 	 * @param {number} count The number that will be set for user sessions.
+	 * @param {string} projectName The analytics project id for which the counter should be set.
 	 * @return {IFuture<void>}
 	 */
-	setUserSessionsCount(count: number): IFuture<void>;
+	setUserSessionsCount(count: number, projectName: string): IFuture<void>;
 }
 
 interface IHostCapabilities {

--- a/definitions/user-settings.d.ts
+++ b/definitions/user-settings.d.ts
@@ -2,5 +2,6 @@ declare module UserSettings {
 	interface IUserSettingsService {
 		getSettingValue<T>(settingName: string): IFuture<T>;
 		saveSetting<T>(key: string, value: T): IFuture<void>;
+		removeSetting(key: string): IFuture<void>;
 	}
 }

--- a/services/analytics-service.ts
+++ b/services/analytics-service.ts
@@ -160,8 +160,8 @@ export class AnalyticsService implements IAnalyticsService {
 			}
 
 			require("../vendor/EqatecMonitor.min");
-
-			let settings = global._eqatec.createSettings(analyticsProjectKey || this.$staticConfig.ANALYTICS_API_KEY);
+			analyticsProjectKey = analyticsProjectKey || this.$staticConfig.ANALYTICS_API_KEY;
+			let settings = global._eqatec.createSettings(analyticsProjectKey);
 			settings.useHttps = false;
 			settings.userAgent = this.getUserAgentString();
 			settings.version = this.$staticConfig.version;
@@ -183,9 +183,9 @@ export class AnalyticsService implements IAnalyticsService {
 
 			try {
 				this._eqatecMonitor.setUserID(this.$analyticsSettingsService.getUserId().wait());
-				let currentCount = this.$analyticsSettingsService.getUserSessionsCount().wait();
+				let currentCount = this.$analyticsSettingsService.getUserSessionsCount(analyticsProjectKey).wait();
 				// increment with 1 every time and persist the new value so next execution will be marked as new session
-				this.$analyticsSettingsService.setUserSessionsCount(++currentCount).wait();
+				this.$analyticsSettingsService.setUserSessionsCount(++currentCount, analyticsProjectKey).wait();
 				this._eqatecMonitor.setStartCount(currentCount);
 			} catch(e) {
 				// user not logged in. don't care.

--- a/services/user-settings-service.ts
+++ b/services/user-settings-service.ts
@@ -24,14 +24,26 @@ export class UserSettingsServiceBase implements UserSettings.IUserSettingsServic
 		return this.saveSettings(settingObject);
 	}
 
-	private saveSettings(data: any): IFuture<void> {
+	public removeSetting(key: string): IFuture<void> {
+		return (() => {
+			this.loadUserSettingsFile().wait();
+
+			delete this.userSettingsData[key];
+			this.saveSettings().wait();
+		}).future<void>()();
+	}
+
+	private saveSettings(data?: any): IFuture<void> {
 		return(() => {
 			this.loadUserSettingsFile().wait();
 			this.userSettingsData = this.userSettingsData || {};
 
-			Object.keys(data).forEach(propertyName => {
-				this.userSettingsData[propertyName] = data[propertyName];
-			});
+			_(data)
+				.keys()
+				.each(propertyName => {
+					this.userSettingsData[propertyName] = data[propertyName];
+				})
+				.value();
 
 			this.$fs.writeJson(this.userSettingsFilePath, this.userSettingsData, "\t").wait();
 		}).future<void>()();


### PR DESCRIPTION
Each sessions count should be tracked per project for which it is started. Currently we were using the same counter for all sessions.
Fix this by using separate counter for each project.
Remove the old key ("SESSIONS_STARTED") and use it as current value for the new key (`SESSIONS_STARTED_<analytics_project_key>`) in case it existed.