### PR TITLE
Fix printing of simulator logs when livesyncing

### DIFF
--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -14,8 +14,6 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase imple
 			super();
 		}
 
-	private deviceLoggingStarted = false;
-
 	public getInstalledApplications(): IFuture<string[]> {
 		return Future.fromResult(this.iosSim.getInstalledApplications(this.identifier));
 	}
@@ -31,8 +29,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase imple
 	public startApplication(appIdentifier: string): IFuture<void> {
 		return (() => {
 			let launchResult = this.iosSim.startApplication(this.identifier, appIdentifier).wait();
-			if (!this.$options.justlaunch && !this.deviceLoggingStarted) {
-				this.deviceLoggingStarted = true;
+			if (!this.$options.justlaunch) {
 				this.iosSim.printDeviceLog(this.identifier, launchResult);
 			}
 


### PR DESCRIPTION
Currenly when `tns livesync ios --watch` is used for iOS Simulator, CLI starts the application on device and prints filtered logs.
The filter is based on the process id of the currently started application. During livesync, the application is restarted, which changes the PID of the running process.
In this case we should start filtering based on the new PID.