### PR TITLE
Change LiveSync API for Proton

### DIFF
--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -96,8 +96,53 @@ interface IPathFilteringService {
 	isFileExcluded(file: string, rules: string[], rootDir: string): boolean
 }
 
+/**
+ * Describes available methods for LiveSync operation from Proton.
+ */
 interface IProtonLiveSyncService {
-	livesync(deviceIdentifiers: IDeviceLiveSyncInfo[], projectDir: string, filePaths: string[]): IFuture<void>;
+	/**
+	 * Sends files to specified devices.
+	 * @param {IDeviceLiveSyncInfo[]} deviceDescriptors Descriptions of the devices, which includes device identifiers and what should be synced.
+	 * @param {string} projectDir Project directory.
+	 * @param {string[]} filePaths Passed only in cases when only some of the files must be synced.
+	 * @return {IDeviceLiveSyncResult[]} Information about each LiveSync operation.
+	 */
+	livesync(deviceDescriptors: IDeviceLiveSyncInfo[], projectDir: string, filePaths?: string[]): IFuture<IDeviceLiveSyncResult>[];
+}
+
+/**
+ * Describes the result of a single livesync operation started by Proton.
+ */
+interface ILiveSyncOperationResult {
+	/**
+	 * Defines if the operation is successful (set to true) or not (value is false).
+	 */
+	isResolved: boolean;
+
+	/**
+	 * Error when livesync operation fails. If `isResolved` is true, error will be undefined.
+	 */
+	error?: Error;
+}
+
+/**
+ * Describes result of all LiveSync operations per device.
+ */
+interface IDeviceLiveSyncResult {
+	/**
+	 * Identifier of the device.
+	 */
+	deviceIdentifier: string;
+
+	/**
+	 * Result of LiveSync operation for application.
+	 */
+	liveSyncToApp?: ILiveSyncOperationResult;
+
+	/**
+	 * Result of LiveSync operation to companion app.
+	 */
+	liveSyncToCompanion?: ILiveSyncOperationResult;
 }
 
 /**

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -476,6 +476,25 @@ interface ILiveSyncServiceBase {
 	 * If watch option is specified executes partial sync
 	 */
 	sync(data: ILiveSyncData, filePaths?: string[]): IFuture<void>;
+
+	/**
+	 * Returns the `canExecute` method which defines if LiveSync operation can be executed on specified device.
+	 * @param {string} platform Platform for which the LiveSync operation should be executed.
+	 * @param {string} appIdentifier Application identifier.
+	 * @param {Function} canExecute Base canExecute function that will be added to the predefined checks.
+	 * @return {Function} Function that returns boolean.
+	 */
+	getCanExecuteAction(platform: string, appIdentifier: string, canExecute: (dev: Mobile.IDevice) => boolean): (dev: Mobile.IDevice) => boolean;
+
+	/**
+	 * Gets LiveSync action that should be executed per device.
+	 * @param {ILiveSyncData} data LiveSync data describing the LiveSync operation.
+	 * @param {string[]} filesToSync Files that have to be synced.
+	 * @param {Function} deviceFilesAction Custom action that has to be executed instead of just copying the files.
+	 * @param {any} liveSyncOptions Defines if the LiveSync operation is for Companion app.
+	 * @return {Function} Function that returns IFuture<void>.
+	 */
+	getSyncAction(data: ILiveSyncData, filesToSync?: string[], deviceFilesAction?: (device: Mobile.IDevice, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => IFuture<void>, liveSyncOptions?: { isForCompanionApp: boolean }): (device: Mobile.IDevice) => IFuture<void>;
 }
 
 interface ISyncBatch {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -116,7 +116,7 @@ declare module Mobile {
 	}
 
 	interface IDeviceAppDataFactory {
-		create<T extends Mobile.IDeviceAppData>(appIdentifier: string, platform: string, device: Mobile.IDevice): T;
+		create<T extends Mobile.IDeviceAppData>(appIdentifier: string, platform: string, device: Mobile.IDevice, liveSyncOptions?: { isForCompanionApp: boolean }): T;
 	}
 
 	interface IDeviceAppDataFactoryRule {

--- a/mobile/device-app-data/device-app-data-factory.ts
+++ b/mobile/device-app-data/device-app-data-factory.ts
@@ -6,9 +6,10 @@ export class DeviceAppDataFactory implements Mobile.IDeviceAppDataFactory {
 		private $injector: IInjector,
 		private $options: ICommonOptions) { }
 
-	create<T>(appIdentifier: string, platform: string, device: Mobile.IDevice): T {
+	create<T>(appIdentifier: string, platform: string, device: Mobile.IDevice, liveSyncOptions?: { isForCompanionApp: boolean }): T {
 		let factoryRules = this.$deviceAppDataProvider.createFactoryRules();
-		let ctor = (<any>factoryRules[platform])[this.$options.companion ? "companion" : "vanilla"];
+		let isForCompanionApp = (liveSyncOptions && liveSyncOptions.isForCompanionApp) || this.$options.companion;
+		let ctor = (<any>factoryRules[platform])[isForCompanionApp ? "companion" : "vanilla"];
 		return this.$injector.resolve(ctor, { _appIdentifier: appIdentifier, device: device, platform: platform });
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
Change LiveSync API for Proton to return array of Promises.
For each device we return Promise which contains information which livesync operation are successful.
Update device-app-data-factory to accept parameter if the LiveSync is for Companion app or not.