### PR TITLE
Fix simulator device detection

### DIFF
--- a/mobile/mobile-core/ios-simulator-discovery.ts
+++ b/mobile/mobile-core/ios-simulator-discovery.ts
@@ -20,14 +20,19 @@ class IOSSimulatorDiscovery extends DeviceDiscovery {
 	}
 
 	public checkForDevices(future?: IFuture<void>): IFuture<void> {
-		if (this.$hostInfo.isDarwin && this.isSimulatorRunning().wait()) {
-			let currentSimulator = this.$iOSSimResolver.iOSSim.getRunningSimulator();
+		if (this.$hostInfo.isDarwin) {
+			if (this.isSimulatorRunning().wait()) {
+				let currentSimulator = this.$iOSSimResolver.iOSSim.getRunningSimulator();
 
-			if (!this.cachedSimulator) {
-				this.createAndAddDevice(currentSimulator);
-			} else if (this.cachedSimulator.id !== currentSimulator.id) {
+				if (!this.cachedSimulator) {
+					this.createAndAddDevice(currentSimulator);
+				} else if (this.cachedSimulator.id !== currentSimulator.id) {
+					this.removeDevice(this.cachedSimulator.id);
+					this.createAndAddDevice(currentSimulator);
+				}
+			} else if (this.cachedSimulator) {
+				// In case there's no running simulator, but it's been running before, we should report it as removed.
 				this.removeDevice(this.cachedSimulator.id);
-				this.createAndAddDevice(currentSimulator);
 			}
 		}
 


### PR DESCRIPTION
When simulator is closed, we do not report it and we do not send deviceLost event.