### PR TITLE
Integrate Ionic CLI projects with AppBuilder CLI

### DIFF
--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -31,6 +31,8 @@ declare module Project {
 		PACKAGE_JSON_NAME: string;
 		ADDITIONAL_FILE_DISPOSITION: string;
 		ADDITIONAL_FILES_DIRECTORY: string;
+		APPBUILDER_PROJECT_PLATFORMS_NAMES: IDictionary<string>;
+		IONIC_PROJECT_PLATFORMS_NAMES: IDictionary<string>;
 	}
 
 	interface ICapabilities {
@@ -52,7 +54,7 @@ declare module Project {
 	interface IData extends IDictionary<any> {
 		ProjectName: string;
 		ProjectGuid: string;
-		projectVersion : number;
+		projectVersion: number;
 		AppIdentifier: string;
 		DisplayName: string;
 		Author: string;
@@ -92,8 +94,8 @@ declare module Project {
 }
 
 interface IPathFilteringService {
-	getRulesFromFile(file: string) : string[];
-	filterIgnoredFiles(files: string[], rules: string[], rootDir: string) :string[];
+	getRulesFromFile(file: string): string[];
+	filterIgnoredFiles(files: string[], rules: string[], rootDir: string): string[];
 	isFileExcluded(file: string, rules: string[], rootDir: string): boolean
 }
 

--- a/appbuilder/project-constants.ts
+++ b/appbuilder/project-constants.ts
@@ -22,6 +22,18 @@ export class ProjectConstants implements Project.IConstants {
 		Cordova: "Cordova",
 		NativeScript: "NativeScript"
 	};
+
+	public APPBUILDER_PROJECT_PLATFORMS_NAMES: IDictionary<string> = {
+		android: "Android",
+		ios: "iOS",
+		wp8: "WP8"
+	};
+
+	public IONIC_PROJECT_PLATFORMS_NAMES: IDictionary<string> = {
+		android: "android",
+		ios: "ios",
+		wp8: "wp8"
+	};
 }
 
 $injector.register("projectConstants", ProjectConstants);


### PR DESCRIPTION
The projects created with Ionic CLI have Ionic specific srtucture and some changes should be done to transform the project to AppBuilder hybrid project.
Rerouting index.html file should be created to pointto the Ionic index.html file in the www folder.
The resources should be copied from the resource folder to App_Resouces folder. Android resources should be renamed and put to the appropriate folders. Windows Phone 8 splashscreen should be JPG not PNG.
The information in the config.xml of the Ionic project should be split and moved to the appropriate AppBuilder folders. Also the sources of the resources should be changed to be relative to the newly added platform specifix config.xml.
All AppBuilder default plugins should be removed from the plugins folder to reduce the size of the project.
All unnecessary files and folders from the Ionic project should be removed.