### PR TITLE
Fix isLiveSyncSupported check for iOS devices on Mac

### DIFF
--- a/mobile/ios/device/ios-core.ts
+++ b/mobile/ios/device/ios-core.ts
@@ -927,14 +927,14 @@ class PosixSocket implements Mobile.IiOSDeviceSocket {
 
 												if (message.Status && message.Status === "Complete") {
 													if (!result.isResolved()) {
-														result.return(message);
+														result.return(messages);
 													}
 												} else {
 													messages.push(message);
 												}
 
-												let status = message[0].Status;
-												let percentComplete = message[0].PercentComplete;
+												let status = message.Status;
+												let percentComplete = message.PercentComplete;
 												this.$logger.trace("Status: " + status + " PercentComplete: " + percentComplete);
 											}
 										} catch (e) {


### PR DESCRIPTION
On Mac `receiveMessage` method returns only the last message instead of all. It contains only the Success/Fail status, so we decide that there are no applications that can be LiveSynced. This breaks Proton.