### PR TITLE
Fix livesync for iOS on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.8.1
+Latest version: 0.8.2
 
-Release date: 2016, April 26
+Release date: 2016, April 29
 
 ### System Requirements
 

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -254,6 +254,8 @@ declare module Mobile {
 		isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string): IFuture<boolean>[];
 		setLogLevel(logLevel: string, deviceIdentifier?: string): void;
 		deployOnDevices(deviceIdentifiers: string[], packageFile: string, packageName: string): IFuture<void>[];
+		startDeviceDetectionInterval(): void;
+		stopDeviceDetectionInterval(): void;
 	}
 
 	interface IiTunesValidator {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
The event loop is really messed with our setInterval that should detect devices. As it's running on 500ms, when livesync operation is in progress, it constantly fails.
As a workaround, stop the device detection while livesyncing and start it again after that.
Try moving device detection to a separate PR in the bright future.