### PR TITLE
Fix detection when iOS Sim is closed and reopened

### DIFF
--- a/mobile/mobile-core/ios-simulator-discovery.ts
+++ b/mobile/mobile-core/ios-simulator-discovery.ts
@@ -5,7 +5,7 @@ import {DeviceDiscovery} from "./device-discovery";
 import Future = require("fibers/future");
 import {IOSSimulator} from "./../ios/simulator/ios-simulator-device";
 
-class IOSSimulatorDiscovery extends DeviceDiscovery {
+export class IOSSimulatorDiscovery extends DeviceDiscovery {
 	private cachedSimulator: Mobile.IiSimDevice;
 
 	constructor(private $childProcess: IChildProcess,
@@ -33,6 +33,7 @@ class IOSSimulatorDiscovery extends DeviceDiscovery {
 			} else if (this.cachedSimulator) {
 				// In case there's no running simulator, but it's been running before, we should report it as removed.
 				this.removeDevice(this.cachedSimulator.id);
+				this.cachedSimulator = null;
 			}
 		}
 
@@ -55,8 +56,8 @@ class IOSSimulatorDiscovery extends DeviceDiscovery {
 	}
 
 	private createAndAddDevice(simulator: Mobile.IiSimDevice): void {
-		this.cachedSimulator = simulator;
-		this.addDevice(this.$injector.resolve(IOSSimulator, {simulator: simulator}));
+		this.cachedSimulator = _.cloneDeep(simulator);
+		this.addDevice(this.$injector.resolve(IOSSimulator, {simulator: this.cachedSimulator}));
 	}
 }
 $injector.register("iOSSimulatorDiscovery", IOSSimulatorDiscovery);

--- a/test/unit-tests/mobile/ios-simulator-discovery.ts
+++ b/test/unit-tests/mobile/ios-simulator-discovery.ts
@@ -1,0 +1,185 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+import {IOSSimulatorDiscovery} from "../../../mobile/mobile-core/ios-simulator-discovery";
+import {Yok} from "../../../yok";
+import Future = require("fibers/future");
+import { assert } from "chai";
+import { DevicePlatformsConstants } from "../../../mobile/device-platforms-constants";
+
+let currentlyRunningSimulator: any,
+	isCurrentlyRunning: boolean;
+
+function createTestInjector(): IInjector {
+	let injector = new Yok();
+	injector.register("childProcess", {
+		exec: (command: string) => Future.fromResult(isCurrentlyRunning ? 'launchd_sim' : '')
+	});
+	injector.register("injector", injector);
+	injector.register("iOSSimResolver", {
+		iOSSim: {
+			getRunningSimulator: () => currentlyRunningSimulator
+		}
+	});
+	injector.register("hostInfo", {
+		isDarwin: true
+	});
+
+	injector.register("devicePlatformsConstants", DevicePlatformsConstants);
+
+	injector.register("iOSSimResolver", {
+		iOSSim: {
+			getRunningSimulator: () => currentlyRunningSimulator
+		}
+	});
+
+	injector.register("iOSSimulatorDiscovery", IOSSimulatorDiscovery);
+	return injector;
+}
+
+describe("ios-simulator-discovery", () => {
+	let testInjector: IInjector,
+		iOSSimulatorDiscovery: Mobile.IDeviceDiscovery,
+		defaultRunningSimulator: any,
+		expectedDeviceInfo: Mobile.IDeviceInfo = null;
+
+	let detectNewSimulatorAttached = (runningSimulator: any): Mobile.IiOSSimulator => {
+		let future = new Future<any>();
+		isCurrentlyRunning = true;
+		currentlyRunningSimulator = _.cloneDeep(runningSimulator);
+		iOSSimulatorDiscovery.once("deviceFound", (device: Mobile.IDevice) => {
+			future.return(device);
+		});
+		iOSSimulatorDiscovery.startLookingForDevices().wait();
+		return future.wait();
+	};
+
+	let detectSimulatorDetached = (): Mobile.IiOSSimulator => {
+		isCurrentlyRunning = false;
+		let lostDeviceFuture = new Future<Mobile.IDevice>();
+		iOSSimulatorDiscovery.once("deviceLost", (device: Mobile.IDevice) => {
+			lostDeviceFuture.return(device);
+		});
+		iOSSimulatorDiscovery.startLookingForDevices().wait();
+		return lostDeviceFuture.wait();
+	};
+
+	let detectSimulatorChanged = (newId: string): any => {
+		isCurrentlyRunning = true;
+		currentlyRunningSimulator.id = newId;
+		let lostDeviceFuture = new Future<Mobile.IDevice>(),
+			foundDeviceFuture = new Future<Mobile.IDevice>();
+
+		iOSSimulatorDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+			lostDeviceFuture.return(device);
+		});
+
+		iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+			foundDeviceFuture.return(device);
+		});
+
+		iOSSimulatorDiscovery.startLookingForDevices().wait();
+
+		let deviceLost = lostDeviceFuture.wait();
+		let deviceFound = foundDeviceFuture.wait();
+		return { deviceLost, deviceFound };
+	};
+
+	beforeEach(() => {
+		isCurrentlyRunning = false;
+		currentlyRunningSimulator = null;
+		testInjector = createTestInjector();
+		iOSSimulatorDiscovery = testInjector.resolve("iOSSimulatorDiscovery");
+		expectedDeviceInfo = { identifier: "id",
+			displayName: 'name',
+			model: 'c',
+			version: '9.2.1',
+			vendor: 'Apple',
+			platform: 'iOS',
+			status: 'Connected',
+			errorHelp: null,
+			isTablet: false,
+			type: 'Emulator'
+		};
+
+		defaultRunningSimulator = {
+			id: "id",
+			name: "name",
+			fullId: "a.b.c",
+			runtimeVersion: "9.2.1",
+		};
+	});
+
+	it("finds new device when it is attached", () => {
+		let device = detectNewSimulatorAttached(defaultRunningSimulator);
+		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
+	});
+
+	it("raises deviceLost when device is detached", () => {
+		let device = detectNewSimulatorAttached(defaultRunningSimulator);
+		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
+		let lostDevice = detectSimulatorDetached();
+		assert.deepEqual(lostDevice, device);
+	});
+
+	it("raises deviceLost and deviceFound when device's id has changed (change simulator type)", () => {
+		let device = detectNewSimulatorAttached(defaultRunningSimulator),
+			newId = "newId";
+		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
+
+		let devices = detectSimulatorChanged(newId);
+		assert.deepEqual(devices.deviceLost, device);
+		expectedDeviceInfo.identifier = newId;
+		assert.deepEqual(devices.deviceFound.deviceInfo, expectedDeviceInfo);
+	});
+
+	it("raises events in correct order when simulator is started, closed and started again", () => {
+		let device = detectNewSimulatorAttached(defaultRunningSimulator);
+		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
+		let lostDevice = detectSimulatorDetached();
+		assert.deepEqual(lostDevice, device);
+
+		device = detectNewSimulatorAttached(defaultRunningSimulator);
+		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
+	});
+
+	it("finds new device when it is attached and reports it as new only once", () => {
+		let device = detectNewSimulatorAttached(defaultRunningSimulator);
+		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
+		iOSSimulatorDiscovery.on("deviceFound", (d: Mobile.IDevice) => {
+			throw new Error("Device found should not be raised for the same device.");
+		});
+		iOSSimulatorDiscovery.startLookingForDevices().wait();
+		iOSSimulatorDiscovery.startLookingForDevices().wait();
+	});
+
+	it("does not detect devices and does not throw when getting running iOS Simulator throws", () => {
+		testInjector.resolve("childProcess").exec = (command: string) => {
+			return (() => {
+				throw new Error("Cannot find iOS Devices.");
+			}).future<any>()();
+		};
+		isCurrentlyRunning = true;
+		iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+			throw new Error("Device found should not be raised when getting running iOS Simulator fails.");
+		});
+		iOSSimulatorDiscovery.startLookingForDevices().wait();
+	});
+
+	it("does not detect iOS Simulator when not running on OS X", () => {
+		testInjector.resolve("hostInfo").isDarwin = false;
+		isCurrentlyRunning = true;
+		iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+			throw new Error("Device found should not be raised when OS is not OS X.");
+		});
+		iOSSimulatorDiscovery.startLookingForDevices().wait();
+	});
+
+	it("checkForDevices return future", () => {
+		testInjector.resolve("hostInfo").isDarwin = false;
+		isCurrentlyRunning = true;
+		iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+			throw new Error("Device found should not be raised when OS is not OS X.");
+		});
+		iOSSimulatorDiscovery.checkForDevices().wait();
+	});
+});


### PR DESCRIPTION
In case you do:
 - start simulator
 - close simulator
 - start simulator

We are not reporting it as started the second time, as we are not clearing our cache. Clear the cache and add unit tests.
Use deep clone of the simulator object returned by ios-sim-portable in order to make the code testable.