### PR TITLE
Allow using .zip files for deploy to iOS simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.8.2
+Latest version: 0.8.3
 
-Release date: 2016, April 29
+Release date: 2016, May 11
 
 ### System Requirements
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.8.2",
+  "version": "0.8.3",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
Allow using .zip files for deploy to iOS simulator - if the passed path is .zip, extract it to temp dir and pass the temp dir to the simulator.