### PR TITLE
Change adb result handling in adb wrapper

### DIFF
--- a/mobile/android/android-debug-bridge.ts
+++ b/mobile/android/android-debug-bridge.ts
@@ -42,7 +42,7 @@ export class AndroidDebugBridge implements Mobile.IAndroidDebugBridge {
 			}
 
 			// Some adb commands returns array of strings instead of object with stdout and stderr. (adb start-server)
-			return result.stdout || result;
+			return (result.stdout === undefined || result.stdout === null) ? result : result.stdout;
 		}).future<any>()();
 	}
 


### PR DESCRIPTION
Some adb commands like adb start-server return array of strings not object with stdout need to check if stdout is undefined or null because if it is empty string it will return incorrect result.