### PR TITLE
Map Android WebView ports to local ones on demand

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -88,7 +88,7 @@ $injector.require("localToDevicePathDataFactory", "./mobile/local-to-device-path
 $injector.require("deviceAppDataFactory", "./mobile/device-app-data/device-app-data-factory");
 
 $injector.requirePublic("devicesService", "./mobile/mobile-core/devices-service");
-$injector.requirePublic("androidProcessService", "./mobile/mobile-core/android-process-service");
+$injector.require("androidProcessService", "./mobile/mobile-core/android-process-service");
 $injector.require("projectNameValidator", "./validators/project-name-validator");
 
 $injector.require("androidEmulatorServices", "./mobile/android/android-emulator-services");

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -88,6 +88,7 @@ $injector.require("localToDevicePathDataFactory", "./mobile/local-to-device-path
 $injector.require("deviceAppDataFactory", "./mobile/device-app-data/device-app-data-factory");
 
 $injector.requirePublic("devicesService", "./mobile/mobile-core/devices-service");
+$injector.requirePublic("androidProcessService", "./mobile/mobile-core/android-process-service");
 $injector.require("projectNameValidator", "./validators/project-name-validator");
 
 $injector.require("androidEmulatorServices", "./mobile/android/android-emulator-services");

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -277,8 +277,16 @@ declare module Mobile {
 		 * Checks for available ports and forwards the current abstract port to one of the available ports.
 		 * @param deviceIdentifier The identifier of the device.
 		 * @param appIdentifier The identifier of the application.
+		 * @return {string} Returns the tcp port number which is mapped to the abstract port.
 		 */
 		mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string): IFuture<string>;
+
+		/**
+		 * Gets the applications which are available for debugging on the specified device.
+		 * @param deviceIdentifier The identifier of the device.
+		 * @return {string[]} Returns array of applications identifiers which are available for debugging.
+		 */
+		getApplicationsAvailableForDebugging(deviceIdentifier: string): IFuture<string[]>;
 	}
 
 	interface IiTunesValidator {
@@ -597,10 +605,9 @@ declare module Mobile {
 	}
 
 	/**
-	 * Describes one row from ANdroid's proc/net/tcp table.
+	 * Describes one row from Android's proc/net/tcp table.
 	 */
 	interface IAndroidPortInformation {
-		sl: string;
 		/**
 		 * Local address in format: IP-address:port both in hex format.
 		 */
@@ -609,10 +616,6 @@ declare module Mobile {
 		 * Remote address in format: IP-address:port both in hex format.
 		 */
 		remAddress: string;
-		/**
-		 * In hex format.
-		 */
-		st: string;
 		/**
 		 * Process id.
 		 */

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -266,6 +266,19 @@ declare module Mobile {
 		startDeviceDetectionInterval(): void;
 		stopDeviceDetectionInterval(): void;
 		getDeviceByIdentifier(identifier: string): Mobile.IDevice;
+		mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string): IFuture<string>;
+	}
+
+	/**
+	 * Describes methods for working with Android processes.
+	 */
+	interface IAndroidProcessService {
+		/**
+		 * Checks for available ports and forwards the current abstract port to one of the available ports.
+		 * @param deviceIdentifier The identifier of the device.
+		 * @param appIdentifier The identifier of the application.
+		 */
+		mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string): IFuture<string>;
 	}
 
 	interface IiTunesValidator {
@@ -581,5 +594,40 @@ declare module Mobile {
 		 * @return {void}.
 		 */
 		handleErrors(errors: IAndroidDebugBridgeError[], treatErrorsAsWarnings?: boolean): void;
+	}
+
+	/**
+	 * Describes one row from ANdroid's proc/net/tcp table.
+	 */
+	interface IAndroidPortInformation {
+		sl: string;
+		/**
+		 * Local address in format: IP-address:port both in hex format.
+		 */
+		localAddress: string;
+		/**
+		 * Remote address in format: IP-address:port both in hex format.
+		 */
+		remAddress: string;
+		/**
+		 * In hex format.
+		 */
+		st: string;
+		/**
+		 * Process id.
+		 */
+		uid: number;
+		/**
+		 * Hex IP address.
+		 */
+		ipAddressHex: string;
+		/**
+		 * Decimal port number.
+		 */
+		number: number;
+		/**
+		 * Hex port number.
+		 */
+		numberHex: string;
 	}
 }

--- a/mobile/mobile-core/android-process-service.ts
+++ b/mobile/mobile-core/android-process-service.ts
@@ -1,35 +1,48 @@
 ///<reference path="./../../.d.ts"/>
 "use strict";
 
-import * as util from "util";
-import * as constants from "../constants";
 import {EOL} from "os";
-import * as androidDebugBridgePath from "../android/android-debug-bridge";
+import {DeviceAndroidDebugBridge} from "../android/device-android-debug-bridge";
 
 export class AndroidProcessService implements Mobile.IAndroidProcessService {
-	// Describes one row from the adb shell cat proc/net/tcp result.
-	private static ANDROID_PORT_INFORMATION_REGEX = /([0-9]+):\W+([0-9A-Za-z]+:[0-9A-Za-z]+)\W+([0-9A-Za-z]+:[0-9A-Za-z]+)\W+([0-9A-Za-z]+)\W+[0-9A-Za-z]+:[0-9A-Za-z]+\W+[0-9A-Za-z]+:[0-9A-Za-z]+ +[0-9A-Za-z]+\W+([0-9]+)/g;
+	private _devicesAdbs: IDictionary<Mobile.IDeviceAndroidDebugBridge>;
+
 	constructor(private $errors: IErrors,
 		private $staticConfig: Config.IStaticConfig,
-		private $injector: IInjector) { }
+		private $injector: IInjector) {
+		this._devicesAdbs = {};
+	}
+
+	private get androidPortInformationRegExp(): RegExp {
+		// The RegExp should look like this:
+		// /(\d+):\s+([0-9A-Za-z]+:[0-9A-Za-z]+)\s+([0-9A-Za-z]+:[0-9A-Za-z]+)\s+[0-9A-Za-z]+\s+[0-9A-Za-z]+:[0-9A-Za-z]+\s+[0-9A-Za-z]+:[0-9A-Za-z]+\s+[0-9A-Za-z]+\s+(\d+)/g
+		let wordCharacters = "[0-9A-Za-z]+";
+		let hexIpAddressWithPort = "[0-9A-Za-z]+:[0-9A-Za-z]+";
+		let hexIpAddressWithPortWithSpace = `${hexIpAddressWithPort}\\s+`;
+		let hexIpAddressWithPortWithSpaceMatch = `(${hexIpAddressWithPort})\\s+`;
+
+		return new RegExp(`(\\d+):\\s+${hexIpAddressWithPortWithSpaceMatch}${hexIpAddressWithPortWithSpaceMatch}${wordCharacters}\\s+${hexIpAddressWithPortWithSpace}${hexIpAddressWithPortWithSpace}${wordCharacters}\\s+(\\d+)`, "g");
+	}
 
 	public mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string): IFuture<string> {
 		return (() => {
-			let adb: Mobile.IAndroidDebugBridge = this.$injector.resolve(androidDebugBridgePath.AndroidDebugBridge, { identifier: deviceIdentifier });
+			let adb = this.getAdb(deviceIdentifier);
 			let processId = this.getProcessId(adb, appIdentifier).wait();
+			let applicationNotStartedErrorMessage = `The application is not started on the device with identifier ${deviceIdentifier}.`;
+
 			if (!processId) {
-				this.$errors.failWithoutHelp(`The application is not installed on the device with identifier ${deviceIdentifier}.`);
+				this.$errors.failWithoutHelp(applicationNotStartedErrorMessage);
 			}
 
 			let abstractPort = this.getAbstractPortForApplication(adb, processId, appIdentifier).wait();
 
 			if (!abstractPort) {
-				this.$errors.failWithoutHelp(`The application is not started on the device with identifier ${deviceIdentifier}.`);
+				this.$errors.failWithoutHelp(applicationNotStartedErrorMessage);
 			}
 
 			// Get the available ports information as late as possible.
 			let availablePorts: Mobile.IAndroidPortInformation[] = this.getAvailableAndroidPortsInformation(adb, appIdentifier).wait();
-			if (!availablePorts || availablePorts.length === 0) {
+			if (!availablePorts || !availablePorts.length) {
 				this.$errors.failWithoutHelp("There are no available ports.");
 			}
 
@@ -41,43 +54,78 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 		}).future<string>()();
 	}
 
-	private getAbstractPortForApplication(adb: Mobile.IAndroidDebugBridge, processId: string, appIdentifier: string): IFuture<string> {
+	public getApplicationsAvailableForDebugging(deviceIdentifier: string): IFuture<string[]> {
+		return (() => {
+			let adb = this.getAdb(deviceIdentifier);
+			let androidWebViewPortInformation = (<string>this.getAbstractPortsInformation(adb).wait()).split(EOL);
+
+			return androidWebViewPortInformation
+				.map((line: string) => this.getApplicationNameFromWebViewPortInformation(adb, line).wait())
+				.filter((appIdentifier: string) => !!appIdentifier);
+		}).future<string[]>()();
+	}
+
+	private getApplicationNameFromWebViewPortInformation(adb: Mobile.IDeviceAndroidDebugBridge, information: string): IFuture<string> {
+		return (() => {
+			// Need to search by processId to check for old Android webviews (@webview_devtools_remote_<processId>).
+			let processIdRegExp = /@webview_devtools_remote_(.+)/g;
+			let processIdMatches = processIdRegExp.exec(information);
+			if (processIdMatches) {
+				let processId = processIdMatches[1];
+				// Process information will look like this (without the columns names):
+				// USER     PID   PPID  VSIZE   RSS   WCHAN    PC         NAME
+				// u0_a63   25512 1334  1519560 96040 ffffffff f76a8f75 S com.telerik.appbuildertabstest
+				let processIdInformation: string = adb.executeShellCommand(["ps", "|grep", "-a", "--text", processId]).wait();
+
+				return _.last(processIdInformation.trim().split(/[ \t]/));
+			}
+
+			// Search for appIdentifier (@<appIdentifier>_devtools_remote).
+			let chromeAppIdentifierRegExp = /@(.+)_devtools_remote\s?/g;
+
+			// Search for appIdentifier (@<appIdentifier-debug>).
+			let nativeScriptAppIdentifierRegExp = /@(.+)-debug/g;
+
+			let chromeAppIdentifierMatches = chromeAppIdentifierRegExp.exec(information);
+			let nativeScriptAppIdentifierMatches = nativeScriptAppIdentifierRegExp.exec(information);
+
+			return (chromeAppIdentifierMatches && chromeAppIdentifierMatches[1]) || (nativeScriptAppIdentifierMatches && nativeScriptAppIdentifierMatches[1]);
+		}).future<string>()();
+	}
+
+	private getAbstractPortForApplication(adb: Mobile.IDeviceAndroidDebugBridge, processId: string, appIdentifier: string): IFuture<string> {
 		return (() => {
 			// The result will look like this (without the columns names):
 			// Num       		 RefCount Protocol Flags    Type St Inode  Path
 			// 0000000000000000: 00000002 00000000 00010000 0001 01 189004 @webview_devtools_remote_25512
 			// The Path column is the abstract port.
-			let abstractPortRegex = /\w+:\W+(\w+[ \t]+){1,6}/;
-
-			// Need to search by processId to check for old Android webviews (@webview_devtools_remote_<processId>).
-			let androidWebViewPortInformation = adb.executeShellCommand(["cat", "proc/net/unix", "|grep", "-a", "--text", processId]).wait();
-			// Search for appIdentifier (@<appIdentifier>_devtools_remote).
-			let chromeWebViewPortInformation = adb.executeShellCommand(["cat", "proc/net/unix", "|grep", "-a", "--text", appIdentifier + "_devtools_remote"]).wait();
-			// Search for appIdentifier (@<appIdentifier-debug>).
-			let nativeScriptWebViewPortInformation = adb.executeShellCommand(["cat", "proc/net/unix", "|grep", "-a", "--text", `${appIdentifier}-debug`]).wait();
-
-			// Need to check for
-			let abstractPortInformation: string = androidWebViewPortInformation || chromeWebViewPortInformation || nativeScriptWebViewPortInformation;
-
-			if (!abstractPortInformation.match(abstractPortRegex)) {
-				return null;
-			}
-
-			// Need to take the third element from the array because after the split the array will conatin ['', '<Match from the regex group>', '<AbstractPort>'].
-			// Abstract port will be in format @<AbstractPort> and need to remove the "@" character.
-			return abstractPortInformation.split(abstractPortRegex)[2].trim().substr(1);
+			let abstractPortsInformation = this.getAbstractPortsInformation(adb).wait();
+			return this.getPortInformation(abstractPortsInformation, processId) ||
+				this.getPortInformation(abstractPortsInformation, `${appIdentifier}_devtools_remote`) ||
+				this.getPortInformation(abstractPortsInformation, `${appIdentifier}-debug`);
 		}).future<string>()();
 	}
 
-	private getProcessId(adb: Mobile.IAndroidDebugBridge, appIdentifier: string): IFuture<string> {
+	private getAbstractPortsInformation(adb: Mobile.IDeviceAndroidDebugBridge): IFuture<string> {
+		return adb.executeShellCommand(["cat", "/proc/net/unix"]);
+	}
+
+	private getPortInformation(abstractPortsInformation: string, searchedInfo: string): string {
+		let processRegExp = new RegExp(`\\w+:\\s+(?:\\w+\\s+){1,6}@(.*?${searchedInfo})$`, "gm");
+
+		let match = processRegExp.exec(abstractPortsInformation);
+		return match && match[1];
+	}
+
+	private getProcessId(adb: Mobile.IDeviceAndroidDebugBridge, appIdentifier: string): IFuture<string> {
 		return (() => {
 			// Process information will look like this (without the columns names):
 			// USER     PID   PPID  VSIZE   RSS   WCHAN    PC         NAME
 			// u0_a63   25512 1334  1519560 96040 ffffffff f76a8f75 S com.telerik.appbuildertabstest
-			let processIdRegex = /^\w*\W*([0-9]+)/;
+			let processIdRegExp = /^\w*\s*(\d+)/;
 			let processIdInformation: string = adb.executeShellCommand(["ps", "|grep", "-a", "--text", appIdentifier]).wait();
 
-			let matches = processIdRegex.exec(processIdInformation);
+			let matches = processIdRegExp.exec(processIdInformation);
 
 			if (!matches || !matches[0]) {
 				return null;
@@ -87,15 +135,8 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 		}).future<string>()();
 	}
 
-	private getAvailableAndroidPortsInformation(adb: Mobile.IAndroidDebugBridge, appIdentifier: string): IFuture<Mobile.IAndroidPortInformation[]> {
+	private getAvailableAndroidPortsInformation(adb: Mobile.IDeviceAndroidDebugBridge, appIdentifier: string): IFuture<Mobile.IAndroidPortInformation[]> {
 		return (() => {
-			// The result of adb shell dumpsys package package.name |grep userId= looks like:
-			// userId=10060 gids=[1028, 1015, 3003]
-			let userIdRegex = /userId=([0-9]+)/;
-			let packageDumpSysInformation = adb.executeShellCommand(["dumpsys", "package", appIdentifier, "|grep", "-a", "--text", "userId="]).wait();
-
-			let applicationUid = parseInt(userIdRegex.exec(packageDumpSysInformation)[1]);
-
 			// Get ports information.
 			// Result will look like this:
 			// sl local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt  uid  timeout inode
@@ -106,15 +147,15 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 			let allPorts: string[] = tcpPorts.concat(tcp6Ports);
 
 			// Get information only for the ports which are not in use - remote address is empty (only zeroes) and have host localhost.
-			let emptyAddressRegex = /^00*:0+/;
+			let emptyAddressRegExp = /^00*:0+/;
 
 			// Localhost hex representation is 0100007F or 0000000000000000FFFF00000100007F
-			let localHostHexRegex = /^00*100007F/;
-			let localHostVersionSixHexRegex = /^00*FFFF00000100007F/;
+			let localHostHexRegExp = /^00*100007F/;
+			let localHostVersionSixHexRegExp = /^00*FFFF00000100007F/;
 			let availablePorts: Mobile.IAndroidPortInformation[] = _(allPorts)
-				.filter((line: string) => line.match(AndroidProcessService.ANDROID_PORT_INFORMATION_REGEX))
-				.map(this.parseAndroidPortInformation)
-				.filter((port: Mobile.IAndroidPortInformation) => port.remAddress.match(emptyAddressRegex) && (port.ipAddressHex.match(localHostHexRegex) || port.ipAddressHex.match(localHostVersionSixHexRegex)))
+				.filter((line: string) => line.match(this.androidPortInformationRegExp))
+				.map((line: string) => this.parseAndroidPortInformation(line))
+				.filter((port: Mobile.IAndroidPortInformation) => port.remAddress.match(emptyAddressRegExp) && (port.ipAddressHex.match(localHostHexRegExp) || port.ipAddressHex.match(localHostVersionSixHexRegExp)))
 				.value();
 
 			return availablePorts;
@@ -122,7 +163,7 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 	}
 
 	private parseAndroidPortInformation(portInformationRow: string): Mobile.IAndroidPortInformation {
-		let matches = AndroidProcessService.ANDROID_PORT_INFORMATION_REGEX.exec(portInformationRow);
+		let matches = this.androidPortInformationRegExp.exec(portInformationRow);
 		if (!matches || !matches[0]) {
 			// The input information does not match the regex.
 			return null;
@@ -137,17 +178,23 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 
 		// The first match is the whole row.
 		let portInformation: Mobile.IAndroidPortInformation = {
-			sl: matches[1],
 			localAddress: localAddress,
 			remAddress: matches[3],
-			st: matches[4],
-			uid: parseInt(matches[5]),
+			uid: parseInt(matches[4]),
 			ipAddressHex: hexIpAddress,
 			number: parseInt(hexPort, 16),
 			numberHex: hexPort
 		};
 
 		return portInformation;
+	}
+
+	private getAdb(deviceIdentifier: string): Mobile.IDeviceAndroidDebugBridge {
+		if (!this._devicesAdbs[deviceIdentifier]) {
+			this._devicesAdbs[deviceIdentifier] = this.$injector.resolve(DeviceAndroidDebugBridge, { identifier: deviceIdentifier });
+		}
+
+		return this._devicesAdbs[deviceIdentifier];
 	}
 }
 

--- a/mobile/mobile-core/android-process-service.ts
+++ b/mobile/mobile-core/android-process-service.ts
@@ -1,0 +1,154 @@
+///<reference path="./../../.d.ts"/>
+"use strict";
+
+import * as util from "util";
+import * as constants from "../constants";
+import {EOL} from "os";
+import * as androidDebugBridgePath from "../android/android-debug-bridge";
+
+export class AndroidProcessService implements Mobile.IAndroidProcessService {
+	// Describes one row from the adb shell cat proc/net/tcp result.
+	private static ANDROID_PORT_INFORMATION_REGEX = /([0-9]+):\W+([0-9A-Za-z]+:[0-9A-Za-z]+)\W+([0-9A-Za-z]+:[0-9A-Za-z]+)\W+([0-9A-Za-z]+)\W+[0-9A-Za-z]+:[0-9A-Za-z]+\W+[0-9A-Za-z]+:[0-9A-Za-z]+ +[0-9A-Za-z]+\W+([0-9]+)/g;
+	constructor(private $errors: IErrors,
+		private $staticConfig: Config.IStaticConfig,
+		private $injector: IInjector) { }
+
+	public mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string): IFuture<string> {
+		return (() => {
+			let adb: Mobile.IAndroidDebugBridge = this.$injector.resolve(androidDebugBridgePath.AndroidDebugBridge, { identifier: deviceIdentifier });
+			let processId = this.getProcessId(adb, appIdentifier).wait();
+			if (!processId) {
+				this.$errors.failWithoutHelp(`The application is not installed on the device with identifier ${deviceIdentifier}.`);
+			}
+
+			let abstractPort = this.getAbstractPortForApplication(adb, processId, appIdentifier).wait();
+
+			if (!abstractPort) {
+				this.$errors.failWithoutHelp(`The application is not started on the device with identifier ${deviceIdentifier}.`);
+			}
+
+			// Get the available ports information as late as possible.
+			let availablePorts: Mobile.IAndroidPortInformation[] = this.getAvailableAndroidPortsInformation(adb, appIdentifier).wait();
+			if (!availablePorts || availablePorts.length === 0) {
+				this.$errors.failWithoutHelp("There are no available ports.");
+			}
+
+			let realPort = availablePorts[0];
+
+			adb.executeCommand(["forward", `tcp:${realPort.number}`, `localabstract:${abstractPort}`]).wait();
+
+			return realPort.number;
+		}).future<string>()();
+	}
+
+	private getAbstractPortForApplication(adb: Mobile.IAndroidDebugBridge, processId: string, appIdentifier: string): IFuture<string> {
+		return (() => {
+			// The result will look like this (without the columns names):
+			// Num       		 RefCount Protocol Flags    Type St Inode  Path
+			// 0000000000000000: 00000002 00000000 00010000 0001 01 189004 @webview_devtools_remote_25512
+			// The Path column is the abstract port.
+			let abstractPortRegex = /\w+:\W+(\w+[ \t]+){1,6}/;
+
+			// Need to search by processId to check for old Android webviews (@webview_devtools_remote_<processId>).
+			let androidWebViewPortInformation = adb.executeShellCommand(["cat", "proc/net/unix", "|grep", "-a", "--text", processId]).wait();
+			// Search for appIdentifier (@<appIdentifier>_devtools_remote).
+			let chromeWebViewPortInformation = adb.executeShellCommand(["cat", "proc/net/unix", "|grep", "-a", "--text", appIdentifier + "_devtools_remote"]).wait();
+			// Search for appIdentifier (@<appIdentifier-debug>).
+			let nativeScriptWebViewPortInformation = adb.executeShellCommand(["cat", "proc/net/unix", "|grep", "-a", "--text", `${appIdentifier}-debug`]).wait();
+
+			// Need to check for
+			let abstractPortInformation: string = androidWebViewPortInformation || chromeWebViewPortInformation || nativeScriptWebViewPortInformation;
+
+			if (!abstractPortInformation.match(abstractPortRegex)) {
+				return null;
+			}
+
+			// Need to take the third element from the array because after the split the array will conatin ['', '<Match from the regex group>', '<AbstractPort>'].
+			// Abstract port will be in format @<AbstractPort> and need to remove the "@" character.
+			return abstractPortInformation.split(abstractPortRegex)[2].trim().substr(1);
+		}).future<string>()();
+	}
+
+	private getProcessId(adb: Mobile.IAndroidDebugBridge, appIdentifier: string): IFuture<string> {
+		return (() => {
+			// Process information will look like this (without the columns names):
+			// USER     PID   PPID  VSIZE   RSS   WCHAN    PC         NAME
+			// u0_a63   25512 1334  1519560 96040 ffffffff f76a8f75 S com.telerik.appbuildertabstest
+			let processIdRegex = /^\w*\W*([0-9]+)/;
+			let processIdInformation: string = adb.executeShellCommand(["ps", "|grep", "-a", "--text", appIdentifier]).wait();
+
+			let matches = processIdRegex.exec(processIdInformation);
+
+			if (!matches || !matches[0]) {
+				return null;
+			}
+
+			return matches[1];
+		}).future<string>()();
+	}
+
+	private getAvailableAndroidPortsInformation(adb: Mobile.IAndroidDebugBridge, appIdentifier: string): IFuture<Mobile.IAndroidPortInformation[]> {
+		return (() => {
+			// The result of adb shell dumpsys package package.name |grep userId= looks like:
+			// userId=10060 gids=[1028, 1015, 3003]
+			let userIdRegex = /userId=([0-9]+)/;
+			let packageDumpSysInformation = adb.executeShellCommand(["dumpsys", "package", appIdentifier, "|grep", "-a", "--text", "userId="]).wait();
+
+			let applicationUid = parseInt(userIdRegex.exec(packageDumpSysInformation)[1]);
+
+			// Get ports information.
+			// Result will look like this:
+			// sl local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt  uid  timeout inode
+			// 0: 0100007F:1C23 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1001       0 2111 1 e22cc000 300 0 0 2 -1
+			let tcpPorts: string[] = adb.executeShellCommand(["cat", "proc/net/tcp"]).wait().split(EOL);
+			let tcp6Ports: string[] = adb.executeShellCommand(["cat", "proc/net/tcp6"]).wait().split(EOL);
+
+			let allPorts: string[] = tcpPorts.concat(tcp6Ports);
+
+			// Get information only for the ports which are not in use - remote address is empty (only zeroes) and have host localhost.
+			let emptyAddressRegex = /^00*:0+/;
+
+			// Localhost hex representation is 0100007F or 0000000000000000FFFF00000100007F
+			let localHostHexRegex = /^00*100007F/;
+			let localHostVersionSixHexRegex = /^00*FFFF00000100007F/;
+			let availablePorts: Mobile.IAndroidPortInformation[] = _(allPorts)
+				.filter((line: string) => line.match(AndroidProcessService.ANDROID_PORT_INFORMATION_REGEX))
+				.map(this.parseAndroidPortInformation)
+				.filter((port: Mobile.IAndroidPortInformation) => port.remAddress.match(emptyAddressRegex) && (port.ipAddressHex.match(localHostHexRegex) || port.ipAddressHex.match(localHostVersionSixHexRegex)))
+				.value();
+
+			return availablePorts;
+		}).future<Mobile.IAndroidPortInformation[]>()();
+	}
+
+	private parseAndroidPortInformation(portInformationRow: string): Mobile.IAndroidPortInformation {
+		let matches = AndroidProcessService.ANDROID_PORT_INFORMATION_REGEX.exec(portInformationRow);
+		if (!matches || !matches[0]) {
+			// The input information does not match the regex.
+			return null;
+		}
+
+		// The local address will look like this IP_address:port both in hex format.
+		let localAddress = matches[2];
+		let localAddressParts = localAddress.split(":");
+
+		let hexIpAddress = localAddressParts[0];
+		let hexPort = localAddressParts[1];
+
+		// The first match is the whole row.
+		let portInformation: Mobile.IAndroidPortInformation = {
+			sl: matches[1],
+			localAddress: localAddress,
+			remAddress: matches[3],
+			st: matches[4],
+			uid: parseInt(matches[5]),
+			ipAddressHex: hexIpAddress,
+			number: parseInt(hexPort, 16),
+			numberHex: hexPort
+		};
+
+		return portInformation;
+	}
+}
+
+$injector.register("androidProcessService", AndroidProcessService);

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -400,6 +400,11 @@ export class DevicesService implements Mobile.IDevicesService {
 		return this.$androidProcessService.mapAbstractToTcpPort(deviceIdentifier, appIdentifier);
 	}
 
+	@exportedPromise("devicesService")
+	public getApplicationsAvailableForDebugging(deviceIdentifier: string): IFuture<string[]> {
+		return this.$androidProcessService.getApplicationsAvailableForDebugging(deviceIdentifier);
+	}
+
 	private deployOnDevice(deviceIdentifier: string, packageFile: string, packageName: string): IFuture<void> {
 		return (() => {
 			let device = this.getDeviceByIdentifier(deviceIdentifier);

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -31,7 +31,8 @@ export class DevicesService implements Mobile.IDevicesService {
 		private $hostInfo: IHostInfo,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $injector: IInjector,
-		private $options: ICommonOptions) {
+		private $options: ICommonOptions,
+		private $androidProcessService: Mobile.IAndroidProcessService) {
 		this.attachToDeviceDiscoveryEvents();
 	}
 
@@ -82,7 +83,7 @@ export class DevicesService implements Mobile.IDevicesService {
 	}
 
 	private getAllPlatforms(): Array<string> {
-		if(this.platforms.length > 0) {
+		if (this.platforms.length > 0) {
 			return this.platforms;
 		}
 
@@ -93,7 +94,7 @@ export class DevicesService implements Mobile.IDevicesService {
 	private getPlatform(platform: string): string {
 		let allSupportedPlatforms = this.getAllPlatforms();
 		let normalizedPlatform = this.$mobileHelper.validatePlatformName(platform);
-		if(!_.contains(allSupportedPlatforms, normalizedPlatform)) {
+		if (!_.contains(allSupportedPlatforms, normalizedPlatform)) {
 			this.$errors.failWithoutHelp("Deploying to %s connected devices is not supported. Build the " +
 				"app using the `build` command and deploy the package manually.", normalizedPlatform);
 		}
@@ -197,22 +198,22 @@ export class DevicesService implements Mobile.IDevicesService {
 	private startLookingForDevices(): IFuture<void> {
 		return (() => {
 			this.$logger.trace("startLookingForDevices; platform is %s", this._platform);
-			if(!this._platform) {
+			if (!this._platform) {
 				this.detectCurrentlyAttachedDevices().wait();
 				this.startDeviceDetectionInterval();
-			} else if(this.$mobileHelper.isiOSPlatform(this._platform)) {
+			} else if (this.$mobileHelper.isiOSPlatform(this._platform)) {
 				this.$iOSDeviceDiscovery.startLookingForDevices().wait();
 				if (this.$hostInfo.isDarwin) {
 					this.$iOSSimulatorDiscovery.startLookingForDevices().wait();
 				}
-			} else if(this.$mobileHelper.isAndroidPlatform(this._platform)) {
+			} else if (this.$mobileHelper.isAndroidPlatform(this._platform)) {
 				this.$androidDeviceDiscovery.startLookingForDevices().wait();
 			}
 		}).future<void>()();
 	}
 
 	private getAllConnectedDevices(): Mobile.IDevice[] {
-		if(!this._platform) {
+		if (!this._platform) {
 			return this.getDeviceInstances();
 		} else {
 			return this.filterDevicesByPlatform();
@@ -220,8 +221,8 @@ export class DevicesService implements Mobile.IDevicesService {
 	}
 
 	private getDeviceByIndex(index: number): Mobile.IDevice {
-		this.validateIndex(index-1);
-		return this.getDeviceInstances()[index-1];
+		this.validateIndex(index - 1);
+		return this.getDeviceInstances()[index - 1];
 	}
 
 	private getDevice(deviceOption: string): IFuture<Mobile.IDevice> {
@@ -229,13 +230,13 @@ export class DevicesService implements Mobile.IDevicesService {
 			this.startLookingForDevices().wait();
 			let device: Mobile.IDevice = null;
 
-			if(this.hasDevice(deviceOption)) {
+			if (this.hasDevice(deviceOption)) {
 				device = this.getDeviceByIdentifier(deviceOption);
-			} else if(helpers.isNumber(deviceOption)) {
+			} else if (helpers.isNumber(deviceOption)) {
 				device = this.getDeviceByIndex(parseInt(deviceOption, 10));
 			}
 
-			if(!device) {
+			if (!device) {
 				this.$errors.fail(this.$messages.Devices.NotFoundDeviceByIdentifierErrorMessage, this.$staticConfig.CLIENT_NAME.toLowerCase());
 			}
 
@@ -245,7 +246,7 @@ export class DevicesService implements Mobile.IDevicesService {
 
 	private executeOnDevice(action: (dev: Mobile.IDevice) => IFuture<void>, canExecute?: (_dev: Mobile.IDevice) => boolean): IFuture<void> {
 		return ((): void => {
-			if(!canExecute || canExecute(this._device)) {
+			if (!canExecute || canExecute(this._device)) {
 				action(this._device).wait();
 			}
 		}).future<void>()();
@@ -287,7 +288,7 @@ export class DevicesService implements Mobile.IDevicesService {
 		return _.map(deviceIdentifiers, deviceIdentifier => this.deployOnDevice(deviceIdentifier, packageFile, packageName));
 	}
 
-	public execute(action: (device: Mobile.IDevice) => IFuture<void>, canExecute?: (dev: Mobile.IDevice) => boolean, options?: {allowNoDevices?: boolean}): IFuture<void> {
+	public execute(action: (device: Mobile.IDevice) => IFuture<void>, canExecute?: (dev: Mobile.IDevice) => boolean, options?: { allowNoDevices?: boolean }): IFuture<void> {
 		return ((): void => {
 			assert.ok(this._isInitialized, "Devices services not initialized!");
 			if (this.hasDevices) {
@@ -319,24 +320,24 @@ export class DevicesService implements Mobile.IDevicesService {
 		if (this._isInitialized) {
 			return Future.fromResult();
 		}
-		return(() => {
+		return (() => {
 			data = data || {};
 			this._data = data;
-			let platform =  data.platform;
+			let platform = data.platform;
 			let deviceOption = data.deviceId;
 
-			if(platform && deviceOption) {
+			if (platform && deviceOption) {
 				this._device = this.getDevice(deviceOption).wait();
 				this._platform = this._device.deviceInfo.platform;
-				if(this._platform !== this.getPlatform(platform)) {
+				if (this._platform !== this.getPlatform(platform)) {
 					this.$errors.fail("Cannot resolve the specified connected device. The provided platform does not match the provided index or identifier." +
 						"To list currently connected devices and verify that the specified pair of platform and index or identifier exists, run 'device'.");
 				}
 				this.$logger.warn("Your application will be deployed only on the device specified by the provided index or identifier.");
-			} else if(!platform && deviceOption) {
+			} else if (!platform && deviceOption) {
 				this._device = this.getDevice(deviceOption).wait();
 				this._platform = this._device.deviceInfo.platform;
-			} else if(platform && !deviceOption) {
+			} else if (platform && !deviceOption) {
 				this._platform = this.getPlatform(platform);
 				this.startLookingForDevices().wait();
 			} else {
@@ -347,22 +348,22 @@ export class DevicesService implements Mobile.IDevicesService {
 					this.detectCurrentlyAttachedDevices().wait();
 					let devices = this.getDeviceInstances();
 					let platforms = _(devices)
-									.map(device => device.deviceInfo.platform)
-									.filter(pl => {
-										try {
-											return this.getPlatform(pl);
-										} catch(err) {
-											this.$logger.warn(err.message);
-											return null;
-										}
-									})
-									.uniq()
-									.value();
+						.map(device => device.deviceInfo.platform)
+						.filter(pl => {
+							try {
+								return this.getPlatform(pl);
+							} catch (err) {
+								this.$logger.warn(err.message);
+								return null;
+							}
+						})
+						.uniq()
+						.value();
 
 					if (platforms.length === 1) {
 						this._platform = platforms[0];
 					} else if (platforms.length === 0) {
-						this.$errors.fail({formatStr: constants.ERROR_NO_DEVICES, suppressCommandHelp: true});
+						this.$errors.fail({ formatStr: constants.ERROR_NO_DEVICES, suppressCommandHelp: true });
 					} else {
 						this.$errors.fail("Multiple device platforms detected (%s). Specify platform or device on command line.",
 							helpers.formatListOfNames(platforms, "and"));
@@ -394,6 +395,11 @@ export class DevicesService implements Mobile.IDevicesService {
 		return this._device;
 	}
 
+	@exportedPromise("devicesService")
+	public mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string): IFuture<string> {
+		return this.$androidProcessService.mapAbstractToTcpPort(deviceIdentifier, appIdentifier);
+	}
+
 	private deployOnDevice(deviceIdentifier: string, packageFile: string, packageName: string): IFuture<void> {
 		return (() => {
 			let device = this.getDeviceByIdentifier(deviceIdentifier);
@@ -402,7 +408,7 @@ export class DevicesService implements Mobile.IDevicesService {
 			if (device.applicationManager.canStartApplication()) {
 				try {
 					device.applicationManager.startApplication(packageName).wait();
-				} catch(err) {
+				} catch (err) {
 					this.$logger.trace("Unable to start application on device. Error is: ", err);
 				}
 			}
@@ -436,7 +442,7 @@ export class DevicesService implements Mobile.IDevicesService {
 	private startEmulator(): IFuture<void> {
 		return (() => {
 			let emulatorServices = this.resolveEmulatorServices();
-			if(!emulatorServices) {
+			if (!emulatorServices) {
 				this.$errors.failWithoutHelp("Unable to detect platform for which to start emulator.");
 			}
 			emulatorServices.startEmulator().wait();
@@ -474,4 +480,5 @@ export class DevicesService implements Mobile.IDevicesService {
 		}).future<IAppInstalledInfo>()();
 	}
 }
+
 $injector.register("devicesService", DevicesService);

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -73,7 +73,7 @@ class AndroidEmulatorServices {
 class IOSEmulatorServices {
 	public isStartEmulatorCalled = false;
 	public startEmulator(): IFuture<void> {
-		if(!this.isStartEmulatorCalled) {
+		if (!this.isStartEmulatorCalled) {
 			this.isStartEmulatorCalled = true;
 			iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
 		}
@@ -88,7 +88,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("iOSDeviceDiscovery", IOSDeviceDiscoveryStub);
 	testInjector.register("iOSSimulatorDiscovery", IOSSimulatorDiscoveryStub);
 	testInjector.register("androidDeviceDiscovery", AndroidDeviceDiscoveryStub);
-	testInjector.register("staticConfig", { CLIENT_NAME: "unit-tests"});
+	testInjector.register("staticConfig", { CLIENT_NAME: "unit-tests" });
 	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
 	testInjector.register("androidEmulatorServices", AndroidEmulatorServices);
 	testInjector.register("iOSEmulatorServices", IOSEmulatorServices);
@@ -111,6 +111,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("options", {
 		emulator: false
 	});
+	testInjector.register("androidProcessService", { /* no implementation required */ });
 	return testInjector;
 }
 
@@ -229,7 +230,7 @@ describe("devicesService", () => {
 			assert.deepEqual(devicesService.getDeviceInstances(), [], "Initially getDevicesInstances must return empty array.");
 			assert.deepEqual(devicesService.getDevices(), [], "Initially getDevices must return empty array.");
 
-			let tempDevice = { deviceInfo: { identifier: "temp-device" }};
+			let tempDevice = { deviceInfo: { identifier: "temp-device" } };
 			androidDeviceDiscovery.emit("deviceFound", androidDevice);
 			androidDeviceDiscovery.emit("deviceFound", tempDevice);
 			assert.deepEqual(devicesService.getDeviceInstances(), [androidDevice, tempDevice]);
@@ -273,7 +274,7 @@ describe("devicesService", () => {
 			assert.throws(() => Future.wait(results));
 			_.each(results, futurizedResult => {
 				let error = futurizedResult.error;
-				if(error) {
+				if (error) {
 					assert.isTrue(error.message.indexOf("invalidDeviceId") !== -1, "The message must contain the id of the invalid device.");
 				} else {
 					assert.isTrue(futurizedResult.get().isInstalled, "The app is installed on iOS Device, so we must return true.");
@@ -283,7 +284,7 @@ describe("devicesService", () => {
 	});
 
 	describe("initialize and other methods behavior after initialze work correctly", () => {
-		let tempDevice =  {
+		let tempDevice = {
 			deviceInfo: {
 				identifier: "temp-device",
 				platform: "android"
@@ -321,7 +322,7 @@ describe("devicesService", () => {
 				counter = 0;
 				assertAndroidEmulatorIsStarted();
 				counter = 0;
-				devicesService.execute(() => { counter++; return Future.fromResult(); }, () => true, {allowNoDevices: true}).wait();
+				devicesService.execute(() => { counter++; return Future.fromResult(); }, () => true, { allowNoDevices: true }).wait();
 				assert.deepEqual(counter, 0, "The action must not be executed when there are no devices.");
 				assert.isTrue(logger.output.indexOf(constants.ERROR_NO_DEVICES) !== -1);
 			};
@@ -335,21 +336,21 @@ describe("devicesService", () => {
 			});
 
 			it("fails when deviceId is invalid index (less than 0)", () => {
-				assert.throws( () => devicesService.initialize({ platform: "android", deviceId: "-1" }).wait() );
+				assert.throws(() => devicesService.initialize({ platform: "android", deviceId: "-1" }).wait());
 			});
 
 			it("fails when deviceId is invalid index (more than currently connected devices)", () => {
-				assert.throws( () => devicesService.initialize({ platform: "android", deviceId: "100" }).wait() );
+				assert.throws(() => devicesService.initialize({ platform: "android", deviceId: "100" }).wait());
 			});
 
 			it("does not fail when iOSDeviceDiscovery startLookingForDevices fails", () => {
-				(<any>iOSDeviceDiscovery).startLookingForDevices = (): IFuture<void> => { throw new Error("my error");};
+				(<any>iOSDeviceDiscovery).startLookingForDevices = (): IFuture<void> => { throw new Error("my error"); };
 				assertAllMethodsResults("1");
 				assert.isTrue(logger.traceOutput.indexOf("my error") !== -1);
 			});
 
 			it("does not fail when androidDeviceDiscovery startLookingForDevices fails", () => {
-				(<any>androidDeviceDiscovery).startLookingForDevices = (): IFuture<void> => { throw new Error("my error");};
+				(<any>androidDeviceDiscovery).startLookingForDevices = (): IFuture<void> => { throw new Error("my error"); };
 				iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
 				devicesService.initialize({ platform: "ios", deviceId: iOSDevice.deviceInfo.identifier }).wait();
 				assert.isTrue(logger.traceOutput.indexOf("my error") !== -1);
@@ -358,7 +359,7 @@ describe("devicesService", () => {
 			it("does not fail when iosSimulatorDiscovery startLookingForDevices fails", () => {
 				let hostInfo = testInjector.resolve("hostInfo");
 				hostInfo.isDarwin = true;
-				(<any>iOSSimulatorDiscovery).startLookingForDevices = (): IFuture<void> => { throw new Error("my error");};
+				(<any>iOSSimulatorDiscovery).startLookingForDevices = (): IFuture<void> => { throw new Error("my error"); };
 				iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
 				devicesService.initialize({ platform: "ios", deviceId: iOSDevice.deviceInfo.identifier }).wait();
 				assert.isTrue(logger.traceOutput.indexOf("my error") !== -1);
@@ -367,21 +368,21 @@ describe("devicesService", () => {
 
 		it("when initialize is called with platform and deviceId and such device cannot be found", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
-			assert.throws( () => devicesService.initialize({ platform: "android", deviceId: androidDevice.deviceInfo.identifier }).wait());
+			assert.throws(() => devicesService.initialize({ platform: "android", deviceId: androidDevice.deviceInfo.identifier }).wait());
 		});
 
 		it("when initialize is called with deviceId and invalid platform", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 			iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
 			androidDeviceDiscovery.emit("deviceFound", androidDevice);
-			assert.throws( () => devicesService.initialize({ platform: "invalidPlatform", deviceId: androidDevice.deviceInfo.identifier }).wait());
+			assert.throws(() => devicesService.initialize({ platform: "invalidPlatform", deviceId: androidDevice.deviceInfo.identifier }).wait());
 		});
 
 		it("when initialize is called with platform and deviceId and device's platform is different", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 			iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
 			androidDeviceDiscovery.emit("deviceFound", androidDevice);
-			assert.throws( () => devicesService.initialize({ platform: "ios", deviceId: androidDevice.deviceInfo.identifier }).wait());
+			assert.throws(() => devicesService.initialize({ platform: "ios", deviceId: androidDevice.deviceInfo.identifier }).wait());
 		});
 
 		describe("when only deviceIdentifier is passed", () => {
@@ -413,7 +414,7 @@ describe("devicesService", () => {
 				counter = 0;
 				assertAndroidEmulatorIsStarted();
 				counter = 0;
-				devicesService.execute(() => { counter++; return Future.fromResult(); }, () => true, {allowNoDevices: true}).wait();
+				devicesService.execute(() => { counter++; return Future.fromResult(); }, () => true, { allowNoDevices: true }).wait();
 				assert.deepEqual(counter, 0, "The action must not be executed when there are no devices.");
 				assert.isTrue(logger.output.indexOf(constants.ERROR_NO_DEVICES) !== -1);
 			};
@@ -427,21 +428,21 @@ describe("devicesService", () => {
 			});
 
 			it("fails when deviceId is invalid index (less than 0)", () => {
-				assert.throws( () => devicesService.initialize({ deviceId: "-1" }).wait() );
+				assert.throws(() => devicesService.initialize({ deviceId: "-1" }).wait());
 			});
 
 			it("fails when deviceId is invalid index (more than currently connected devices)", () => {
-				assert.throws( () => devicesService.initialize({ deviceId: "100" }).wait() );
+				assert.throws(() => devicesService.initialize({ deviceId: "100" }).wait());
 			});
 
 			it("does not fail when iOSDeviceDiscovery startLookingForDevices fails", () => {
-				(<any>iOSDeviceDiscovery).startLookingForDevices = (): IFuture<void> => { throw new Error("my error");};
+				(<any>iOSDeviceDiscovery).startLookingForDevices = (): IFuture<void> => { throw new Error("my error"); };
 				assertAllMethodsResults("1");
 				assert.isTrue(logger.traceOutput.indexOf("my error") !== -1);
 			});
 
 			it("does not fail when androidDeviceDiscovery startLookingForDevices fails", () => {
-				(<any>androidDeviceDiscovery).startLookingForDevices = (): IFuture<void> => { throw new Error("my error");};
+				(<any>androidDeviceDiscovery).startLookingForDevices = (): IFuture<void> => { throw new Error("my error"); };
 				iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
 				devicesService.initialize({ deviceId: iOSDevice.deviceInfo.identifier }).wait();
 				assert.isTrue(logger.traceOutput.indexOf("my error") !== -1);
@@ -467,7 +468,7 @@ describe("devicesService", () => {
 				testInjector.resolve("options").emulator = true;
 				testInjector.resolve("hostInfo").isDarwin = true;
 				iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
-				devicesService.initialize({ platform: "ios"}).wait();
+				devicesService.initialize({ platform: "ios" }).wait();
 				let deviceIdentifier: string;
 				counter = 0;
 				devicesService.execute((d: Mobile.IDevice) => { deviceIdentifier = d.deviceInfo.identifier; counter++; return Future.fromResult(); }).wait();
@@ -517,7 +518,7 @@ describe("devicesService", () => {
 				counter = 0;
 				assertAndroidEmulatorIsStarted();
 				counter = 0;
-				devicesService.execute(() => { counter++; return Future.fromResult(); }, () => true, {allowNoDevices: true}).wait();
+				devicesService.execute(() => { counter++; return Future.fromResult(); }, () => true, { allowNoDevices: true }).wait();
 				assert.deepEqual(counter, 0, "The action must not be executed when there are no devices.");
 				assert.isTrue(logger.output.indexOf(constants.ERROR_NO_DEVICES) !== -1);
 				assert.isFalse(androidEmulatorServices.isStartEmulatorCalled);
@@ -528,7 +529,7 @@ describe("devicesService", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 			androidDeviceDiscovery.emit("deviceFound", androidDevice);
 			iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
-			devicesService.initialize({skipInferPlatform: true}).wait();
+			devicesService.initialize({ skipInferPlatform: true }).wait();
 			assert.deepEqual(devicesService.platform, undefined);
 			assert.deepEqual(devicesService.deviceCount, 2);
 			androidDeviceDiscovery.emit("deviceFound", tempDevice);
@@ -552,9 +553,9 @@ describe("devicesService", () => {
 			androidDeviceDiscovery.emit("deviceLost", tempDevice);
 			iOSDeviceDiscovery.emit("deviceLost", iOSDevice);
 			counter = 0;
-			assert.throws( () => devicesService.execute(() => { counter++; return Future.fromResult(); }, () => true).wait() );
+			assert.throws(() => devicesService.execute(() => { counter++; return Future.fromResult(); }, () => true).wait());
 			counter = 0;
-			devicesService.execute(() => { counter++; return Future.fromResult(); }, () => true, {allowNoDevices: true}).wait();
+			devicesService.execute(() => { counter++; return Future.fromResult(); }, () => true, { allowNoDevices: true }).wait();
 			assert.deepEqual(counter, 0, "The action must not be executed when there are no devices.");
 			assert.isTrue(logger.output.indexOf(constants.ERROR_NO_DEVICES) !== -1);
 		});
@@ -587,7 +588,7 @@ describe("devicesService", () => {
 			counter = 0;
 			assertAndroidEmulatorIsStarted();
 			counter = 0;
-			devicesService.execute(() => { counter++; return Future.fromResult(); }, () => true, {allowNoDevices: true}).wait();
+			devicesService.execute(() => { counter++; return Future.fromResult(); }, () => true, { allowNoDevices: true }).wait();
 			assert.deepEqual(counter, 0, "The action must not be executed when there are no devices.");
 			assert.isTrue(logger.output.indexOf(constants.ERROR_NO_DEVICES) !== -1);
 		});
@@ -596,13 +597,13 @@ describe("devicesService", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 			androidDeviceDiscovery.emit("deviceFound", androidDevice);
 			iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
-			assert.throws( () => devicesService.initialize().wait());
+			assert.throws(() => devicesService.initialize().wait());
 		});
 
 		it("when parameters are not passed and devices with invalid platforms are detected initialize should work with correct devices only", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 			androidDeviceDiscovery.emit("deviceFound", androidDevice);
-			iOSDeviceDiscovery.emit("deviceFound",  {
+			iOSDeviceDiscovery.emit("deviceFound", {
 				deviceInfo: {
 					identifier: "invalid-platform-device",
 					platform: "invalid-platform"
@@ -614,13 +615,13 @@ describe("devicesService", () => {
 
 		it("when parameters are not passed and only devices with invalid platforms are detected, initialize should throw", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
-			iOSDeviceDiscovery.emit("deviceFound",  {
+			iOSDeviceDiscovery.emit("deviceFound", {
 				deviceInfo: {
 					identifier: "invalid-platform-device",
 					platform: "invalid-platform"
 				}
 			});
-			assert.throws( () => devicesService.initialize().wait() );
+			assert.throws(() => devicesService.initialize().wait());
 			assert.isTrue(logger.output.indexOf("is not supported") !== -1);
 		});
 
@@ -644,7 +645,7 @@ describe("devicesService", () => {
 
 			it("throws when iOS platform is specified and iOS device identifier is passed", () => {
 				iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
-				assert.throws(() => devicesService.initialize({ platform: "ios",  deviceId: iOSDevice.deviceInfo.identifier }).wait(), "You can use iOS simulator only on OS X.");
+				assert.throws(() => devicesService.initialize({ platform: "ios", deviceId: iOSDevice.deviceInfo.identifier }).wait(), "You can use iOS simulator only on OS X.");
 			});
 
 			it("throws when iOS device identifier is passed", () => {
@@ -667,7 +668,7 @@ describe("devicesService", () => {
 
 			it("does not throw when Android platform is specified and Android device identifier is passed", () => {
 				androidDeviceDiscovery.emit("deviceFound", androidDevice);
-				devicesService.initialize({ platform: "android",  deviceId: androidDevice.deviceInfo.identifier }).wait();
+				devicesService.initialize({ platform: "android", deviceId: androidDevice.deviceInfo.identifier }).wait();
 			});
 		});
 
@@ -681,7 +682,7 @@ describe("devicesService", () => {
 
 			it("when iOS platform is specified and iOS device identifier is passed", () => {
 				iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
-				devicesService.initialize({ platform: "ios",  deviceId: iOSDevice.deviceInfo.identifier }).wait();
+				devicesService.initialize({ platform: "ios", deviceId: iOSDevice.deviceInfo.identifier }).wait();
 			});
 
 			it("when iOS device identifier is passed", () => {
@@ -704,7 +705,7 @@ describe("devicesService", () => {
 
 			it("when iOS platform is specified and iOS simulator device identifier is passed", () => {
 				iOSDeviceDiscovery.emit("deviceFound", iOSSimulator);
-				devicesService.initialize({ platform: "ios",  deviceId: iOSSimulator.deviceInfo.identifier }).wait();
+				devicesService.initialize({ platform: "ios", deviceId: iOSSimulator.deviceInfo.identifier }).wait();
 			});
 
 			it("when iOS simulator identifier is passed", () => {
@@ -771,7 +772,7 @@ describe("devicesService", () => {
 			assert.throws(() => Future.wait(results));
 			_.each(results, futurizedResult => {
 				let error = futurizedResult.error;
-				if(error) {
+				if (error) {
 					assert.isTrue(error.message.indexOf("invalidDeviceId") !== -1, "The message must contain the id of the invalid device.");
 				} else {
 					assert.isTrue(futurizedResult.get() === undefined, "On success, undefined should be returned.");
@@ -792,7 +793,7 @@ describe("devicesService", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 			androidDeviceDiscovery.emit("deviceFound", androidDevice);
 			iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
-			let tempDeviceInstance = { deviceInfo: { identifier: "temp-device",	platform: "android"	} };
+			let tempDeviceInstance = { deviceInfo: { identifier: "temp-device", platform: "android" } };
 			androidDeviceDiscovery.emit("deviceFound", tempDeviceInstance);
 			assert.deepEqual(devicesService.getDevicesForPlatform("android"), [androidDevice, tempDeviceInstance]);
 			assert.deepEqual(devicesService.getDevicesForPlatform("ios"), [iOSDevice]);
@@ -803,7 +804,7 @@ describe("devicesService", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 			androidDeviceDiscovery.emit("deviceFound", androidDevice);
 			iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
-			let tempDeviceInstance = { deviceInfo: { identifier: "temp-device",	platform: "AndroId"	} };
+			let tempDeviceInstance = { deviceInfo: { identifier: "temp-device", platform: "AndroId" } };
 			androidDeviceDiscovery.emit("deviceFound", tempDeviceInstance);
 			assert.deepEqual(devicesService.getDevicesForPlatform("android"), [androidDevice, tempDeviceInstance]);
 			assert.deepEqual(devicesService.getDevicesForPlatform("ios"), [iOSDevice]);
@@ -825,12 +826,12 @@ describe("devicesService", () => {
 		});
 
 		it("returns true when android emulator is passed", () => {
-			assert.isTrue(devicesService.isAndroidDevice(<any>{ deviceInfo: { platform: "android"}, isEmulator: true }));
+			assert.isTrue(devicesService.isAndroidDevice(<any>{ deviceInfo: { platform: "android" }, isEmulator: true }));
 		});
 
 		it("returns true when android device is passed, assert case insensitivity", () => {
-			assert.isTrue(devicesService.isAndroidDevice(<any>{ deviceInfo: { platform: "aNdRoId"}}));
-			assert.isTrue(devicesService.isAndroidDevice(<any>{ deviceInfo: { platform: "ANDROID"}}));
+			assert.isTrue(devicesService.isAndroidDevice(<any>{ deviceInfo: { platform: "aNdRoId" } }));
+			assert.isTrue(devicesService.isAndroidDevice(<any>{ deviceInfo: { platform: "ANDROID" } }));
 		});
 
 		it("returns false when iOS device is passed", () => {
@@ -839,7 +840,7 @@ describe("devicesService", () => {
 		});
 
 		it("returns false when device with invalid platform is passed", () => {
-			assert.isFalse(devicesService.isAndroidDevice(<any>{ deviceInfo: { platform: "invalid platform"}}));
+			assert.isFalse(devicesService.isAndroidDevice(<any>{ deviceInfo: { platform: "invalid platform" } }));
 		});
 	});
 
@@ -849,8 +850,8 @@ describe("devicesService", () => {
 		});
 
 		it("returns true when iOS device is passed, assert case insensitivity", () => {
-			assert.isTrue(devicesService.isiOSDevice(<any>{ deviceInfo: { platform: "iOs"}}));
-			assert.isTrue(devicesService.isiOSDevice(<any>{ deviceInfo: { platform: "IOS"}}));
+			assert.isTrue(devicesService.isiOSDevice(<any>{ deviceInfo: { platform: "iOs" } }));
+			assert.isTrue(devicesService.isiOSDevice(<any>{ deviceInfo: { platform: "IOS" } }));
 		});
 
 		it("returns false when android device is passed", () => {
@@ -858,7 +859,7 @@ describe("devicesService", () => {
 		});
 
 		it("returns false when device with invalid platform is passed", () => {
-			assert.isFalse(devicesService.isiOSDevice(<any>{ deviceInfo: { platform: "invalid platform"}}));
+			assert.isFalse(devicesService.isiOSDevice(<any>{ deviceInfo: { platform: "invalid platform" } }));
 		});
 
 		it("returns false when iOS emulator is passed", () => {
@@ -872,8 +873,8 @@ describe("devicesService", () => {
 		});
 
 		it("returns true when iOS simulator is passed, assert case insensitivity", () => {
-			assert.isTrue(devicesService.isiOSSimulator(<any>{ deviceInfo: { platform: "iOs"}, isEmulator: true}));
-			assert.isTrue(devicesService.isiOSSimulator(<any>{ deviceInfo: { platform: "IOS"}, isEmulator: true}));
+			assert.isTrue(devicesService.isiOSSimulator(<any>{ deviceInfo: { platform: "iOs" }, isEmulator: true }));
+			assert.isTrue(devicesService.isiOSSimulator(<any>{ deviceInfo: { platform: "IOS" }, isEmulator: true }));
 		});
 
 		it("returns false when iOS device is passed", () => {
@@ -882,11 +883,11 @@ describe("devicesService", () => {
 
 		it("returns false when Androd device or Android Emulator is passed", () => {
 			assert.isFalse(devicesService.isiOSSimulator(<any>androidDevice));
-			assert.isFalse(devicesService.isiOSSimulator(<any>{ deviceInfo: { platform: "android"}, isEmulator: true }));
+			assert.isFalse(devicesService.isiOSSimulator(<any>{ deviceInfo: { platform: "android" }, isEmulator: true }));
 		});
 
 		it("returns false when device with invalid platform is passed", () => {
-			assert.isFalse(devicesService.isiOSSimulator(<any>{ deviceInfo: { platform: "invalid platform"}}));
+			assert.isFalse(devicesService.isiOSSimulator(<any>{ deviceInfo: { platform: "invalid platform" } }));
 		});
 	});
 


### PR DESCRIPTION
To forward the port need to find the current process id, then use the process id or the application identifier to find the abstract port, find available port on localhost and do the forwarding.

Implements http://teampulse.telerik.com/view#item/313437.

Add method which finds applications which are available for debugging. To determine which applications are available for debugging need to run adb shell cat proc/net/unix and find the applications which have abstract ports like @webview_devtools_remote_[pid], @[app_id]_devtools_remote or @[app_id]-debug.