### PR TITLE
Fix starting many adb processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,35 @@ require("mobile-cli-lib").devicesService.setLogLevel("INFO", "129604ab96a4d00530
 This will set the logging level to `INFO` only for device with identifier `129604ab96a4d0053023b4bf5b288cf34a9ed5fa`.
 
 
-* `isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string)` - checks if the specified application is installed on each of the specified devices.
+* `isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string): Promise<IAppInstalledInfo>[]` - checks if the specified application is installed on each of the specified devices and is LiveSync supported for this application.
+The returned type for each device is `IAppInstalledInfo`:
+```JavaScript
+/**
+ * Describes if LiveSync is supported for specific device and application.
+ */
+interface IAppInstalledInfo extends ILiveSyncSupportedInfo {
+	/**
+	 * Unique identifier of the device.
+	 */
+	deviceIdentifier: string;
+
+	/**
+	 * Application identifier.
+	 */
+	appIdentifier: string;
+
+	/**
+	 * Defines if application is installed on device.
+	 */
+	isInstalled: boolean;
+
+	/**
+	 * Result, indicating is livesync supported for specified device and specified application.
+	 * `true` in case livesync is supported and false otherwise.
+	 */
+	isLiveSyncSupported: boolean;
+}
+```
 Sample usage:
 ```JavaScript
 Promise.all(require("mobile-cli-lib")
@@ -376,7 +404,20 @@ Promise.all(require("mobile-cli-lib")
 			console.log(err);
 		});
 ```
-Result will be `[ false, false ]` for example.
+Sample result will be:
+```JSON
+[{
+	"deviceIdentifier": "deviceId1",
+	"appIdentifier": "appId",
+	"isInstalled": true,
+	"isLiveSyncSupported": true
+}, {
+	"deviceIdentifier": "deviceId2",
+	"appIdentifier": "appId",
+	"isInstalled": false,
+	"isLiveSyncSupported": false
+}]
+```
 
 ### Module liveSyncService
 > Stability: 1 - Could be changed due to some new requirments.
@@ -468,25 +509,52 @@ Promise.all(require("mobile-cli-lib").liveSyncService.livesync(deviceInfos, proj
 	});
 ```
 
-### Module fs
-> Stability: 0 - Only for testing purposes. Will be removed.
-
-For testing purposes we have exposed fs module and one of its methods: getFileSize. Its signature is:
-`getFileSize(path: string): number`
-This method throws exception in case the passed path does not exist.
-
-Example usage:
+* `isLiveSyncSupported(deviceIdentifiers: string[], appIdentifier: string): Promise<ILiveSyncSupportedInfo>[]` - checks if user can use LiveSync for application and for specified devices.
+For each device the following object will be returned:
 ```JavaScript
-var common = require("mobile-cli-lib");
-common.fs.getFileSize("D:\\Work\\t.txt")
-    .then(function (a) {
-    	console.log("File size is: ");
-    	console.log(a);
-    	return a;
-	}, function (err) {
-    	console.log("Error happened:");
-    	console.log(err);
+/**
+ * Describes if LiveSync is supported for specific device and application.
+ */
+interface ILiveSyncSupportedInfo {
+	/**
+	 * Unique identifier of the device.
+	 */
+	deviceIdentifier: string;
+
+	/**
+	 * Application identifier.
+	 */
+	appIdentifier: string;
+
+	/**
+	 * Result, indicating is livesync supported for specified device and specified application.
+	 * `true` in case livesync is supported and false otherwise.
+	 */
+	isLiveSyncSupported: boolean;
+}
+```
+
+Sample usage:
+```JavaScript
+Promise.all(require("mobile-cli-lib").liveSyncService.isLiveSyncSupported(["deviceId1", "deviceId2"], "appIdentifier"))
+	.then(function(result) {
+			console.log("Result is: ", result);
+	}).catch(function(err) {
+			console.log("Error while checking is LiveSync supported: ", err);
 	});
+```
+
+Sample result will be:
+```JSON
+[{
+	"deviceIdentifier": "deviceId1",
+	"appIdentifier": "appIdentifier",
+	"isLiveSyncSupported": true
+}, {
+	"deviceIdentifier": "deviceId2",
+	"appIdentifier": "appIdentifier",
+	"isLiveSyncSupported": false
+}]
 ```
 
 Technical details

--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -166,6 +166,37 @@ interface IDeviceLiveSyncInfo {
 }
 
 /**
+ * Describes if LiveSync is supported for specific device and application.
+ */
+interface ILiveSyncSupportedInfo {
+	/**
+	 * Unique identifier of the device.
+	 */
+	deviceIdentifier: string;
+
+	/**
+	 * Application identifier.
+	 */
+	appIdentifier: string;
+
+	/**
+	 * Result, indicating is livesync supported for specified device and specified application.
+	 * `true` in case livesync is supported and false otherwise.
+	 */
+	isLiveSyncSupported: boolean;
+}
+
+/**
+ * Describes if LiveSync is supported for specific device and application.
+ */
+interface IAppInstalledInfo extends ILiveSyncSupportedInfo {
+	/**
+	 * Defines if application is installed on device.
+	 */
+	isInstalled: boolean;
+}
+
+/**
  * Describes information about Telerik Companion Apps.
  */
 interface ICompanionAppsService {

--- a/appbuilder/device-emitter.ts
+++ b/appbuilder/device-emitter.ts
@@ -66,14 +66,14 @@ class DeviceEmitter extends EventEmitter {
 	}
 
 	private attachApplicationChangedHandlers(device: Mobile.IDevice): void {
-		device.applicationManager.on("applicationInstalled", (applicationName: string, applicationSettings: {isLiveSyncEnabled: boolean}) => {
-			this.emit("applicationInstalled", device.deviceInfo.identifier, applicationName, applicationSettings);
-			this.checkCompanionAppChanged(device, applicationName, "companionAppInstalled");
+		device.applicationManager.on("applicationInstalled", (appIdentifier: string) => {
+			this.emit("applicationInstalled", device.deviceInfo.identifier, appIdentifier);
+			this.checkCompanionAppChanged(device, appIdentifier, "companionAppInstalled");
 		});
 
-		device.applicationManager.on("applicationUninstalled", (applicationName: string) => {
-			this.emit("applicationUninstalled", device.deviceInfo.identifier, applicationName);
-			this.checkCompanionAppChanged(device, applicationName, "companionAppUninstalled");
+		device.applicationManager.on("applicationUninstalled", (appIdentifier: string) => {
+			this.emit("applicationUninstalled", device.deviceInfo.identifier, appIdentifier);
+			this.checkCompanionAppChanged(device, appIdentifier, "companionAppUninstalled");
 		});
 	}
 

--- a/appbuilder/proton-static-config.ts
+++ b/appbuilder/proton-static-config.ts
@@ -22,5 +22,7 @@ export class ProtonStaticConfig extends StaticConfigBase {
 	}
 
 	public disableAnalytics = true;
+
+	public CLIENT_NAME = "Desktop Universal Client";
 }
 $injector.register("staticConfig", ProtonStaticConfig);

--- a/appbuilder/services/livesync/livesync-service.ts
+++ b/appbuilder/services/livesync/livesync-service.ts
@@ -26,6 +26,12 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 		return _.map(deviceDescriptors, deviceDescriptor => this.liveSyncOnDevice(deviceDescriptor, filePaths));
 	}
 
+	@exportedPromise("liveSyncService")
+	public isLiveSyncSupported(deviceIdentifiers: string[], appIdentifier: string): IFuture<ILiveSyncSupportedInfo>[] {
+		this.$logger.trace(`Called isLiveSyncSupported for identifiers ${deviceIdentifiers}. AppIdentifier is ${appIdentifier}.`);
+		return _.map(deviceIdentifiers, deviceId => this.isLiveSyncSupportedOnDevice(deviceId, appIdentifier));
+	}
+
 	private liveSyncOnDevice(deviceDescriptor: IDeviceLiveSyncInfo, filePaths: string[]): IFuture<IDeviceLiveSyncResult> {
 		return ((): IDeviceLiveSyncResult => {
 			let result: IDeviceLiveSyncResult = {
@@ -99,6 +105,18 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 
 			return liveSyncOperationResult;
 		}).future<ILiveSyncOperationResult>()();
+	}
+
+	private isLiveSyncSupportedOnDevice(deviceIdentifier: string, appIdentifier: string): IFuture<ILiveSyncSupportedInfo> {
+		return ((): ILiveSyncSupportedInfo => {
+			let device = this.$devicesService.getDeviceByIdentifier(deviceIdentifier);
+			let isLiveSyncSupported = !!device.applicationManager.isLiveSyncSupported(appIdentifier).wait();
+			return {
+				deviceIdentifier,
+				appIdentifier,
+				isLiveSyncSupported
+			};
+		}).future<ILiveSyncSupportedInfo>()();
 	}
 }
 $injector.register("liveSyncService", ProtonLiveSyncService);

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -193,7 +193,6 @@ declare module Mobile {
 		canStartApplication(): boolean;
 		checkForApplicationUpdates(): IFuture<void>;
 		isLiveSyncSupported(appIdentifier: string): IFuture<boolean>;
-		getApplicationsLiveSyncSupportedStatus(newApplications: string[]): IFuture<void>;
 	}
 
 	interface IApplicationLiveSyncStatus {
@@ -261,11 +260,12 @@ declare module Mobile {
 		isiOSDevice(device: Mobile.IDevice): boolean;
 		isiOSSimulator(device: Mobile.IDevice): boolean;
 		isOnlyiOSSimultorRunning(): boolean;
-		isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string): IFuture<boolean>[];
+		isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string): IFuture<IAppInstalledInfo>[];
 		setLogLevel(logLevel: string, deviceIdentifier?: string): void;
 		deployOnDevices(deviceIdentifiers: string[], packageFile: string, packageName: string): IFuture<void>[];
 		startDeviceDetectionInterval(): void;
 		stopDeviceDetectionInterval(): void;
+		getDeviceByIdentifier(identifier: string): Mobile.IDevice;
 	}
 
 	interface IiTunesValidator {

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -57,7 +57,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		return true;
 	}
 
-	protected isLiveSyncSupportedOnDevice(appIdentifier: string): IFuture<boolean> {
+	public isLiveSyncSupported(appIdentifier: string): IFuture<boolean> {
 		return ((): boolean => {
 			let liveSyncVersion = this.adb.sendBroadcastToDevice(LiveSyncConstants.CHECK_LIVESYNC_INTENT_NAME, {"app-id": appIdentifier}).wait();
 			return liveSyncVersion === LiveSyncConstants.VERSION_2 || liveSyncVersion === LiveSyncConstants.VERSION_3;

--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -6,7 +6,7 @@ import Future = require("fibers/future");
 import * as path from "path";
 import * as temp from "temp";
 
-export class IOSSimulatorApplicationManager extends ApplicationManagerBase implements Mobile.IDeviceApplicationManager {
+export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 	constructor(private iosSim: any,
 		private identifier: string,
 		private $options: ICommonOptions,
@@ -57,7 +57,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase imple
 		return true;
 	}
 
-	protected isLiveSyncSupportedOnDevice(appIdentifier: string): IFuture<boolean> {
+	public isLiveSyncSupported(appIdentifier: string): IFuture<boolean> {
 		return ((): boolean => {
 			let applicationPath = this.iosSim.getApplicationPath(this.identifier, appIdentifier);
 			let pathToInfoPlist = path.join(applicationPath, "Info.plist");


### PR DESCRIPTION
When new device is attached, common lib is trying to get all of its applications and to send intents for each of them in order to check is livesync supported for them.
This leads to tens or even hundreds of started adb processes. At some point, when you have more than one device, adb cannot handle the whole flow and it suicides itself.
After that you have to kill manually the only existing adb process or it will never detect any devices.
In order to prevent this behavior, change the way of detection is LiveSync supported. Expose new public method that will be used to check if LiveSync is supported for specific devices (and one appIdentifier).
Remove the reporting of isLiveSyncSupported in the "applicationInstalled" event.