### PR TITLE
Fix LiveSync to companion app

### DIFF
--- a/appbuilder/services/livesync/livesync-service.ts
+++ b/appbuilder/services/livesync/livesync-service.ts
@@ -86,7 +86,7 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 
 			if(liveSyncOptions.isForCompanionApp) {
 				// We should check if the companion app is installed, not the real application.
-				appIdentifier = this.$companionAppsService.getCompanionAppIdentifier(this.$project.projectData.Framework, device.deviceInfo.platform);
+				livesyncData.appIdentifier = appIdentifier = this.$companionAppsService.getCompanionAppIdentifier(this.$project.projectData.Framework, device.deviceInfo.platform);
 			}
 
 			if(device.applicationManager.isApplicationInstalled(appIdentifier).wait()) {


### PR DESCRIPTION
Currently LiveSync to companion app via Proton fails with error that application is not installed. In fact it fails because we've not changed the appIdentifier to be the companion app's identifier.