### PR TITLE
Disable iOS device detection interval on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.8.3
+Latest version: 0.9.0
 
-Release date: 2016, May 11
+Release date: 2016, May 13
 
 ### System Requirements
 

--- a/appbuilder/services/livesync/livesync-service.ts
+++ b/appbuilder/services/livesync/livesync-service.ts
@@ -38,42 +38,36 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 				deviceIdentifier: deviceDescriptor.deviceIdentifier
 			};
 
-			try {
-				// HACK: On Mac OS the livesync for iOS devices fails due to the setInterval for device detection.
-				// Stop the interval during livesync operation and start it again after that.
-				this.$devicesService.stopDeviceDetectionInterval();
-				let device = _.find(this.$devicesService.getDeviceInstances(), d => d.deviceInfo.identifier === deviceDescriptor.deviceIdentifier);
-				if(!device) {
-					result.liveSyncToApp = result.liveSyncToCompanion = {
-						isResolved: false,
-						error: new Error(`Cannot find connected device with identifier ${deviceDescriptor.deviceIdentifier}.`)
-					};
+			let device = _.find(this.$devicesService.getDeviceInstances(), d => d.deviceInfo.identifier === deviceDescriptor.deviceIdentifier);
+			if(!device) {
+				result.liveSyncToApp = result.liveSyncToCompanion = {
+					isResolved: false,
+					error: new Error(`Cannot find connected device with identifier ${deviceDescriptor.deviceIdentifier}.`)
+				};
 
-					return result;
-				}
-
-				let appIdentifier = this.$project.projectData.AppIdentifier,
-					canExecute = (d: Mobile.IDevice) => d.deviceInfo.identifier === device.deviceInfo.identifier,
-					livesyncData: ILiveSyncData = {
-						platform: device.deviceInfo.platform,
-						appIdentifier: appIdentifier,
-						projectFilesPath: this.$project.projectDir,
-						syncWorkingDirectory: this.$project.projectDir,
-						excludedProjectDirsAndFiles: this.excludedProjectDirsAndFiles,
-						canExecuteFastSync: false
-					};
-
-				let canExecuteAction = this.$liveSyncServiceBase.getCanExecuteAction(device.deviceInfo.platform, appIdentifier, canExecute);
-				if(deviceDescriptor.syncToApp) {
-					result.liveSyncToApp = this.liveSyncCore(livesyncData, device, appIdentifier, canExecuteAction, { isForCompanionApp: false }, filePaths).wait();
-				}
-
-				if(deviceDescriptor.syncToCompanion) {
-					result.liveSyncToCompanion = this.liveSyncCore(livesyncData, device, appIdentifier, canExecuteAction, { isForCompanionApp: true }, filePaths).wait();
-				}
-			} finally {
-				this.$devicesService.startDeviceDetectionInterval();
+				return result;
 			}
+
+			let appIdentifier = this.$project.projectData.AppIdentifier,
+				canExecute = (d: Mobile.IDevice) => d.deviceInfo.identifier === device.deviceInfo.identifier,
+				livesyncData: ILiveSyncData = {
+					platform: device.deviceInfo.platform,
+					appIdentifier: appIdentifier,
+					projectFilesPath: this.$project.projectDir,
+					syncWorkingDirectory: this.$project.projectDir,
+					excludedProjectDirsAndFiles: this.excludedProjectDirsAndFiles,
+					canExecuteFastSync: false
+				};
+
+			let canExecuteAction = this.$liveSyncServiceBase.getCanExecuteAction(device.deviceInfo.platform, appIdentifier, canExecute);
+			if(deviceDescriptor.syncToApp) {
+				result.liveSyncToApp = this.liveSyncCore(livesyncData, device, appIdentifier, canExecuteAction, { isForCompanionApp: false }, filePaths).wait();
+			}
+
+			if(deviceDescriptor.syncToCompanion) {
+				result.liveSyncToCompanion = this.liveSyncCore(livesyncData, device, appIdentifier, canExecuteAction, { isForCompanionApp: true }, filePaths).wait();
+			}
+
 			return result;
 		}).future<IDeviceLiveSyncResult>()();
 	}

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -142,12 +142,12 @@ export class DevicesService implements Mobile.IDevicesService {
 		} else {
 			this.deviceDetectionInterval = setInterval(() => {
 				fiberBootstrap.run(() => {
-					try {
-						// This code could be faster, by using Future.wait([...]), but it turned out this is breaking iOS deployment on Mac
-						// It's causing error 21 when deploying on some iOS devices during transfer of the first package.
-						this.$iOSDeviceDiscovery.checkForDevices().wait();
-					} catch (err) {
-						this.$logger.trace("Error while checking for new iOS devices.", err);
+					if(!this.$hostInfo.isDarwin) {
+						try {
+							this.$iOSDeviceDiscovery.checkForDevices().wait();
+						} catch (err) {
+							this.$logger.trace("Error while checking for new iOS devices.", err);
+						}
 					}
 
 					try {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.8.3",
+  "version": "0.9.0",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
On Mac OS X, there's no need to call iOSDeviceDetection process in setInterval, as when runLoopRun is called once (first time before the setInterval), after that it starts calling our callback whenever a device is changed (attached/detached).
So ignore the code on Mac.