### PR TITLE
Fix add android platform dependencies

### DIFF
--- a/definitions/semver.d.ts
+++ b/definitions/semver.d.ts
@@ -83,7 +83,12 @@ declare module SemVerModule {
 	 * Return true if the version is outside the bounds of the range in either the high or low direction. The hilo argument must be either the string '>' or '<'. (This is the function called by gtr and ltr.)
 	 */
 	function outside(version: string, range: string, hilo: string, loose?: boolean): boolean;
-	
+
+	/**
+	 * Return the cleaned version. Does not clean ^, ~ or *. Return null if version is not valid.
+	 */
+	function clean(version: string): string;
+
 	function major(version: string): number;
 
 	class SemVerBase {
@@ -104,10 +109,11 @@ declare module SemVerModule {
 		build: string[];
 		prerelease: string[];
 
-		compare(other:SemVer): number;
-		compareMain(other:SemVer): number;
-		comparePre(other:SemVer): number;
+		compare(other: SemVer): number;
+		compareMain(other: SemVer): number;
+		comparePre(other: SemVer): number;
 		inc(release: string): SemVer;
+		clean(version: string): string;
 	}
 
 	class Comparator extends SemVerBase {
@@ -117,7 +123,7 @@ declare module SemVerModule {
 		operator: string;
 		value: boolean;
 		parse(comp: string): void;
-		test(version:SemVer): boolean;
+		test(version: SemVer): boolean;
 	}
 
 	class Range extends SemVerBase {


### PR DESCRIPTION
When checking if platform dependency is installed in the current project before adding the platform need to check if the current version is valid or check in the node_modules directory for the installed plugin version.