### PR TITLE
Allow starting of NativeScript apps on Android via Proton

### DIFF
--- a/appbuilder/appbuilder-static-config-base.ts
+++ b/appbuilder/appbuilder-static-config-base.ts
@@ -1,0 +1,15 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import { StaticConfigBase } from "../static-config-base";
+
+export abstract class AppBuilderStaticConfigBase extends StaticConfigBase {
+	constructor($injector: IInjector) {
+		super($injector);
+	}
+
+	public get START_PACKAGE_ACTIVITY_NAME(): string {
+		let project: Project.IProjectBase = $injector.resolve("project");
+		return project.startPackageActivity;
+	}
+}

--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -87,6 +87,7 @@ declare module Project {
 		getProjectDir(): IFuture<string>;
 		projectData: IData;
 		capabilities: ICapabilities;
+		startPackageActivity: string;
 	}
 }
 

--- a/appbuilder/project/project-base.ts
+++ b/appbuilder/project/project-base.ts
@@ -3,6 +3,7 @@
 
 import Future = require("fibers/future");
 import * as path from "path";
+import { StartPackageActivityNames } from "../../mobile/constants";
 export class Project implements Project.IProjectBase {
 	constructor(private $cordovaProjectCapabilities: Project.ICapabilities,
 		private $fs: IFileSystem,
@@ -38,5 +39,8 @@ export class Project implements Project.IProjectBase {
 
 		return null;
 	}
+
+	// Will be set to new value on each deploy.
+	public startPackageActivity = StartPackageActivityNames.CORDOVA;
 }
 $injector.register("project", Project);

--- a/appbuilder/proton-static-config.ts
+++ b/appbuilder/proton-static-config.ts
@@ -1,14 +1,13 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-import {StaticConfigBase} from "../static-config-base";
+import { AppBuilderStaticConfigBase } from "./appbuilder-static-config-base";
 import * as path from "path";
 
-export class ProtonStaticConfig extends StaticConfigBase {
+export class ProtonStaticConfig extends AppBuilderStaticConfigBase {
 	constructor($injector: IInjector) {
 		super($injector);
 	}
-	public START_PACKAGE_ACTIVITY_NAME = ".TelerikCallbackActivity";
 
 	public getAdbFilePath(): IFuture<string> {
 		return (() => {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -262,7 +262,7 @@ declare module Mobile {
 		isOnlyiOSSimultorRunning(): boolean;
 		isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string): IFuture<IAppInstalledInfo>[];
 		setLogLevel(logLevel: string, deviceIdentifier?: string): void;
-		deployOnDevices(deviceIdentifiers: string[], packageFile: string, packageName: string): IFuture<void>[];
+		deployOnDevices(deviceIdentifiers: string[], packageFile: string, packageName: string, framework: string): IFuture<void>[];
 		startDeviceDetectionInterval(): void;
 		stopDeviceDetectionInterval(): void;
 		getDeviceByIdentifier(identifier: string): Mobile.IDevice;

--- a/mobile/constants.ts
+++ b/mobile/constants.ts
@@ -21,3 +21,8 @@ export class LiveSyncConstants {
 	static CHECK_LIVESYNC_INTENT_NAME = "com.telerik.IsLiveSyncSupported";
 	static IOS_PROJECT_PATH = "/Library/Application Support/LiveSync";
 }
+
+export class StartPackageActivityNames {
+	static NATIVESCRIPT = "com.tns.NativeScriptActivity";
+	static CORDOVA = ".TelerikCallbackActivity";
+}

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -271,8 +271,19 @@ export class DevicesService implements Mobile.IDevicesService {
 	}
 
 	@exportedPromise("devicesService")
-	public deployOnDevices(deviceIdentifiers: string[], packageFile: string, packageName: string): IFuture<void>[] {
+	public deployOnDevices(deviceIdentifiers: string[], packageFile: string, packageName: string, framework: string): IFuture<void>[] {
 		this.$logger.trace(`Called deployOnDevices for identifiers ${deviceIdentifiers} for packageFile: ${packageFile}. packageName is ${packageName}.`);
+		try {
+			let project = this.$injector.resolve("project"),
+				projectConstants: Project.IConstants = this.$injector.resolve("projectConstants");
+			if (project) {
+				framework = framework || "";
+				project.startPackageActivity = framework.toLowerCase() === projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase() ?
+													constants.StartPackageActivityNames.NATIVESCRIPT : constants.StartPackageActivityNames.CORDOVA;
+			}
+		} catch (err) {
+			this.$logger.trace("Error while trying to set startPackageActivity during deploy. Error is: ", err);
+		}
 		return _.map(deviceIdentifiers, deviceIdentifier => this.deployOnDevice(deviceIdentifier, packageFile, packageName));
 	}
 

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -747,7 +747,7 @@ describe("devicesService", () => {
 		});
 
 		it("returns undefined for each device on which the app is installed", () => {
-			let results = devicesService.deployOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "path", "packageName");
+			let results = devicesService.deployOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "path", "packageName", "cordova");
 			assert.isTrue(results.length > 0);
 			_.each(results, futurizedResult => {
 				let realResult = futurizedResult.wait();
@@ -760,14 +760,14 @@ describe("devicesService", () => {
 			iOSDevice.applicationManager.startApplication = (): IFuture<void> => {
 				throw new Error("Start application must not be called for iOSDevice when canStartApplication returns false.");
 			};
-			let results = devicesService.deployOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "path", "packageName");
+			let results = devicesService.deployOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "path", "packageName", "cordova");
 			assert.isTrue(results.length > 0);
 			Future.wait(results);
 			assert.deepEqual(results.map(r => r.get()), [undefined, undefined]);
 		});
 
 		it("throws error when invalid identifier is passed", () => {
-			let results = devicesService.deployOnDevices(["invalidDeviceId", iOSDevice.deviceInfo.identifier], "path", "packageName");
+			let results = devicesService.deployOnDevices(["invalidDeviceId", iOSDevice.deviceInfo.identifier], "path", "packageName", "cordova");
 			assert.throws(() => Future.wait(results));
 			_.each(results, futurizedResult => {
 				let error = futurizedResult.error;


### PR DESCRIPTION
Currently when deploying NativeScript apps on Android via Proton, we are unable to start the application, as we pass incorrect StartPackageActivity.
Fix this by extracting the correct names in constants. When deploy is called from Proton side, we'll set the correct name in the `$project`.
After that the execution of start method will use the value from `$staticConfig`. StaticConfig will return the value of project's property.

`deployOnDevices` method now has additional argument - framework. If it is passed and the provided value is NativeScript, we'll use the NativeScript's StartPackageActivity.
In all other cases we'll use Cordova's StartPackageActivity.