### PR TITLE
Use installationProxy to get installed applications on iOS

### DIFF
--- a/appbuilder/services/livesync/livesync-service.ts
+++ b/appbuilder/services/livesync/livesync-service.ts
@@ -23,6 +23,7 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 	@exportedPromise("liveSyncService")
 	public livesync(deviceDescriptors: IDeviceLiveSyncInfo[], projectDir: string, filePaths?: string[]): IFuture<IDeviceLiveSyncResult>[] {
 		this.$project.projectDir = projectDir;
+		this.$logger.trace(`Called livesync for identifiers ${_.map(deviceDescriptors, d => d.deviceIdentifier)}. Project dir is ${projectDir}. Files are: ${filePaths}`);
 		return _.map(deviceDescriptors, deviceDescriptor => this.liveSyncOnDevice(deviceDescriptor, filePaths));
 	}
 

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -22,8 +22,7 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 
 	public isApplicationInstalled(appIdentifier: string): IFuture<boolean> {
 		return (() => {
-			let installedApplications = this.getInstalledApplications().wait();
-			return _.contains(installedApplications, appIdentifier);
+			return _.contains(this.lastInstalledAppIdentifiers, appIdentifier);
 		}).future<boolean>()();
 	}
 

--- a/mobile/ios/device/ios-proxy-services.ts
+++ b/mobile/ios/device/ios-proxy-services.ts
@@ -224,6 +224,7 @@ export class AfcClient implements Mobile.IAfcClient {
 
 export class InstallationProxyClient {
 	private plistService: Mobile.IiOSDeviceSocket = null;
+	private plistInstallationService: iOSCore.PlistService;
 
 	constructor(private device: Mobile.IiOSDevice,
 		private $logger: ILogger,
@@ -250,11 +251,12 @@ export class InstallationProxyClient {
 	public sendMessage(message: any): IFuture<any> {
 		return (() => {
 			let service = this.device.startService(MobileServices.INSTALLATION_PROXY);
-			let plistService = this.$injector.resolve(iOSCore.PlistService, { service: service,  format: iOSCore.CoreTypes.kCFPropertyListBinaryFormat_v1_0 });
+			if(!this.plistInstallationService) {
+				this.plistInstallationService = this.$injector.resolve(iOSCore.PlistService, { service: service,  format: iOSCore.CoreTypes.kCFPropertyListBinaryFormat_v1_0 });
+			}
+			this.plistInstallationService.sendMessage(message);
 
-			plistService.sendMessage(message);
-
-			let response = plistService.receiveMessage().wait();
+			let response = this.plistInstallationService.receiveMessage().wait();
 			if(response.Error) {
 				this.$errors.failWithoutHelp(response.Error);
 			}

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -460,9 +460,16 @@ export class DevicesService implements Mobile.IDevicesService {
 
 	private isApplicationInstalledOnDevice(deviceIdentifier: string, appIdentifier: string): IFuture<IAppInstalledInfo> {
 		return ((): IAppInstalledInfo => {
-			let device = this.getDeviceByIdentifier(deviceIdentifier),
-				isInstalled = device.applicationManager.isApplicationInstalled(appIdentifier).wait(),
+			let isInstalled = false,
+				isLiveSyncSupported = false,
+				device = this.getDeviceByIdentifier(deviceIdentifier);
+
+			try {
+				isInstalled = device.applicationManager.isApplicationInstalled(appIdentifier).wait();
 				isLiveSyncSupported = isInstalled && device.applicationManager.isLiveSyncSupported(appIdentifier).wait();
+			} catch (err) {
+				this.$logger.trace("Error while checking is application installed. Error is: ", err);
+			}
 
 			return {
 				appIdentifier,
@@ -470,7 +477,6 @@ export class DevicesService implements Mobile.IDevicesService {
 				isInstalled,
 				isLiveSyncSupported
 			};
-
 		}).future<IAppInstalledInfo>()();
 	}
 }


### PR DESCRIPTION
Currently we are using AMDeviceLookupApplications to check the installed applications on iOS.
As we need information is LiveSync supported for all user's applications, we have to make another call through installationProxy, that returns both CFBundleIdentifier and IsLiveSyncSupported property.
So we do not need the first call at all as the second one gives us all the required information.
Also cache the installation proxy instead of creating new one each time.

Use the cached data for isApplicationInstalled method. In case the app is not there, applicationInstalled will be raised when it is installed.
Cache the Installation Plist service, so we'll have only one instance per each iOS device.