### PR TITLE
Remove caching of iOS services

### DIFF
--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -22,6 +22,10 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 
 	public isApplicationInstalled(appIdentifier: string): IFuture<boolean> {
 		return (() => {
+			if (!this.lastInstalledAppIdentifiers || !this.lastInstalledAppIdentifiers.length) {
+				this.checkForApplicationUpdates().wait();
+			}
+
 			return _.contains(this.lastInstalledAppIdentifiers, appIdentifier);
 		}).future<boolean>()();
 	}


### PR DESCRIPTION
### Remove caching of iOS services
Revert caching of iOS services as this caused several issues with multiple data parsing, keeping sockets opened, etc.
Make sure to close the socket after each operation.

### Get currently installed applications when checking is app installed
In case you call isApplicationInstalled before checkForApplicationUpdates, the cache will not be populated and the result will always be false.
In case there's no data in the cache, call checkForApplicationUpdates.