### PR TITLE
Fix livesync when app is not installed

### DIFF
--- a/appbuilder/providers/device-app-data-provider.ts
+++ b/appbuilder/providers/device-app-data-provider.ts
@@ -57,6 +57,8 @@ export class AndroidAppIdentifier extends DeviceAppDataBase implements ILiveSync
 			let isApplicationInstalled = this.device.applicationManager.isApplicationInstalled(this.appIdentifier).wait();
 			if (!isApplicationInstalled) {
 				this.$deployHelper.deploy(this.$devicePlatformsConstants.Android.toLowerCase()).wait();
+				// Update cache of installed apps
+				this.device.applicationManager.checkForApplicationUpdates().wait();
 			}
 		 	return this.getLiveSyncVersion().wait() !== 0;
 		}).future<boolean>()();

--- a/services/livesync-service-base.ts
+++ b/services/livesync-service-base.ts
@@ -213,7 +213,7 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 						this.$logger.info(`Successfully synced application ${data.appIdentifier} on device ${device.deviceInfo.identifier}.`);
 					}
 				} else {
-					throw new Error(`LiveSync is not supported for device with ${device.deviceInfo.identifier}.`);
+					throw new Error(`LiveSync is not supported for application: ${deviceAppData.appIdentifier} on device with identifier ${device.deviceInfo.identifier}.`);
 				}
 			}).future<void>()();
 		};


### PR DESCRIPTION
Fix livesync of application when it is not installed on device. Currently it is running two builds for Android.