### PR TITLE
iOS Device operations fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.10.1
+Latest version: 0.11.0
 
-Release date: 2016, May 17
+Release date: 2016, May 24
 
 ### System Requirements
 

--- a/appbuilder/proton-bootstrap.ts
+++ b/appbuilder/proton-bootstrap.ts
@@ -26,7 +26,7 @@ $injector.register("emulatorSettingsService", {
 });
 
 $injector.require("logger", "./logger");
-// When debugging uncomment the lines below and comment the line #6 (requiring logger).
+// When debugging uncomment the lines below
 // $injector.resolve("logger").setLevel("TRACE");
 
 // Mock as it is used in LiveSync logic to deploy on devices.

--- a/mobile/ios/device/ios-device.ts
+++ b/mobile/ios/device/ios-device.ts
@@ -59,6 +59,11 @@ export class IOSDevice implements Mobile.IiOSDevice {
 			this.deviceInfo.color = this.getValue("DeviceColor");
 			this.deviceInfo.isTablet = productType && productType.toLowerCase().indexOf("ipad") !== -1;
 			this.deviceInfo.activeArchitecture = this.getActiveArchitecture(productType);
+
+			// In case any of the operations had failed, the device status should be Unreachable.
+			if (this.deviceInfo.errorHelp) {
+				this.deviceInfo.status = constants.UNREACHABLE_STATUS;
+			}
 		}
 
 	private getActiveArchitecture(productType: string): string {
@@ -112,11 +117,8 @@ export class IOSDevice implements Mobile.IiOSDevice {
 		return null;
 	}
 
-	private validateResult(result: number, error: string, statusOptions?: { setStatusToUnreachable: boolean }) {
+	private validateResult(result: number, error: string) {
 		if (result !== 0) {
-			if (statusOptions && statusOptions.setStatusToUnreachable) {
-				this.deviceInfo.status = constants.UNREACHABLE_STATUS;
-			}
 			this.$errors.fail(util.format("%s. Result code is: %s", error, result));
 		} else {
 			this.deviceInfo.status = constants.CONNECTED_STATUS;
@@ -129,19 +131,19 @@ export class IOSDevice implements Mobile.IiOSDevice {
 
 	private pair(): number {
 		let result = this.$mobileDevice.devicePair(this.devicePointer);
-		this.validateResult(result, "Make sure you have trusted the computer from your device. If your phone is locked with a passcode, unlock then reconnect it", { setStatusToUnreachable: true });
+		this.validateResult(result, "Make sure you have trusted the computer from your device. If your phone is locked with a passcode, unlock then reconnect it");
 		return result;
 	}
 
 	private validatePairing() : number{
 		let result = this.$mobileDevice.deviceValidatePairing(this.devicePointer);
-		this.validateResult(result, "Unable to validate pairing", { setStatusToUnreachable: true });
+		this.validateResult(result, "Unable to validate pairing");
 		return result;
 	}
 
 	private connect() : number {
 		let result = this.$mobileDevice.deviceConnect(this.devicePointer);
-		this.validateResult(result, "Unable to connect to device", { setStatusToUnreachable: true });
+		this.validateResult(result, "Unable to connect to device");
 
 		if (!this.isPaired()) {
 			this.pair();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.10.1",
+  "version": "0.11.0",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
### 	Retry iOS device file related operations
Most of the iOS File related operations may fail on Mac OS X, but after retrying them, they succeed.
Retry the operations several times and fail in case they do not succeed.
Also fix error: "Futures left behind" during transfer of files when `ensureDevicePathExist` throws (the future had not been resolved).

### Set iOS Device status to Unreachable only in constructor
Set iOS Device status to Unreachable only in constructor, not when some operation fails.
Most of the operations may fail a single time only, so the device is not Unreachable.
When device is trusted, we will remove current instance of iOS Device and we'll create new one, where the status will be Connected.