### PR TITLE
Pass CLI Name to verifyNodeVersion

### DIFF
--- a/verify-node-version.ts
+++ b/verify-node-version.ts
@@ -9,18 +9,18 @@ import * as semver from "semver";
 // We are absolutely sure we cannot work with them, so inform the user if he is trying to use any of them and exit the process.
 let versionsCausingFailure = ["0.10.34", "4.0.0", "4.2.0", "5.0.0"];
 
-export function verifyNodeVersion(supportedVersionsRange: string): void {
+export function verifyNodeVersion(supportedVersionsRange: string, cliName: string, deprecationVersion: string): void {
 	// The colors module should not be assigned to variable because the lint task will fail for not used variable.
 	require("colors");
 	let nodeVer = process.version.substr(1);
 
 	if (versionsCausingFailure.indexOf(nodeVer) !== -1) {
-		console.error(`${EOL}Node.js '${nodeVer}' is not supported. To be able to work with this CLI, install any Node.js version in the following range: ${supportedVersionsRange}.${EOL}`.red.bold);
+		console.error(`${EOL}Node.js '${nodeVer}' is not supported. To be able to work with ${cliName} CLI, install any Node.js version in the following range: ${supportedVersionsRange}.${EOL}`.red.bold);
 		process.exit(1);
 	}
 
 	if (semver.satisfies(nodeVer, "~0.10.0")) {
-		console.warn(`${EOL}Support for Node.js 0.10.x is deprecated and it will be removed in the next release. Please upgrade to latest Node.js LTS version.${EOL}`.yellow.bold);
+		console.warn(`${EOL}Support for Node.js 0.10.x is deprecated and will be removed in the ${cliName} ${deprecationVersion} release. Please, upgrade to the latest Node.js LTS version.${EOL}`.yellow.bold);
 	} else {
 		let checkSatisfied = semver.satisfies(nodeVer, supportedVersionsRange);
 		if (!checkSatisfied) {


### PR DESCRIPTION
Update message for Node.js 0.10.x deprecation and add additional arguments to verification method - CLI's name and version in which support for Node.js 0.10.x will be removed.