### PR TITLE
Start application on isLivesSyncSupported call from Proton

### DIFF
--- a/appbuilder/project/project-base.ts
+++ b/appbuilder/project/project-base.ts
@@ -19,7 +19,7 @@ export class Project implements Project.IProjectBase {
 	public get projectData(): Project.IData {
 		if(this.projectDir) {
 			let projectFile = path.join(this.projectDir, this.$projectConstants.PROJECT_FILE);
-			let jsonContent = this.$fs.readJson(projectFile).wait();
+			let jsonContent: Project.IData = this.$fs.readJson(projectFile).wait();
 			this.$logger.trace("Project data is: ", jsonContent);
 			return jsonContent;
 		}
@@ -40,7 +40,6 @@ export class Project implements Project.IProjectBase {
 		return null;
 	}
 
-	// Will be set to new value on each deploy.
 	public startPackageActivity = StartPackageActivityNames.CORDOVA;
 }
 $injector.register("project", Project);

--- a/appbuilder/services/livesync/livesync-service.ts
+++ b/appbuilder/services/livesync/livesync-service.ts
@@ -28,9 +28,9 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 	}
 
 	@exportedPromise("liveSyncService")
-	public isLiveSyncSupported(deviceIdentifiers: string[], appIdentifier: string): IFuture<ILiveSyncSupportedInfo>[] {
+	public isLiveSyncSupported(deviceIdentifiers: string[], appIdentifier: string, framework: string): IFuture<ILiveSyncSupportedInfo>[] {
 		this.$logger.trace(`Called isLiveSyncSupported for identifiers ${deviceIdentifiers}. AppIdentifier is ${appIdentifier}.`);
-		return _.map(deviceIdentifiers, deviceId => this.isLiveSyncSupportedOnDevice(deviceId, appIdentifier));
+		return _.map(deviceIdentifiers, deviceId => this.isLiveSyncSupportedOnDevice(deviceId, appIdentifier, framework));
 	}
 
 	private liveSyncOnDevice(deviceDescriptor: IDeviceLiveSyncInfo, filePaths: string[]): IFuture<IDeviceLiveSyncResult> {
@@ -102,9 +102,10 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 		}).future<ILiveSyncOperationResult>()();
 	}
 
-	private isLiveSyncSupportedOnDevice(deviceIdentifier: string, appIdentifier: string): IFuture<ILiveSyncSupportedInfo> {
+	private isLiveSyncSupportedOnDevice(deviceIdentifier: string, appIdentifier: string, framework: string): IFuture<ILiveSyncSupportedInfo> {
 		return ((): ILiveSyncSupportedInfo => {
 			let device = this.$devicesService.getDeviceByIdentifier(deviceIdentifier);
+			device.applicationManager.tryStartApplication(appIdentifier, framework).wait();
 			let isLiveSyncSupported = !!device.applicationManager.isLiveSyncSupported(appIdentifier).wait();
 			return {
 				deviceIdentifier,

--- a/definitions/logger.d.ts
+++ b/definitions/logger.d.ts
@@ -1,17 +1,17 @@
 interface ILogger {
 	setLevel(level: string): void;
 	getLevel(): string;
-	fatal(formatStr?: any, ...args: string[]): void;
-	error(formatStr?: any, ...args: string[]): void;
-	warn(formatStr?: any, ...args: string[]): void;
-	warnWithLabel(formatStr?: any, ...args: string[]): void;
-	info(formatStr?: any, ...args: string[]): void;
-	debug(formatStr?: any, ...args: string[]): void;
-	trace(formatStr?: any, ...args: string[]): void;
-	printMarkdown(...args: string[]): void;
+	fatal(formatStr?: any, ...args: any[]): void;
+	error(formatStr?: any, ...args: any[]): void;
+	warn(formatStr?: any, ...args: any[]): void;
+	warnWithLabel(formatStr?: any, ...args: any[]): void;
+	info(formatStr?: any, ...args: any[]): void;
+	debug(formatStr?: any, ...args: any[]): void;
+	trace(formatStr?: any, ...args: any[]): void;
+	printMarkdown(...args: any[]): void;
 
-	out(formatStr?: any, ...args: string[]): void;
-	write(...args: string[]): void;
+	out(formatStr?: any, ...args: any[]): void;
+	write(...args: any[]): void;
 
 	prepare(item: any): string;
 	printInfoMessageOnSameLine(message: string): void;

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -187,12 +187,13 @@ declare module Mobile {
 		installApplication(packageFilePath: string): IFuture<void>;
 		uninstallApplication(appIdentifier: string): IFuture<void>;
 		reinstallApplication(appIdentifier: string, packageFilePath: string): IFuture<void>;
-		startApplication(appIdentifier: string): IFuture<void>;
+		startApplication(appIdentifier: string, framework?: string): IFuture<void>;
 		stopApplication(appIdentifier: string): IFuture<void>;
-		restartApplication(appIdentifier: string, bundleExecutable?: string): IFuture<void>;
+		restartApplication(appIdentifier: string, bundleExecutable?: string, framework?: string): IFuture<void>
 		canStartApplication(): boolean;
 		checkForApplicationUpdates(): IFuture<void>;
 		isLiveSyncSupported(appIdentifier: string): IFuture<boolean>;
+		tryStartApplication(appIdentifier: string, framework?: string): IFuture<void>;
 	}
 
 	interface IApplicationLiveSyncStatus {

--- a/mobile/ios/device/ios-application-manager.ts
+++ b/mobile/ios/device/ios-application-manager.ts
@@ -13,19 +13,19 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 	private _gdbServer: Mobile.IGDBServer = null;
 	private applicationsLiveSyncStatus: Mobile.IApplicationLiveSyncStatus[];
 
-	constructor(private device: Mobile.IiOSDevice,
+	constructor(protected $logger: ILogger,
+		private device: Mobile.IiOSDevice,
 		private devicePointer: NodeBuffer,
 		private $childProcess: IChildProcess,
 		private $coreFoundation: Mobile.ICoreFoundation,
 		private $errors: IErrors,
 		private $injector: IInjector,
 		private $mobileDevice: Mobile.IMobileDevice,
-		private $logger: ILogger,
 		private $hostInfo: IHostInfo,
 		private $staticConfig: Config.IStaticConfig,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $options: ICommonOptions) {
-			super();
+			super($logger);
 			this.uninstallApplicationCallbackPtr = CoreTypes.am_device_mount_image_callback.toPointer(IOSApplicationManager.uninstallCallback);
 		}
 

--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -11,8 +11,9 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		private identifier: string,
 		private $options: ICommonOptions,
 		private $fs: IFileSystem,
-		private $bplistParser: IBinaryPlistParser) {
-			super();
+		private $bplistParser: IBinaryPlistParser,
+		$logger: ILogger) {
+			super($logger);
 		}
 
 	public getInstalledApplications(): IFuture<string[]> {

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -52,7 +52,8 @@ let androidDeviceDiscovery: EventEmitter,
 		applicationManager: {
 			getInstalledApplications: () => Future.fromResult(["com.telerik.unitTest1", "com.telerik.unitTest2"]),
 			canStartApplication: () => true,
-			startApplication: (packageName: string) => Future.fromResult(),
+			startApplication: (packageName: string, framework: string) => Future.fromResult(),
+			tryStartApplication: (packageName: string, framework: string) => Future.fromResult(),
 			reinstallApplication: (packageName: string, packageFile: string) => Future.fromResult(),
 			isApplicationInstalled: (packageName: string) => Future.fromResult(_.contains(["com.telerik.unitTest1", "com.telerik.unitTest2"], packageName)),
 			isLiveSyncSupported: (appIdentifier: string) => Future.fromResult(_.contains(["com.telerik.unitTest1", "com.telerik.unitTest2"], appIdentifier))
@@ -125,7 +126,8 @@ describe("devicesService", () => {
 			applicationManager: {
 				getInstalledApplications: () => Future.fromResult(["com.telerik.unitTest1", "com.telerik.unitTest2"]),
 				canStartApplication: () => true,
-				startApplication: (packageName: string) => Future.fromResult(),
+				startApplication: (packageName: string, framework: string) => Future.fromResult(),
+				tryStartApplication: (packageName: string, framework: string) => Future.fromResult(),
 				reinstallApplication: (packageName: string, packageFile: string) => Future.fromResult(),
 				isApplicationInstalled: (packageName: string) => Future.fromResult(_.contains(["com.telerik.unitTest1", "com.telerik.unitTest2"], packageName)),
 				isLiveSyncSupported: (appIdentifier: string) => Future.fromResult(_.contains(["com.telerik.unitTest1", "com.telerik.unitTest2"], appIdentifier))
@@ -140,7 +142,8 @@ describe("devicesService", () => {
 			applicationManager: {
 				getInstalledApplications: () => Future.fromResult(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"]),
 				canStartApplication: () => true,
-				startApplication: (packageName: string) => Future.fromResult(),
+				startApplication: (packageName: string, framework: string) => Future.fromResult(),
+				tryStartApplication: (packageName: string, framework: string) => Future.fromResult(),
 				reinstallApplication: (packageName: string, packageFile: string) => Future.fromResult(),
 				isApplicationInstalled: (packageName: string) => Future.fromResult(_.contains(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"], packageName)),
 				isLiveSyncSupported: (appIdentifier: string) => Future.fromResult(_.contains(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"], appIdentifier))


### PR DESCRIPTION
LiveSync plugin requires application to be started on device at least once in order to report that LiveSync for current app is enabled.
The reason is that when the application is started for first time, LiveSync plugin bootstraps the app, by replacing some files. In case we send our newly changed files before that and start the application, LiveSync plugin will replace our files with the original ones from .apk.
So for Proton, start the application when `isLiveSyncSupported` called. The workflow is:
* Call `Build and Deploy` from Proton
* Install the app
* common-lib raises `appInstalled` event
* Proton catches `appInstalled` and calls `isLiveSyncSupported` for the specific devices and application.
* common-lib starts the application and after that calls isLiveSyncSupported.

The other case is when Proton is started and project is opened. In this case Proton automatically calls `isLiveSyncSupported` for current app, so we'll immediately start it on devices (in case it is installed).

### BREAKING CHANGE
Add new parameter to `isLiveSyncSupported` method  - framework. Valid values are cordova and nativescript.