### PR TITLE
Remove isLiveSyncSupported from public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,35 @@ Sample result will be:
 }]
 ```
 
+* `isCompanionAppInstalledOnDevices(deviceIdentifiers: string[], framework: string): Promise<IAppInstalledInfo>[]` - checks if the companion application is installed on each of the specified devices and is LiveSync supported for this application.
+The returned type for each device is `IAppInstalledInfo` (check above for full description of the interface).
+Sample usage:
+```JavaScript
+Promise.all(require("mobile-cli-lib")
+				.devicesService
+				.isCompanionAppInstalledOnDevices(devicesFound, "cordova"))
+		.then(function(data) {
+			console.log(data);
+		}, function(err) {
+			console.log(err);
+		});
+```
+Sample result will be:
+```JSON
+[{
+	"deviceIdentifier": "deviceId1",
+	"appIdentifier": "com.telerik.AppBuilder",
+	"isInstalled": true,
+	"isLiveSyncSupported": true
+}, {
+	"deviceIdentifier": "deviceId2",
+	"appIdentifier": "com.telerik.AppBuilder",
+	"isInstalled": false,
+	"isLiveSyncSupported": false
+}]
+```
+
+
 * `mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string): Promise<string>` - This function forwards the abstract port of the web view on the device to available tcp port on the host and returns the tcp port.
 
 Sample usage:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.11.1
+Latest version: 0.12.0
 
-Release date: 2016, May 25
+Release date: 2016, June 1
 
 ### System Requirements
 

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ require("mobile-cli-lib").devicesService.setLogLevel("INFO", "129604ab96a4d00530
 This will set the logging level to `INFO` only for device with identifier `129604ab96a4d0053023b4bf5b288cf34a9ed5fa`.
 
 
-* `isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string): Promise<IAppInstalledInfo>[]` - checks if the specified application is installed on each of the specified devices and is LiveSync supported for this application.
+* `isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string, framework: string): Promise<IAppInstalledInfo>[]` - checks if the specified application is installed on each of the specified devices and is LiveSync supported for this application.
 The returned type for each device is `IAppInstalledInfo`:
 ```JavaScript
 /**
@@ -394,11 +394,13 @@ interface IAppInstalledInfo extends ILiveSyncSupportedInfo {
 	isLiveSyncSupported: boolean;
 }
 ```
+
+> NOTE: This method will try to start the application on each device in order to understand is LiveSync supported.
 Sample usage:
 ```JavaScript
 Promise.all(require("mobile-cli-lib")
 				.devicesService
-				.isAppInstalledOnDevices(devicesFound, "com.telerik.myApp"))
+				.isAppInstalledOnDevices(devicesFound, "com.telerik.myApp", "cordova"))
 		.then(function(data) {
 			console.log(data);
 		}, function(err) {
@@ -534,54 +536,6 @@ Promise.all(require("mobile-cli-lib").liveSyncService.livesync(deviceInfos, proj
 	}).catch(function(err) {
 			console.log("Error while livesyncing: ", err);
 	});
-```
-
-* `isLiveSyncSupported(deviceIdentifiers: string[], appIdentifier: string): Promise<ILiveSyncSupportedInfo>[]` - checks if user can use LiveSync for application and for specified devices.
-For each device the following object will be returned:
-```JavaScript
-/**
- * Describes if LiveSync is supported for specific device and application.
- */
-interface ILiveSyncSupportedInfo {
-	/**
-	 * Unique identifier of the device.
-	 */
-	deviceIdentifier: string;
-
-	/**
-	 * Application identifier.
-	 */
-	appIdentifier: string;
-
-	/**
-	 * Result, indicating is livesync supported for specified device and specified application.
-	 * `true` in case livesync is supported and false otherwise.
-	 */
-	isLiveSyncSupported: boolean;
-}
-```
-
-Sample usage:
-```JavaScript
-Promise.all(require("mobile-cli-lib").liveSyncService.isLiveSyncSupported(["deviceId1", "deviceId2"], "appIdentifier"))
-	.then(function(result) {
-			console.log("Result is: ", result);
-	}).catch(function(err) {
-			console.log("Error while checking is LiveSync supported: ", err);
-	});
-```
-
-Sample result will be:
-```JSON
-[{
-	"deviceIdentifier": "deviceId1",
-	"appIdentifier": "appIdentifier",
-	"isLiveSyncSupported": true
-}, {
-	"deviceIdentifier": "deviceId2",
-	"appIdentifier": "appIdentifier",
-	"isLiveSyncSupported": false
-}]
 ```
 
 Technical details

--- a/appbuilder/services/livesync/livesync-service.ts
+++ b/appbuilder/services/livesync/livesync-service.ts
@@ -27,12 +27,6 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 		return _.map(deviceDescriptors, deviceDescriptor => this.liveSyncOnDevice(deviceDescriptor, filePaths));
 	}
 
-	@exportedPromise("liveSyncService")
-	public isLiveSyncSupported(deviceIdentifiers: string[], appIdentifier: string, framework: string): IFuture<ILiveSyncSupportedInfo>[] {
-		this.$logger.trace(`Called isLiveSyncSupported for identifiers ${deviceIdentifiers}. AppIdentifier is ${appIdentifier}.`);
-		return _.map(deviceIdentifiers, deviceId => this.isLiveSyncSupportedOnDevice(deviceId, appIdentifier, framework));
-	}
-
 	private liveSyncOnDevice(deviceDescriptor: IDeviceLiveSyncInfo, filePaths: string[]): IFuture<IDeviceLiveSyncResult> {
 		return ((): IDeviceLiveSyncResult => {
 			let result: IDeviceLiveSyncResult = {
@@ -100,19 +94,6 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 
 			return liveSyncOperationResult;
 		}).future<ILiveSyncOperationResult>()();
-	}
-
-	private isLiveSyncSupportedOnDevice(deviceIdentifier: string, appIdentifier: string, framework: string): IFuture<ILiveSyncSupportedInfo> {
-		return ((): ILiveSyncSupportedInfo => {
-			let device = this.$devicesService.getDeviceByIdentifier(deviceIdentifier);
-			device.applicationManager.tryStartApplication(appIdentifier, framework).wait();
-			let isLiveSyncSupported = !!device.applicationManager.isLiveSyncSupported(appIdentifier).wait();
-			return {
-				deviceIdentifier,
-				appIdentifier,
-				isLiveSyncSupported
-			};
-		}).future<ILiveSyncSupportedInfo>()();
 	}
 }
 $injector.register("liveSyncService", ProtonLiveSyncService);

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -261,7 +261,7 @@ declare module Mobile {
 		isiOSDevice(device: Mobile.IDevice): boolean;
 		isiOSSimulator(device: Mobile.IDevice): boolean;
 		isOnlyiOSSimultorRunning(): boolean;
-		isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string): IFuture<IAppInstalledInfo>[];
+		isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string, framework: string): IFuture<IAppInstalledInfo>[];
 		setLogLevel(logLevel: string, deviceIdentifier?: string): void;
 		deployOnDevices(deviceIdentifiers: string[], packageFile: string, packageName: string, framework: string): IFuture<void>[];
 		startDeviceDetectionInterval(): void;

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -73,9 +73,9 @@ export class DevicesService implements Mobile.IDevicesService {
 	/* tslint:enable:no-unused-variable */
 
 	@exportedPromise("devicesService")
-	public isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string): IFuture<IAppInstalledInfo>[] {
+	public isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string, framework: string): IFuture<IAppInstalledInfo>[] {
 		this.$logger.trace(`Called isInstalledOnDevices for identifiers ${deviceIdentifiers}. AppIdentifier is ${appIdentifier}.`);
-		return _.map(deviceIdentifiers, deviceIdentifier => this.isApplicationInstalledOnDevice(deviceIdentifier, appIdentifier));
+		return _.map(deviceIdentifiers, deviceIdentifier => this.isApplicationInstalledOnDevice(deviceIdentifier, appIdentifier, framework));
 	}
 
 	public getDeviceInstances(): Mobile.IDevice[] {
@@ -452,15 +452,15 @@ export class DevicesService implements Mobile.IDevicesService {
 		return this.executeOnAllConnectedDevices(action, canExecute);
 	}
 
-	private isApplicationInstalledOnDevice(deviceIdentifier: string, appIdentifier: string): IFuture<IAppInstalledInfo> {
+	private isApplicationInstalledOnDevice(deviceIdentifier: string, appIdentifier: string, framework: string): IFuture<IAppInstalledInfo> {
 		return ((): IAppInstalledInfo => {
 			let isInstalled = false,
 				isLiveSyncSupported = false,
 				device = this.getDeviceByIdentifier(deviceIdentifier);
-
 			try {
 				isInstalled = device.applicationManager.isApplicationInstalled(appIdentifier).wait();
-				isLiveSyncSupported = isInstalled && device.applicationManager.isLiveSyncSupported(appIdentifier).wait();
+				device.applicationManager.tryStartApplication(appIdentifier, framework).wait();
+				isLiveSyncSupported = isInstalled && !!device.applicationManager.isLiveSyncSupported(appIdentifier).wait();
 			} catch (err) {
 				this.$logger.trace("Error while checking is application installed. Error is: ", err);
 			}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.11.1",
+  "version": "0.12.0",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -94,6 +94,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("androidEmulatorServices", AndroidEmulatorServices);
 	testInjector.register("iOSEmulatorServices", IOSEmulatorServices);
 	testInjector.register("messages", Messages);
+	testInjector.register("companionAppsService", {});
 	testInjector.register("mobileHelper", {
 		platformNames: ["ios", "android"],
 		validatePlatformName: (platform: string) => platform.toLowerCase(),

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -254,7 +254,7 @@ describe("devicesService", () => {
 		it("returns true for each device on which the app is installed", () => {
 			let deviceIdentifiers = [androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier],
 				appId = "com.telerik.unitTest1";
-			let results = devicesService.isAppInstalledOnDevices(deviceIdentifiers, appId);
+			let results = devicesService.isAppInstalledOnDevices(deviceIdentifiers, appId, "cordova");
 			assert.isTrue(results.length > 0);
 			_.each(results, (futurizedResult: IFuture<IAppInstalledInfo>, index: number) => {
 				let realResult = futurizedResult.wait();
@@ -266,14 +266,14 @@ describe("devicesService", () => {
 		});
 
 		it("returns false for each device on which the app is not installed", () => {
-			let results = devicesService.isAppInstalledOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "com.telerik.unitTest3");
+			let results = devicesService.isAppInstalledOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "com.telerik.unitTest3", "cordova");
 			assert.isTrue(results.length > 0);
 			Future.wait(results);
 			assert.deepEqual(results.map(r => r.get().isInstalled), [true, false]);
 		});
 
 		it("throws error when invalid identifier is passed", () => {
-			let results = devicesService.isAppInstalledOnDevices(["invalidDeviceId", iOSDevice.deviceInfo.identifier], "com.telerik.unitTest1");
+			let results = devicesService.isAppInstalledOnDevices(["invalidDeviceId", iOSDevice.deviceInfo.identifier], "com.telerik.unitTest1", "cordova");
 			assert.throws(() => Future.wait(results));
 			_.each(results, futurizedResult => {
 				let error = futurizedResult.error;


### PR DESCRIPTION
### BREAKING CHANGE
Remove isLiveSyncSupported method as isAppInstalledOnDevices returns the same information, so it should be used.

Also from now on, when `isAppInstalledOnDevices` is called, it will start the application, if possible.

### 	Add isCompanionAppInstalledOnDevices method to public API

Add new method to check if companion app is installed on devices.
`isCompanionAppInstalledOnDevices(deviceIdentifiers: string[], framework: string): Promise<IAppInstalledInfo>[]`

The difference from `isAppInstalledOnDevices` is that this method will not start the application on device.

### Set version to 0.12.0
Set version to 0.12.0