### PR TITLE
Add public API for deleting files during liveSync operation

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -495,6 +495,13 @@ interface ILiveSyncServiceBase {
 	 * @return {Function} Function that returns IFuture<void>.
 	 */
 	getSyncAction(data: ILiveSyncData, filesToSync?: string[], deviceFilesAction?: (device: Mobile.IDevice, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => IFuture<void>, liveSyncOptions?: { isForCompanionApp: boolean }): (device: Mobile.IDevice) => IFuture<void>;
+
+	/**
+	 * Gets LiveSync action that should be executed per device when files should be deleted.
+	 * @param {ILiveSyncData} data LiveSync data describing the LiveSync operation.
+	 * @return {Function} Function that returns IFuture<void>.
+	 */
+	getSyncRemovedFilesAction(data: ILiveSyncData): (device: Mobile.IDevice, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => IFuture<void>;
 }
 
 interface ISyncBatch {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -405,6 +405,7 @@ declare module Mobile {
 		getLocalPath(): string;
 		getDevicePath(): string;
 		getRelativeToProjectBasePath(): string;
+		deviceProjectRootPath: string;
 	}
 
 	interface ILocalToDevicePathDataFactory {

--- a/mobile/android/android-livesync-service.ts
+++ b/mobile/android/android-livesync-service.ts
@@ -17,6 +17,10 @@ class LiveSyncCommands {
 	public static RefreshCurrentViewCommand(): string {
 		return "RefreshCurrentView \r";
 	}
+
+	public static DeleteFile(relativePath: string): string {
+		return `DeleteFile "${relativePath}" \r`;
+	}
 }
 
 export class AndroidLiveSyncService implements Mobile.IAndroidLiveSyncService {

--- a/mobile/local-to-device-path-data-factory.ts
+++ b/mobile/local-to-device-path-data-factory.ts
@@ -10,7 +10,7 @@ class LocalToDevicePathData implements Mobile.ILocalToDevicePathData {
 	constructor(private filePath: string,
 		private localProjectRootPath: string,
 		private onDeviceFileName: string,
-		private deviceProjectRootPath: string) { }
+		public deviceProjectRootPath: string) { }
 
 	public getLocalPath(): string {
 		return this.filePath;

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -19,6 +19,10 @@ export class DevicesService implements Mobile.IDevicesService {
 	private _data: Mobile.IDevicesServicesInitializationOptions;
 	private deviceDetectionInterval: any;
 
+	private get $companionAppsService(): ICompanionAppsService {
+		return this.$injector.resolve("companionAppsService");
+	}
+
 	constructor(private $logger: ILogger,
 		private $errors: IErrors,
 		private $iOSSimulatorDiscovery: Mobile.IDeviceDiscovery,
@@ -32,8 +36,7 @@ export class DevicesService implements Mobile.IDevicesService {
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $injector: IInjector,
 		private $options: ICommonOptions,
-		private $androidProcessService: Mobile.IAndroidProcessService,
-		private $companionAppsService: ICompanionAppsService) {
+		private $androidProcessService: Mobile.IAndroidProcessService) {
 		this.attachToDeviceDiscoveryEvents();
 	}
 

--- a/services/livesync-service-base.ts
+++ b/services/livesync-service-base.ts
@@ -159,13 +159,18 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 
 	private syncRemovedFile(data: ILiveSyncData, filePath: string): IFuture<void> {
 		return (() => {
-			let deviceFilesAction = (device: Mobile.IDevice, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => {
-				let platformLiveSyncService = this.resolvePlatformLiveSyncService(data.platform, device);
-				return platformLiveSyncService.removeFiles(data.appIdentifier, localToDevicePaths);
-			};
+			let filePathArray = [filePath],
+				deviceFilesAction = this.getSyncRemovedFilesAction(data);
 
-			this.syncCore(data, [filePath], deviceFilesAction).wait();
+			this.syncCore(data, filePathArray, deviceFilesAction).wait();
 		}).future<void>()();
+	}
+
+	public getSyncRemovedFilesAction(data: ILiveSyncData): (device: Mobile.IDevice, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => IFuture<void> {
+		return (device: Mobile.IDevice, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => {
+			let platformLiveSyncService = this.resolvePlatformLiveSyncService(data.platform, device);
+			return platformLiveSyncService.removeFiles(data.appIdentifier, localToDevicePaths);
+		};
 	}
 
 	public getSyncAction(data: ILiveSyncData, filesToSync?: string[], deviceFilesAction?: (device: Mobile.IDevice, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => IFuture<void>, liveSyncOptions?: { isForCompanionApp: boolean }): (device: Mobile.IDevice) => IFuture<void> {


### PR DESCRIPTION
Add public method in liveSyncService that should be used to delete files when LiveSync operation is in progress.
This way, when user deletes file in Proton, the application will call `liveSyncService.deleteFiles` method for it and it will be removed from device.