### PR TITLE
Add post action on exportedPromise decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.13.0
+Latest version: 0.13.1
 
-Release date: 2016, June 2
+Release date: 2016, June 3
 
 ### System Requirements
 

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -281,8 +281,11 @@ export class DevicesService implements Mobile.IDevicesService {
 		}).future<void>()();
 	}
 
-	@exportedPromise("devicesService")
+	@exportedPromise("devicesService", function() {
+		this.startDeviceDetectionInterval();
+	})
 	public deployOnDevices(deviceIdentifiers: string[], packageFile: string, packageName: string, framework: string): IFuture<void>[] {
+		this.stopDeviceDetectionInterval();
 		this.$logger.trace(`Called deployOnDevices for identifiers ${deviceIdentifiers} for packageFile: ${packageFile}. packageName is ${packageName}.`);
 		return _.map(deviceIdentifiers, deviceIdentifier => this.deployOnDevice(deviceIdentifier, packageFile, packageName, framework));
 	}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.13.0",
+  "version": "0.13.1",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
Add postAction on exportedPromise decorator. This action will be called when all Promises are fulfilled.
Stop deviceDetection interval when starting deployOnDevices as it causes issues when deploying on iPhones from Mac.
In the post action start the device detection interval.