### PR TITLE
Stop device detection and checking for application updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.13.1
+Latest version: 0.13.2
 
-Release date: 2016, June 3
+Release date: 2016, June 4
 
 ### System Requirements
 

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -265,7 +265,7 @@ declare module Mobile {
 		setLogLevel(logLevel: string, deviceIdentifier?: string): void;
 		deployOnDevices(deviceIdentifiers: string[], packageFile: string, packageName: string, framework: string): IFuture<void>[];
 		startDeviceDetectionInterval(): void;
-		stopDeviceDetectionInterval(): void;
+		stopDeviceDetectionInterval(): IFuture<void>;
 		getDeviceByIdentifier(identifier: string): Mobile.IDevice;
 		mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string): IFuture<string>;
 		detectCurrentlyAttachedDevices(): IFuture<void>;

--- a/mobile/mobile-core/android-device-discovery.ts
+++ b/mobile/mobile-core/android-device-discovery.ts
@@ -15,6 +15,7 @@ interface IAdbAndroidDeviceInfo {
 
 export class AndroidDeviceDiscovery extends DeviceDiscovery implements Mobile.IAndroidDeviceDiscovery {
 	private _devices: IAdbAndroidDeviceInfo[] = [];
+	private isStarted: boolean;
 
 	constructor(private $childProcess: IChildProcess,
 		private $injector: IInjector,
@@ -104,7 +105,18 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery implements Mobile.IA
 	}
 
 	public ensureAdbServerStarted(): IFuture<any> {
-		return this.$adb.executeCommand(["start-server"]);
+		return ((): any => {
+			if (!this.isStarted) {
+				this.isStarted = true;
+
+				try {
+					return this.$adb.executeCommand(["start-server"]).wait();
+				} catch (err) {
+					this.isStarted = false;
+					throw err;
+				}
+			}
+		}).future<any>()();
 	}
 }
 $injector.register("androidDeviceDiscovery", AndroidDeviceDiscovery);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.13.1",
+  "version": "0.13.2",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
When you have deploy operation or livesync operation, we must stop device detection and checking for application changes as it breaks the deployment on iOS Devices.
The problem is that in case ANY async callback is called during uploading .ipa file to iOS Device for installation, the installation fails with different errors (PackageExtractionFailed, PackageVerificationFailed, etc.).
Add new future inside the setInterval and in case it's not resolved, the next time when setInterval is called, it will see that there's a future pending and will not schedule new execution.
Also when stopDeviceDetectionInterval is called and the future from setInterval is still pending, wait for it before starting the real operation.