### PR TITLE
Fix device run command

### DIFF
--- a/commands/device/run-application.ts
+++ b/commands/device/run-application.ts
@@ -4,7 +4,9 @@ export class RunApplicationOnDeviceCommand implements ICommand {
 		private $errors: IErrors,
 		private $stringParameter: ICommandParameter,
 		private $staticConfig: Config.IStaticConfig,
-		private $options: ICommonOptions) { }
+		private $options: ICommonOptions,
+		private $projectConstants: Project.IConstants,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	allowedParameters: ICommandParameter[] = [this.$stringParameter];
 
@@ -16,9 +18,9 @@ export class RunApplicationOnDeviceCommand implements ICommand {
 				this.$errors.failWithoutHelp("More than one device found. Specify device explicitly with --device option. To discover device ID, use $%s device command.", this.$staticConfig.CLIENT_NAME.toLowerCase());
 			}
 
-			let action = (device: Mobile.IDevice) => device.applicationManager.startApplication(args[0]);
-			this.$devicesService.execute(action).wait();
+			this.$devicesService.execute((device: Mobile.IDevice) => device.applicationManager.startApplication(args[0])).wait();
 		}).future<void>()();
 	}
 }
+
 $injector.registerCommand("device|run", RunApplicationOnDeviceCommand);

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -189,7 +189,7 @@ declare module Mobile {
 		reinstallApplication(appIdentifier: string, packageFilePath: string): IFuture<void>;
 		startApplication(appIdentifier: string, framework?: string): IFuture<void>;
 		stopApplication(appIdentifier: string): IFuture<void>;
-		restartApplication(appIdentifier: string, bundleExecutable?: string, framework?: string): IFuture<void>
+		restartApplication(appIdentifier: string, bundleExecutable?: string, framework?: string): IFuture<void>;
 		canStartApplication(): boolean;
 		checkForApplicationUpdates(): IFuture<void>;
 		isLiveSyncSupported(appIdentifier: string): IFuture<boolean>;

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -37,7 +37,7 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 			// As this method is called on 500ms, but it's execution may last much longer
 			// use locking, so the next executions will not get into the body, while the first one is still working.
 			// In case we do not break the next executions, we'll report each app as newly installed several times.
-			if(!this.isChecking) {
+			if (!this.isChecking) {
 				try {
 					this.isChecking = true;
 					let currentlyInstalledAppIdentifiers = this.getInstalledApplications().wait();
@@ -63,7 +63,7 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 				if (this.isApplicationInstalled(appIdentifier).wait() && this.canStartApplication()) {
 					this.startApplication(appIdentifier, framework).wait();
 				}
-			} catch(err) {
+			} catch (err) {
 				this.$logger.trace(`Unable to start application ${appIdentifier}. Error is: ${err.message}`);
 			}
 		}).future<void>()();

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -3,8 +3,8 @@ import Future = require("fibers/future");
 import * as helpers from "../../helpers";
 import * as assert from "assert";
 import * as constants from "../constants";
-import {exportedPromise, exported} from "../../decorators";
 import * as fiberBootstrap from "../../fiber-bootstrap";
+import {exportedPromise, exported} from "../../decorators";
 
 export class DevicesService implements Mobile.IDevicesService {
 	private _devices: IDictionary<Mobile.IDevice> = {};


### PR DESCRIPTION
When executing `appbuilder device run appid` outside of project the CLI cannot determine which startPackageActivity name to use - for NativeScript or for Cordova application. The fix is to check where the command is executed and if it is not in project we need to run the adb command for both NativeScript and Cordova projects.