### PR TITLE
Fix grep command arguments in android process service

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,11 +463,11 @@ require("mobile-cli-lib").devicesService.mapAbstractToTcpPort("4df18f307d8a8f1b"
 	});
 ```
 
-* `getApplicationsAvailableForDebugging(deviceIdentifier: string): Promise<string[]>` - This function checks the proc/net/unix file of the device for web views connected to abstract ports and returns the applications identifiers.
+* `getDebuggableApps(deviceIdentifier: string): Promise<string[]>` - This function checks the proc/net/unix file of the device for web views connected to abstract ports and returns the applications identifiers.
 
 Sample usage:
 ```JavaScript
-require("mobile-cli-lib").devicesService.getApplicationsAvailableForDebugging("4df18f307d8a8f1b")
+require("mobile-cli-lib").devicesService.getDebuggableApps("4df18f307d8a8f1b")
 	.then(function(applicationsIdentifiers) {
 		applicationsIdentifiers.forEach(function(applicationIdentifier) {
 			console.log(applicationIdentifier);

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -288,7 +288,7 @@ declare module Mobile {
 		 * @param deviceIdentifier The identifier of the device.
 		 * @return {string[]} Returns array of applications identifiers which are available for debugging.
 		 */
-		getApplicationsAvailableForDebugging(deviceIdentifier: string): IFuture<string[]>;
+		getDebuggableApps(deviceIdentifier: string): IFuture<string[]>;
 	}
 
 	interface IiTunesValidator {

--- a/mobile/mobile-core/android-process-service.ts
+++ b/mobile/mobile-core/android-process-service.ts
@@ -54,7 +54,7 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 		}).future<string>()();
 	}
 
-	public getApplicationsAvailableForDebugging(deviceIdentifier: string): IFuture<string[]> {
+	public getDebuggableApps(deviceIdentifier: string): IFuture<string[]> {
 		return (() => {
 			let adb = this.getAdb(deviceIdentifier);
 			let androidWebViewPortInformation = (<string>this.getAbstractPortsInformation(adb).wait()).split(EOL);
@@ -75,7 +75,7 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 				// Process information will look like this (without the columns names):
 				// USER     PID   PPID  VSIZE   RSS   WCHAN    PC         NAME
 				// u0_a63   25512 1334  1519560 96040 ffffffff f76a8f75 S com.telerik.appbuildertabstest
-				let processIdInformation: string = adb.executeShellCommand(["ps", "|grep", "-a", "--text", processId]).wait();
+				let processIdInformation: string = adb.executeShellCommand(["ps", "|grep", processId]).wait();
 
 				return _.last(processIdInformation.trim().split(/[ \t]/));
 			}
@@ -123,7 +123,7 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 			// USER     PID   PPID  VSIZE   RSS   WCHAN    PC         NAME
 			// u0_a63   25512 1334  1519560 96040 ffffffff f76a8f75 S com.telerik.appbuildertabstest
 			let processIdRegExp = /^\w*\s*(\d+)/;
-			let processIdInformation: string = adb.executeShellCommand(["ps", "|grep", "-a", "--text", appIdentifier]).wait();
+			let processIdInformation: string = adb.executeShellCommand(["ps", "|grep", appIdentifier]).wait();
 
 			let matches = processIdRegExp.exec(processIdInformation);
 

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -415,8 +415,8 @@ export class DevicesService implements Mobile.IDevicesService {
 	}
 
 	@exportedPromise("devicesService")
-	public getApplicationsAvailableForDebugging(deviceIdentifier: string): IFuture<string[]> {
-		return this.$androidProcessService.getApplicationsAvailableForDebugging(deviceIdentifier);
+	public getDebuggableApps(deviceIdentifier: string): IFuture<string[]> {
+		return this.$androidProcessService.getDebuggableApps(deviceIdentifier);
 	}
 
 	private deployOnDevice(deviceIdentifier: string, packageFile: string, packageName: string, framework: string): IFuture<void> {


### PR DESCRIPTION
Remove the -a and --text from all grep commands in the android-process-service because they are not supported on every system.