### PR TITLE
Move TARGET_FRAMEWORK_IDENTIFIERS to constants

### DIFF
--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -9,11 +9,6 @@ interface IDeployHelper {
 }
 
 declare module Project {
-	interface ITargetFrameworkIdentifiers {
-		Cordova: string;
-		NativeScript: string;
-	}
-
 	interface IConstants {
 		PROJECT_FILE: string;
 		PROJECT_IGNORE_FILE: string;
@@ -23,7 +18,6 @@ declare module Project {
 		RELEASE_PROJECT_FILE_NAME: string;
 		CORE_PLUGINS_PROPERTY_NAME: string;
 		CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME: string;
-		TARGET_FRAMEWORK_IDENTIFIERS: ITargetFrameworkIdentifiers;
 		APPIDENTIFIER_PROPERTY_NAME: string;
 		EXPERIMENTAL_TAG: string;
 		NATIVESCRIPT_APP_DIR_NAME: string;

--- a/appbuilder/project-constants.ts
+++ b/appbuilder/project-constants.ts
@@ -15,11 +15,6 @@ export class ProjectConstants implements Project.IConstants {
 	public ADDITIONAL_FILE_DISPOSITION = "AdditionalFile";
 	public ADDITIONAL_FILES_DIRECTORY = ".ab";
 
-	public TARGET_FRAMEWORK_IDENTIFIERS = {
-		Cordova: "Cordova",
-		NativeScript: "NativeScript"
-	};
-
 	public APPBUILDER_PROJECT_PLATFORMS_NAMES: IDictionary<string> = {
 		android: "Android",
 		ios: "iOS",

--- a/appbuilder/project/project-base.ts
+++ b/appbuilder/project/project-base.ts
@@ -1,6 +1,8 @@
 import Future = require("fibers/future");
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../mobile/constants";
 import * as path from "path";
 import { startPackageActivityNames } from "../../mobile/constants";
+
 export class Project implements Project.IProjectBase {
 	constructor(private $cordovaProjectCapabilities: Project.ICapabilities,
 		private $fs: IFileSystem,
@@ -27,9 +29,9 @@ export class Project implements Project.IProjectBase {
 	public get capabilities(): Project.ICapabilities {
 		let projectData = this.projectData;
 		if(projectData) {
-			if(projectData.Framework && projectData.Framework.toLowerCase() === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()) {
+			if(projectData.Framework && projectData.Framework.toLowerCase() === TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()) {
 				return this.$nativeScriptProjectCapabilities;
-			} else if(projectData.Framework && projectData.Framework.toLowerCase() === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()) {
+			} else if(projectData.Framework && projectData.Framework.toLowerCase() === TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()) {
 				return this.$cordovaProjectCapabilities;
 			}
 		}
@@ -37,6 +39,6 @@ export class Project implements Project.IProjectBase {
 		return null;
 	}
 
-	public startPackageActivity = startPackageActivityNames[this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()];
+	public startPackageActivity = startPackageActivityNames[TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()];
 }
 $injector.register("project", Project);

--- a/appbuilder/providers/device-app-data-provider.ts
+++ b/appbuilder/providers/device-app-data-provider.ts
@@ -4,6 +4,7 @@ import * as querystring from "querystring";
 import * as path from "path";
 import * as util from "util";
 import { LiveSyncConstants } from "../../mobile/constants";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../mobile/constants";
 
 export class AndroidAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	private _deviceProjectRootPath: string = null;
@@ -75,9 +76,8 @@ export class AndroidCompanionAppIdentifier extends DeviceAppDataBase implements 
 	constructor(_appIdentifier: string,
 		public device: Mobile.IDevice,
 		public platform: string,
-		private $companionAppsService: ICompanionAppsService,
-		private $projectConstants: Project.IConstants) {
-		super($companionAppsService.getCompanionAppIdentifier($projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, platform));
+		private $companionAppsService: ICompanionAppsService) {
+		super($companionAppsService.getCompanionAppIdentifier(TARGET_FRAMEWORK_IDENTIFIERS.Cordova, platform));
 	}
 
 	public get deviceProjectRootPath(): string {
@@ -105,9 +105,8 @@ export class AndroidNativeScriptCompanionAppIdentifier extends DeviceAppDataBase
 	constructor(_appIdentifier: string,
 		public device: Mobile.IDevice,
 		public platform: string,
-		private $companionAppsService: ICompanionAppsService,
-		private $projectConstants: Project.IConstants) {
-		super($companionAppsService.getCompanionAppIdentifier($projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript, platform));
+		private $companionAppsService: ICompanionAppsService) {
+		super($companionAppsService.getCompanionAppIdentifier(TARGET_FRAMEWORK_IDENTIFIERS.NativeScript, platform));
 	}
 
 	public get deviceProjectRootPath(): string {
@@ -214,9 +213,8 @@ export class IOSNativeScriptAppIdentifier extends DeviceAppDataBase implements I
 export class IOSCompanionAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	constructor(public device: Mobile.IDevice,
 		public platform: string,
-		private $companionAppsService: ICompanionAppsService,
-		private $projectConstants: Project.IConstants) {
-		super($companionAppsService.getCompanionAppIdentifier($projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, platform));
+		private $companionAppsService: ICompanionAppsService) {
+		super($companionAppsService.getCompanionAppIdentifier(TARGET_FRAMEWORK_IDENTIFIERS.Cordova, platform));
 	}
 
 	public get deviceProjectRootPath(): string {
@@ -243,9 +241,8 @@ export class IOSCompanionAppIdentifier extends DeviceAppDataBase implements ILiv
 export class IOSNativeScriptCompanionAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	constructor(public device: Mobile.IDevice,
 		public platform: string,
-		private $companionAppsService: ICompanionAppsService,
-		private $projectConstants: Project.IConstants) {
-		super($companionAppsService.getCompanionAppIdentifier($projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript, platform));
+		private $companionAppsService: ICompanionAppsService) {
+		super($companionAppsService.getCompanionAppIdentifier(TARGET_FRAMEWORK_IDENTIFIERS.NativeScript, platform));
 	}
 
 	public get deviceProjectRootPath(): string {
@@ -272,9 +269,8 @@ export class IOSNativeScriptCompanionAppIdentifier extends DeviceAppDataBase imp
 export class WP8CompanionAppIdentifier extends DeviceAppDataBase implements ILiveSyncDeviceAppData {
 	constructor(public device: Mobile.IDevice,
 		public platform: string,
-		private $companionAppsService: ICompanionAppsService,
-		private $projectConstants: Project.IConstants) {
-		super($companionAppsService.getCompanionAppIdentifier($projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, platform));
+		private $companionAppsService: ICompanionAppsService) {
+		super($companionAppsService.getCompanionAppIdentifier(TARGET_FRAMEWORK_IDENTIFIERS.Cordova, platform));
 	}
 
 	public get deviceProjectRootPath(): string {

--- a/appbuilder/services/livesync/companion-apps-service.ts
+++ b/appbuilder/services/livesync/companion-apps-service.ts
@@ -1,4 +1,5 @@
 import { exported } from "../../../decorators";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../../mobile/constants";
 
 const NS_COMPANION_APP_IDENTIFIER = "com.telerik.NativeScript";
 const APPBUILDER_ANDROID_COMPANION_APP_IDENTIFIER = "com.telerik.AppBuilder";
@@ -6,8 +7,7 @@ const APPBUILDER_IOS_COMPANION_APP_IDENTIFIER = "com.telerik.Icenium";
 const APPBUILDER_WP8_COMPANION_APP_IDENTIFIER = "{9155af5b-e7ed-486d-bc6b-35087fb59ecc}";
 
 export class CompanionAppsService implements ICompanionAppsService {
-	constructor(private $projectConstants: Project.IConstants,
-		private $mobileHelper: Mobile.IMobileHelper,
+	constructor(private $mobileHelper: Mobile.IMobileHelper,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	@exported("companionAppsService")
@@ -15,7 +15,7 @@ export class CompanionAppsService implements ICompanionAppsService {
 		let lowerCasedFramework = (framework || "").toLowerCase();
 		let lowerCasedPlatform = (platform || "").toLowerCase();
 
-		if (lowerCasedFramework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()) {
+		if (lowerCasedFramework === TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()) {
 			if(this.$mobileHelper.isAndroidPlatform(lowerCasedPlatform)) {
 				return APPBUILDER_ANDROID_COMPANION_APP_IDENTIFIER;
 			} else if(this.$mobileHelper.isiOSPlatform(lowerCasedPlatform)) {
@@ -23,7 +23,7 @@ export class CompanionAppsService implements ICompanionAppsService {
 			} else if(this.$mobileHelper.isWP8Platform(lowerCasedPlatform)) {
 				return APPBUILDER_WP8_COMPANION_APP_IDENTIFIER;
 			}
-		} else if (lowerCasedFramework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()) {
+		} else if (lowerCasedFramework === TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()) {
 			if(!this.$mobileHelper.isWP8Platform(lowerCasedPlatform)) {
 				return NS_COMPANION_APP_IDENTIFIER;
 			}
@@ -41,8 +41,8 @@ export class CompanionAppsService implements ICompanionAppsService {
 		];
 
 		let frameworks = [
-			this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase(),
-			this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()
+			TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase(),
+			TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()
 		];
 
 		let companionAppIdentifiers: IDictionary<IStringDictionary> = {};

--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as shell from "shelljs";
 let osenv = require("osenv");
 import { LiveSyncConstants } from "../../../mobile/constants";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../../mobile/constants";
 
 export class IOSLiveSyncService implements IPlatformLiveSyncService {
 	private get $project(): any {
@@ -13,8 +14,7 @@ export class IOSLiveSyncService implements IPlatformLiveSyncService {
 		private $fs: IFileSystem,
 		private $injector: IInjector,
 		private $logger: ILogger,
-		private $errors: IErrors,
-		private $projectConstants: Project.IConstants) { }
+		private $errors: IErrors) { }
 
 	private get device(): Mobile.IiOSDevice {
 		return this._device;
@@ -53,7 +53,7 @@ export class IOSLiveSyncService implements IPlatformLiveSyncService {
 			} else {
 				this.device.fileSystem.deleteFile("/Library/Preferences/ServerInfo.plist", deviceAppData.appIdentifier);
 				let notificationProxyClient = this.$injector.resolve(iOSProxyServices.NotificationProxyClient, {device: this.device});
-				let notification = this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript ? "com.telerik.app.refreshApp" : "com.telerik.app.refreshWebView";
+				let notification = this.$project.projectData.Framework === TARGET_FRAMEWORK_IDENTIFIERS.NativeScript ? "com.telerik.app.refreshApp" : "com.telerik.app.refreshWebView";
 				notificationProxyClient.postNotification(notification);
 				notificationProxyClient.closeSocket();
 			}

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1078,4 +1078,3 @@ interface IVersionData {
 	minor: string;
 	patch: string;
 }
-

--- a/mobile/constants.ts
+++ b/mobile/constants.ts
@@ -26,3 +26,8 @@ export let startPackageActivityNames: IStringDictionary = {
 	"nativescript": "com.tns.NativeScriptActivity",
 	"cordova": ".TelerikCallbackActivity"
 };
+
+export let TARGET_FRAMEWORK_IDENTIFIERS = {
+	Cordova: "Cordova",
+	NativeScript: "NativeScript"
+};

--- a/mobile/mobile-core/android-process-service.ts
+++ b/mobile/mobile-core/android-process-service.ts
@@ -1,5 +1,6 @@
 import {EOL} from "os";
 import {DeviceAndroidDebugBridge} from "../android/device-android-debug-bridge";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../constants";
 
 export class AndroidProcessService implements Mobile.IAndroidProcessService {
 	private _devicesAdbs: IDictionary<Mobile.IDeviceAndroidDebugBridge>;
@@ -7,8 +8,7 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 	constructor(private $errors: IErrors,
 		private $staticConfig: Config.IStaticConfig,
 		private $injector: IInjector,
-		private $httpClient: Server.IHttpClient,
-		private $projectConstants: Project.IConstants) {
+		private $httpClient: Server.IHttpClient) {
 		this._devicesAdbs = {};
 	}
 
@@ -93,7 +93,7 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 			if (cordovaAppIdentifier) {
 				return {
 					packageId: cordovaAppIdentifier,
-					framework: this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova,
+					framework: TARGET_FRAMEWORK_IDENTIFIERS.Cordova,
 					title: this.getPageTitleFromWebView(adb, deviceIdentifier, cordovaAppIdentifier).wait()
 				};
 			}
@@ -106,7 +106,7 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 				let appIdentifier = nativeScriptAppIdentifierMatches[1];
 				return {
 					packageId: appIdentifier,
-					framework: this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript,
+					framework: TARGET_FRAMEWORK_IDENTIFIERS.NativeScript,
 					title: "NativeScript Application"
 				};
 			}


### PR DESCRIPTION
Move TARGET_FRAMEWORK_IDENTIFIERS from $projectConstants (available in AppBuilder CLI only) to constants.
This way we can use it in common lib and all CLIs directly.