### PR TITLE
Fix error when converting to boolean

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -105,8 +105,8 @@ export function isInteractive(): boolean {
 	return process.stdout.isTTY && process.stdin.isTTY;
 }
 
-export function toBoolean(str: string) {
-	return str && str.toLowerCase() === "true";
+export function toBoolean(str: any) {
+	return str && str.toString().toLowerCase() === "true";
 }
 
 export function block(operation: () => void): void {


### PR DESCRIPTION
If passed value is object or number, toBoolean helper method fails as they do not have .toLowerCase() method.