### PR TITLE
Fix LiveSync in AppBuilder and Proton

### DIFF
--- a/appbuilder/providers/appbuilder-livesync-provider-base.ts
+++ b/appbuilder/providers/appbuilder-livesync-provider-base.ts
@@ -26,7 +26,7 @@ export abstract class AppBuilderLiveSyncProviderBase implements ILiveSyncProvide
 	}
 
 	public transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, isFullSync: boolean): IFuture<void> {
-		return Future.fromResult();
+		return deviceAppData.device.fileSystem.transferFiles(deviceAppData, localToDevicePaths);
 	}
 
 }


### PR DESCRIPTION
Fix LiveSync in AppBuilder and Proton by calling correct method in livesyncProvider.