### PR TITLE
Execute batch sync when you live syncing application with the --watch option

### DIFF
--- a/appbuilder/services/livesync/livesync-service.ts
+++ b/appbuilder/services/livesync/livesync-service.ts
@@ -81,7 +81,7 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 					projectFilesPath: this.$project.projectDir,
 					syncWorkingDirectory: this.$project.projectDir,
 					excludedProjectDirsAndFiles: this.excludedProjectDirsAndFiles,
-					canExecuteFastSync: false
+					forceExecuteFullSync: true
 				};
 
 			let canExecuteAction = this.$liveSyncServiceBase.getCanExecuteAction(device.deviceInfo.platform, appIdentifier, canExecute);

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -525,7 +525,6 @@ interface ILiveSyncData {
 	projectFilesPath: string;
 	/** The path to a directory that is watched */
 	syncWorkingDirectory: string;
-	canExecuteFastSync?: boolean;
 	forceExecuteFullSync?: boolean;
 	excludedProjectDirsAndFiles?: string[];
 	/**
@@ -539,7 +538,7 @@ interface IPlatformLiveSyncService {
 	/**
 	 * Refreshes the application's content on a device
 	 */
-	refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], canExecuteFastSync?: boolean): IFuture<void>;
+	refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], forceExecuteFullSync: boolean): IFuture<void>;
 	/**
 	 * Removes specified files from a connected device
 	 */

--- a/services/livesync-service-base.ts
+++ b/services/livesync-service-base.ts
@@ -94,10 +94,8 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 								return;
 							}
 
-							data.canExecuteFastSync = data.forceExecuteFullSync ? false : that.$liveSyncProvider.canExecuteFastSync(filePath, data.platform);
-
 							if (event === "added" || event === "changed" || event === "renamed") {
-								that.syncAddedOrChangedFile(data, mappedFilePath).wait();
+								that.batchSync(data, mappedFilePath);
 							} else if (event === "deleted") {
 								that.fileHashes = <any>(_.omit(that.fileHashes, filePath));
 								that.syncRemovedFile(data, mappedFilePath).wait();
@@ -139,23 +137,6 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 		}
 
 		this.batch.addFile(filePath);
-	}
-
-	private fastSync(data: ILiveSyncData, filePath: string): IFuture<void> {
-		return (() => {
-			this.$liveSyncProvider.preparePlatformForSync(data.platform).wait();
-			this.syncCore(data, [filePath]).wait();
-		}).future<void>()();
-	}
-
-	private syncAddedOrChangedFile(data: ILiveSyncData, filePath: string): IFuture<void> {
-		return (() => {
-			if (data.canExecuteFastSync) {
-				this.fastSync(data, filePath).wait();
-			} else {
-				this.batchSync(data, filePath);
-			}
-		}).future<void>()();
 	}
 
 	private syncRemovedFile(data: ILiveSyncData, filePath: string): IFuture<void> {
@@ -221,7 +202,7 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 						}
 
 						this.$logger.info("Applying changes...");
-						platformLiveSyncService.refreshApplication(deviceAppData, localToDevicePaths, data.canExecuteFastSync).wait();
+						platformLiveSyncService.refreshApplication(deviceAppData, localToDevicePaths, data.forceExecuteFullSync).wait();
 						this.$logger.info(`Successfully synced application ${data.appIdentifier} on device ${device.deviceInfo.identifier}.`);
 					}
 				} else {


### PR DESCRIPTION
Remove the data.canExecuteFastSync. The check is made in the respective {N} service instead of in the base implementation