### PR TITLE
Fix AFC Connection errors when --device is specified

### DIFF
--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -247,7 +247,7 @@ export class DevicesService implements Mobile.IDevicesService {
 
 	private getDevice(deviceOption: string): IFuture<Mobile.IDevice> {
 		return (() => {
-			this.startLookingForDevices().wait();
+			this.detectCurrentlyAttachedDevices().wait();
 			let device: Mobile.IDevice = null;
 
 			if (this.hasDevice(deviceOption)) {


### PR DESCRIPTION
When `--device` is specified, CLI is trying to find all currently attached devices and check if the passed option is valid. This leads to starting of a setInterval, that is trying to detect when new device is attached.
The setInterval is executed on 2 seconds and it starts iOS related services and adb related services. It looks like this breaks the execution of AFC service.

Fix this by using a method that do not start the setInterval, but detects all currently detected devices.
This fix errors like:
`Error: Unable to close afc file connection: '4361027664'. Result is: '3'`
and
`Error: Unable to write to file: '4361027664'. Result is: '11'`
when `--device` is used.