### PR TITLE
Fixed: livesync recompiles the app always when first time livesync

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -547,7 +547,7 @@ interface IPlatformLiveSyncService {
 	 * Specifies some action that will be executed before every sync operation
 	 */
 	beforeLiveSyncAction?(deviceAppData: Mobile.IDeviceAppData): IFuture<void>;
-	afterInstallApplicationAction?(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<void>;
+	afterInstallApplicationAction?(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<boolean>;
 }
 
 interface ISysInfoData {


### PR DESCRIPTION
When the application is installed on device for the first time with the livesync command, it always recompiles the app e.g:

tns livesync ios --watch