### PR TITLE
Add events for debuggable apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,40 @@ require("mobile-cli-lib").deviceEmitter.on("applicationInstalled",  function(ide
 });
 ```
 
+* `debuggableAppFound` - Raised when application on a device becomes available for debugging. The callback has one argument - `applicationInfo`. <br/><br/>
+Sample usage:
+```JavaScript
+require("mobile-cli-lib").deviceEmitter.on("debuggableAppFound",  function(applicationInfo) {
+	console.log("Application " + applicationInfo.appIdentifier  + " is available for debugging on device with id: " + applicationInfo.deviceIdentifier);
+});
+```
+Sample result for `applicationInfo` will be:
+```JSON
+{
+	"deviceIdentifier": "4df18f307d8a8f1b",
+	"appIdentifier": "com.telerik.Fitness",
+	"framework": "NativeScript",
+	"title": "NativeScript Application"
+}
+```
+
+* `debuggableAppLost` - Raised when application on a device is not available for debugging anymore. The callback has one argument - `applicationInfo`. <br/><br/>
+Sample usage:
+```JavaScript
+require("mobile-cli-lib").deviceEmitter.on("debuggableAppLost",  function(applicationInfo) {
+	console.log("Application " + applicationInfo.appIdentifier  + " is not available for debugging anymore on device with id: " + applicationInfo.deviceIdentifier);
+});
+```
+Sample result for `applicationInfo` will be:
+```JSON
+{
+	"deviceIdentifier": "4df18f307d8a8f1b",
+	"appIdentifier": "com.telerik.Fitness",
+	"framework": "NativeScript",
+	"title": "NativeScript Application"
+}
+```
+
 * `applicationUninstalled` - Raised when application is removed from device. The callback has two arguments - `deviceIdentifier` and `applicationIdentifier`. <br/><br/>
 Sample usage:
 ```JavaScript
@@ -463,16 +497,21 @@ require("mobile-cli-lib").devicesService.mapAbstractToTcpPort("4df18f307d8a8f1b"
 	});
 ```
 
-* `getDebuggableApps(deviceIdentifier: string): Promise<IAndroidApplicationInformation[]>` - This function checks the proc/net/unix file of the device for web views connected to abstract ports and returns information about the applications.
+* `getDebuggableApps(deviceIdentifiers: string[]): Promise<IAndroidApplicationInformation[]>[]` - This function checks the proc/net/unix file of each device from the deviceIdentifiers argument for web views connected to abstract ports and returns information about the applications.
 ```JavaScript
 /**
  * Describes basic information about Android application.
  */
 interface IAndroidApplicationInformation {
 	/**
-	 * The package identifier of the application.
+	 * The device identifier.
 	 */
-	packageId: string;
+	deviceIdentifier: string;
+
+	/**
+	 * The application identifier.
+	 */
+	appIdentifier: string;
 
 	/**
 	 * The framework of the project (Cordova or NativeScript).
@@ -488,10 +527,10 @@ interface IAndroidApplicationInformation {
 
 Sample usage:
 ```JavaScript
-require("mobile-cli-lib").devicesService.getApplicationsAvailableForDebugging("4df18f307d8a8f1b")
-	.then(function(applicationsInfo) {
-		applicationsInfo.forEach(function(applicationInfo) {
-			console.log(applicationInfo);
+Promise.all(require("mobile-cli-lib").devicesService.getDebuggableApps(["4df18f307d8a8f1b", "JJY5KBTW75TCHQUK"]))
+	.then(function(data) {
+		data.forEach(function(apps) {
+			console.log(apps);
 		});
 	}, function(err) {
 		console.log(err);
@@ -499,15 +538,22 @@ require("mobile-cli-lib").devicesService.getApplicationsAvailableForDebugging("4
 ```
 Sample result will be:
 ```JSON
-[{
-	"packageId": "com.telerik.Fitness",
+[[{
+	"deviceIdentifier": "4df18f307d8a8f1b",
+	"appIdentifier": "com.telerik.Fitness",
 	"framework": "NativeScript",
 	"title": "NativeScript Application"
 }, {
-	"packageId": "com.telerik.livesynctest",
+	"deviceIdentifier": "4df18f307d8a8f1b",
+	"appIdentifier": "com.telerik.livesynctest",
 	"framework": "Cordova",
 	"title": "Home View"
-}]
+}], [{
+	"deviceIdentifier": "JJY5KBTW75TCHQUK",
+	"appIdentifier": "com.telerik.PhotoAlbum",
+	"framework": "NativeScript",
+	"title": "NativeScript Application"
+}]]
 ```
 
 ### Module liveSyncService

--- a/appbuilder/device-emitter.ts
+++ b/appbuilder/device-emitter.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events";
 
 class DeviceEmitter extends EventEmitter {
-	constructor(private $androidDeviceDiscovery:Mobile.IAndroidDeviceDiscovery,
+	constructor(private $androidDeviceDiscovery: Mobile.IAndroidDeviceDiscovery,
 		private $iOSDeviceDiscovery: Mobile.IDeviceDiscovery,
 		private $iOSSimulatorDiscovery: Mobile.IDeviceDiscovery,
 		private $devicesService: Mobile.IDevicesService,
@@ -14,7 +14,7 @@ class DeviceEmitter extends EventEmitter {
 
 	private _companionAppIdentifiers: IDictionary<IStringDictionary>;
 	private get companionAppIdentifiers(): IDictionary<IStringDictionary> {
-		if(!this._companionAppIdentifiers) {
+		if (!this._companionAppIdentifiers) {
 			this._companionAppIdentifiers = this.$companionAppsService.getAllCompanionAppIdentifiers();
 		}
 
@@ -54,7 +54,7 @@ class DeviceEmitter extends EventEmitter {
 				this.emit("deviceLost", device.deviceInfo);
 			});
 
-			this.$devicesService.initialize({skipInferPlatform: true}).wait();
+			this.$devicesService.initialize({ skipInferPlatform: true }).wait();
 
 			this.$deviceLogProvider.on("data", (identifier: string, data: any) => {
 				this.emit('deviceLogData', identifier, data.toString());
@@ -72,12 +72,20 @@ class DeviceEmitter extends EventEmitter {
 			this.emit("applicationUninstalled", device.deviceInfo.identifier, appIdentifier);
 			this.checkCompanionAppChanged(device, appIdentifier, "companionAppUninstalled");
 		});
+
+		device.applicationManager.on("debuggableAppFound", (appIdentifier: string) => {
+			this.emit("debuggableAppFound", appIdentifier);
+		});
+
+		device.applicationManager.on("debuggableAppLost", (appIdentifier: string) => {
+			this.emit("debuggableAppLost", appIdentifier);
+		});
 	}
 
 	private checkCompanionAppChanged(device: Mobile.IDevice, applicationName: string, eventName: string): void {
 		let devicePlatform = device.deviceInfo.platform.toLowerCase();
 		_.each(this.companionAppIdentifiers, (platformsCompanionAppIdentifiers: IStringDictionary, framework: string) => {
-			if(applicationName === platformsCompanionAppIdentifiers[devicePlatform]) {
+			if (applicationName === platformsCompanionAppIdentifiers[devicePlatform]) {
 				this.emit(eventName, device.deviceInfo.identifier, framework);
 				// break each
 				return false;

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -194,6 +194,7 @@ declare module Mobile {
 		checkForApplicationUpdates(): IFuture<void>;
 		isLiveSyncSupported(appIdentifier: string): IFuture<boolean>;
 		tryStartApplication(appIdentifier: string, framework?: string): IFuture<void>;
+		getDebuggableApps(): IFuture<Mobile.IAndroidApplicationInformation[]>;
 	}
 
 	interface IApplicationLiveSyncStatus {
@@ -642,9 +643,14 @@ declare module Mobile {
 	 */
 	interface IAndroidApplicationInformation {
 		/**
-		 * The package identifier of the application.
+		 * The device identifier.
 		 */
-		packageId: string;
+		deviceIdentifier: string;
+
+		/**
+		 * The application identifier.
+		 */
+		appIdentifier: string;
 
 		/**
 		 * The framework of the project (Cordova or NativeScript).

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -9,6 +9,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		private $staticConfig: Config.IStaticConfig,
 		private $options: ICommonOptions,
 		private $logcatHelper: Mobile.ILogcatHelper,
+		private $androidProcessService: Mobile.IAndroidProcessService,
 		$logger: ILogger) {
 		super($logger);
 	}
@@ -70,6 +71,10 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 			let liveSyncVersion = this.adb.sendBroadcastToDevice(LiveSyncConstants.CHECK_LIVESYNC_INTENT_NAME, { "app-id": appIdentifier }).wait();
 			return liveSyncVersion === LiveSyncConstants.VERSION_2 || liveSyncVersion === LiveSyncConstants.VERSION_3;
 		}).future<boolean>()();
+	}
+
+	public getDebuggableApps(): IFuture<Mobile.IAndroidApplicationInformation[]> {
+		return this.$androidProcessService.getDebuggableApps(this.identifier);
 	}
 
 	private getStartPackageActivity(framework?: string): string {

--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -10,8 +10,8 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		private $fs: IFileSystem,
 		private $bplistParser: IBinaryPlistParser,
 		$logger: ILogger) {
-			super($logger);
-		}
+		super($logger);
+	}
 
 	public getInstalledApplications(): IFuture<string[]> {
 		return Future.fromResult(this.iosSim.getInstalledApplications(this.identifier));
@@ -19,7 +19,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 
 	public installApplication(packageFilePath: string): IFuture<void> {
 		return (() => {
-			if(this.$fs.exists(packageFilePath).wait() && path.extname(packageFilePath) === ".zip") {
+			if (this.$fs.exists(packageFilePath).wait() && path.extname(packageFilePath) === ".zip") {
 				temp.track();
 				let dir = temp.mkdirSync("simulatorPackage");
 				this.$fs.unzip(packageFilePath, dir).wait();
@@ -59,12 +59,16 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		return ((): boolean => {
 			let applicationPath = this.iosSim.getApplicationPath(this.identifier, appIdentifier);
 			let pathToInfoPlist = path.join(applicationPath, "Info.plist");
-			if(this.$fs.exists(pathToInfoPlist).wait()) {
+			if (this.$fs.exists(pathToInfoPlist).wait()) {
 				let plistContent: any = this.$bplistParser.parseFile(pathToInfoPlist).wait()[0];
 				return !!plistContent && !!plistContent.IceniumLiveSyncEnabled;
 			}
 
 			return false;
 		}).future<boolean>()();
+	}
+
+	public getDebuggableApps(): IFuture<Mobile.IAndroidApplicationInformation[]> {
+		return Future.fromResult([]);
 	}
 }

--- a/mobile/mobile-core/android-process-service.ts
+++ b/mobile/mobile-core/android-process-service.ts
@@ -1,6 +1,6 @@
 import {EOL} from "os";
 import {DeviceAndroidDebugBridge} from "../android/device-android-debug-bridge";
-import { TARGET_FRAMEWORK_IDENTIFIERS } from "../constants";
+import {TARGET_FRAMEWORK_IDENTIFIERS} from "../constants";
 
 export class AndroidProcessService implements Mobile.IAndroidProcessService {
 	private _devicesAdbs: IDictionary<Mobile.IDeviceAndroidDebugBridge>;
@@ -92,7 +92,8 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 
 			if (cordovaAppIdentifier) {
 				return {
-					packageId: cordovaAppIdentifier,
+					deviceIdentifier: deviceIdentifier,
+					appIdentifier: cordovaAppIdentifier,
 					framework: TARGET_FRAMEWORK_IDENTIFIERS.Cordova,
 					title: this.getPageTitleFromWebView(adb, deviceIdentifier, cordovaAppIdentifier).wait()
 				};
@@ -105,7 +106,8 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 			if (nativeScriptAppIdentifierMatches && nativeScriptAppIdentifierMatches.length > 0) {
 				let appIdentifier = nativeScriptAppIdentifierMatches[1];
 				return {
-					packageId: appIdentifier,
+					deviceIdentifier: deviceIdentifier,
+					appIdentifier: appIdentifier,
 					framework: TARGET_FRAMEWORK_IDENTIFIERS.NativeScript,
 					title: "NativeScript Application"
 				};

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -411,8 +411,15 @@ export class DevicesService implements Mobile.IDevicesService {
 	}
 
 	@exportedPromise("devicesService")
-	public getDebuggableApps(deviceIdentifier: string): IFuture<Mobile.IAndroidApplicationInformation[]> {
-		return this.$androidProcessService.getDebuggableApps(deviceIdentifier);
+	public getDebuggableApps(deviceIdentifiers: string[]): IFuture<Mobile.IAndroidApplicationInformation[]>[] {
+		return _.map(deviceIdentifiers, (deviceIdentifier: string) => this.getDebuggableAppsCore(deviceIdentifier));
+	}
+
+	private getDebuggableAppsCore(deviceIdentifier: string): IFuture<Mobile.IAndroidApplicationInformation[]> {
+		return ((): Mobile.IAndroidApplicationInformation[] => {
+			let device = this.getDeviceByIdentifier(deviceIdentifier);
+			return device.applicationManager.getDebuggableApps().wait();
+		}).future<Mobile.IAndroidApplicationInformation[]>()();
 	}
 
 	private deployOnDevice(deviceIdentifier: string, packageFile: string, packageName: string, framework: string): IFuture<void> {


### PR DESCRIPTION
Add `debuggableAppFound` and `debuggableAppLost` events which are raised when an application becomes available for debugging or when an application is not available for debugging anymore.