### PR TITLE
Set version to 0.16.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,6 @@ coverage
 .tscache
 test-reports.xml
 *.tgz
+.vscode
+.npmignore
+

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.15.0
+Latest version: 0.16.0
 
-Release date: 2016, June 24
+Release date: 2016, June 29
 
 ### System Requirements
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.15.0",
+  "version": "0.16.0",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
Set version to 0.16.0
Ignore  .vscode dir and .npmignore file - we do not need them in the npm package.