### PR TITLE
Remove title property from debuggable apps info

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,12 +497,12 @@ require("mobile-cli-lib").devicesService.mapAbstractToTcpPort("4df18f307d8a8f1b"
 	});
 ```
 
-* `getDebuggableApps(deviceIdentifiers: string[]): Promise<IAndroidApplicationInformation[]>[]` - This function checks the proc/net/unix file of each device from the deviceIdentifiers argument for web views connected to abstract ports and returns information about the applications.
+* `getDebuggableApps(deviceIdentifiers: string[]): Promise<IDeviceApplicationInformation[]>[]` - This function checks the proc/net/unix file of each device from the deviceIdentifiers argument for web views connected to abstract ports and returns information about the applications.
 ```JavaScript
 /**
- * Describes basic information about Android application.
+ * Describes basic information about application on device.
  */
-interface IAndroidApplicationInformation {
+interface IDeviceApplicationInformation {
 	/**
 	 * The device identifier.
 	 */
@@ -517,11 +517,6 @@ interface IAndroidApplicationInformation {
 	 * The framework of the project (Cordova or NativeScript).
 	 */
 	framework: string;
-
-	/**
-	 * The title of the current html view which is loaded in the Android WebView. For NativeScript applications the title cannot be acquired.
-	 */
-	title?: string;
 }
 ```
 
@@ -541,18 +536,15 @@ Sample result will be:
 [[{
 	"deviceIdentifier": "4df18f307d8a8f1b",
 	"appIdentifier": "com.telerik.Fitness",
-	"framework": "NativeScript",
-	"title": "NativeScript Application"
+	"framework": "NativeScript"
 }, {
 	"deviceIdentifier": "4df18f307d8a8f1b",
 	"appIdentifier": "com.telerik.livesynctest",
-	"framework": "Cordova",
-	"title": "Home View"
+	"framework": "Cordova"
 }], [{
 	"deviceIdentifier": "JJY5KBTW75TCHQUK",
 	"appIdentifier": "com.telerik.PhotoAlbum",
-	"framework": "NativeScript",
-	"title": "NativeScript Application"
+	"framework": "NativeScript"
 }]]
 ```
 

--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -165,17 +165,7 @@ interface IDeviceLiveSyncInfo {
 /**
  * Describes if LiveSync is supported for specific device and application.
  */
-interface ILiveSyncSupportedInfo {
-	/**
-	 * Unique identifier of the device.
-	 */
-	deviceIdentifier: string;
-
-	/**
-	 * Application identifier.
-	 */
-	appIdentifier: string;
-
+interface ILiveSyncSupportedInfo extends Mobile.IDeviceApplicationInformationBase {
 	/**
 	 * Result, indicating is livesync supported for specified device and specified application.
 	 * `true` in case livesync is supported and false otherwise.

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -194,7 +194,7 @@ declare module Mobile {
 		checkForApplicationUpdates(): IFuture<void>;
 		isLiveSyncSupported(appIdentifier: string): IFuture<boolean>;
 		tryStartApplication(appIdentifier: string, framework?: string): IFuture<void>;
-		getDebuggableApps(): IFuture<Mobile.IAndroidApplicationInformation[]>;
+		getDebuggableApps(): IFuture<Mobile.IDeviceApplicationInformation[]>;
 	}
 
 	interface IApplicationLiveSyncStatus {
@@ -287,9 +287,9 @@ declare module Mobile {
 		/**
 		 * Gets the applications which are available for debugging on the specified device.
 		 * @param deviceIdentifier The identifier of the device.
-		 * @return {Mobile.IAndroidApplicationInformation[]} Returns array of applications information for the applications which are available for debugging.
+		 * @return {Mobile.IDeviceApplicationInformation[]} Returns array of applications information for the applications which are available for debugging.
 		 */
-		getDebuggableApps(deviceIdentifier: string): IFuture<Mobile.IAndroidApplicationInformation[]>;
+		getDebuggableApps(deviceIdentifier: string): IFuture<Mobile.IDeviceApplicationInformation[]>;
 	}
 
 	interface IiTunesValidator {
@@ -639,9 +639,9 @@ declare module Mobile {
 	}
 
 	/**
-	 * Describes basic information about Android application.
+	 * Describes basic information about application on device.
 	 */
-	interface IAndroidApplicationInformation {
+	interface IDeviceApplicationInformationBase {
 		/**
 		 * The device identifier.
 		 */
@@ -651,15 +651,15 @@ declare module Mobile {
 		 * The application identifier.
 		 */
 		appIdentifier: string;
+	}
 
+	/**
+	 * Describes information about application on device.
+	 */
+	interface IDeviceApplicationInformation extends IDeviceApplicationInformationBase {
 		/**
 		 * The framework of the project (Cordova or NativeScript).
 		 */
 		framework: string;
-
-		/**
-		 * The title of the current html view which is loaded in the Android WebView. For NativeScript applications the title cannot be acquired.
-		 */
-		title?: string;
 	}
 }

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -73,7 +73,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		}).future<boolean>()();
 	}
 
-	public getDebuggableApps(): IFuture<Mobile.IAndroidApplicationInformation[]> {
+	public getDebuggableApps(): IFuture<Mobile.IDeviceApplicationInformation[]> {
 		return this.$androidProcessService.getDebuggableApps(this.identifier);
 	}
 

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "events";
 
 export abstract class ApplicationManagerBase extends EventEmitter implements Mobile.IDeviceApplicationManager {
 	private lastInstalledAppIdentifiers: string[];
-	private lastAvailableDebuggableApps: Mobile.IAndroidApplicationInformation[];
+	private lastAvailableDebuggableApps: Mobile.IDeviceApplicationInformation[];
 
 	constructor(protected $logger: ILogger) {
 		super();
@@ -80,7 +80,7 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 	public abstract stopApplication(appIdentifier: string): IFuture<void>;
 	public abstract getInstalledApplications(): IFuture<string[]>;
 	public abstract canStartApplication(): boolean;
-	public abstract getDebuggableApps(): IFuture<Mobile.IAndroidApplicationInformation[]>;
+	public abstract getDebuggableApps(): IFuture<Mobile.IDeviceApplicationInformation[]>;
 
 	private checkForAvailableDebuggableAppsChanges(): IFuture<void> {
 		return (() => {
@@ -92,8 +92,8 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 
 			this.lastAvailableDebuggableApps = currentlyAvailableDebuggableApps;
 
-			_.each(newAvailableDebuggableApps, (appInfo: Mobile.IAndroidApplicationInformation) => this.emit("debuggableAppFound", appInfo));
-			_.each(notAvailableAppsForDebugging, (appInfo: Mobile.IAndroidApplicationInformation) => this.emit("debuggableAppLost", appInfo));
+			_.each(newAvailableDebuggableApps, (appInfo: Mobile.IDeviceApplicationInformation) => this.emit("debuggableAppFound", appInfo));
+			_.each(notAvailableAppsForDebugging, (appInfo: Mobile.IDeviceApplicationInformation) => this.emit("debuggableAppLost", appInfo));
 		}).future<void>()();
 	}
 }

--- a/mobile/ios/device/ios-application-manager.ts
+++ b/mobile/ios/device/ios-application-manager.ts
@@ -204,7 +204,7 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 		return this.$hostInfo.isDarwin || (this.$hostInfo.isWindows && this.$staticConfig.enableDeviceRunCommandOnWindows);
 	}
 
-	public getDebuggableApps(): IFuture<Mobile.IAndroidApplicationInformation[]> {
+	public getDebuggableApps(): IFuture<Mobile.IDeviceApplicationInformation[]> {
 		// Implement when we can find debuggable applications for iOS.
 		return Future.fromResult([]);
 	}

--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -68,7 +68,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		}).future<boolean>()();
 	}
 
-	public getDebuggableApps(): IFuture<Mobile.IAndroidApplicationInformation[]> {
+	public getDebuggableApps(): IFuture<Mobile.IDeviceApplicationInformation[]> {
 		return Future.fromResult([]);
 	}
 }

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -411,15 +411,15 @@ export class DevicesService implements Mobile.IDevicesService {
 	}
 
 	@exportedPromise("devicesService")
-	public getDebuggableApps(deviceIdentifiers: string[]): IFuture<Mobile.IAndroidApplicationInformation[]>[] {
+	public getDebuggableApps(deviceIdentifiers: string[]): IFuture<Mobile.IDeviceApplicationInformation[]>[] {
 		return _.map(deviceIdentifiers, (deviceIdentifier: string) => this.getDebuggableAppsCore(deviceIdentifier));
 	}
 
-	private getDebuggableAppsCore(deviceIdentifier: string): IFuture<Mobile.IAndroidApplicationInformation[]> {
-		return ((): Mobile.IAndroidApplicationInformation[] => {
+	private getDebuggableAppsCore(deviceIdentifier: string): IFuture<Mobile.IDeviceApplicationInformation[]> {
+		return ((): Mobile.IDeviceApplicationInformation[] => {
 			let device = this.getDeviceByIdentifier(deviceIdentifier);
 			return device.applicationManager.getDebuggableApps().wait();
-		}).future<Mobile.IAndroidApplicationInformation[]>()();
+		}).future<Mobile.IDeviceApplicationInformation[]>()();
 	}
 
 	private deployOnDevice(deviceIdentifier: string, packageFile: string, packageName: string, framework: string): IFuture<void> {


### PR DESCRIPTION
When information about debuggable apps is returned, the title property does not give any value. It's not real app title, as when the page is changed in WebView, it will be changed as well. So it is removed now.
Also rename the interface and extract new one, that can be used whenever device identifier and application identifier should be used.