### PR TITLE
Fix debuggableAppFound and debuggableAppLost events

### DIFF
--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -234,7 +234,7 @@ interface ICompanionAppsService {
 	/**
 	 * Returns all companion application identifiers in a dictionary where the top level keys are framwork identifiers.
 	 * For each framework there are three values, specified in a dictionary. The keys of the dictionary are platforms (android, ios and wp8).
-	 * @return {string} Companion appIdentifier or null.
+	 * @return {IDictionary<IStringDictionary>} Companion appIdentifiers separated in different properties of object.
 	 */
 	getAllCompanionAppIdentifiers(): IDictionary<IStringDictionary>;
 }

--- a/appbuilder/device-emitter.ts
+++ b/appbuilder/device-emitter.ts
@@ -73,12 +73,12 @@ class DeviceEmitter extends EventEmitter {
 			this.checkCompanionAppChanged(device, appIdentifier, "companionAppUninstalled");
 		});
 
-		device.applicationManager.on("debuggableAppFound", (appIdentifier: string) => {
-			this.emit("debuggableAppFound", appIdentifier);
+		device.applicationManager.on("debuggableAppFound", (debuggableAppInfo: Mobile.IDeviceApplicationInformation) => {
+			this.emit("debuggableAppFound", debuggableAppInfo);
 		});
 
-		device.applicationManager.on("debuggableAppLost", (appIdentifier: string) => {
-			this.emit("debuggableAppLost", appIdentifier);
+		device.applicationManager.on("debuggableAppLost", (debuggableAppInfo: Mobile.IDeviceApplicationInformation) => {
+			this.emit("debuggableAppLost", debuggableAppInfo);
 		});
 	}
 

--- a/appbuilder/device-emitter.ts
+++ b/appbuilder/device-emitter.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 
-class DeviceEmitter extends EventEmitter {
+export class DeviceEmitter extends EventEmitter {
 	constructor(private $androidDeviceDiscovery: Mobile.IAndroidDeviceDiscovery,
 		private $iOSDeviceDiscovery: Mobile.IDeviceDiscovery,
 		private $iOSSimulatorDiscovery: Mobile.IDeviceDiscovery,
@@ -8,7 +8,7 @@ class DeviceEmitter extends EventEmitter {
 		private $deviceLogProvider: EventEmitter,
 		private $companionAppsService: ICompanionAppsService,
 		private $projectConstants: Project.IConstants,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
+		private $logger: ILogger) {
 		super();
 	}
 
@@ -23,7 +23,12 @@ class DeviceEmitter extends EventEmitter {
 
 	public initialize(): IFuture<void> {
 		return (() => {
-			this.$androidDeviceDiscovery.ensureAdbServerStarted().wait();
+			try {
+				this.$androidDeviceDiscovery.ensureAdbServerStarted().wait();
+			} catch(err) {
+				this.$logger.warn(`Unable to start adb server. Error message is: ${err.message}`);
+			}
+
 			this.$androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
 				this.emit("deviceFound", device.deviceInfo);
 				this.attachApplicationChangedHandlers(device);

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -88,8 +88,8 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 			let currentlyAvailableDebuggableApps = this.getDebuggableApps().wait();
 			let previouslyAvailableDebuggableApps = this.lastAvailableDebuggableApps || [];
 
-			let newAvailableDebuggableApps = _.differenceBy(currentlyAvailableDebuggableApps, previouslyAvailableDebuggableApps, "packageId");
-			let notAvailableAppsForDebugging = _.differenceBy(previouslyAvailableDebuggableApps, currentlyAvailableDebuggableApps, "packageId");
+			let newAvailableDebuggableApps = _.differenceBy(currentlyAvailableDebuggableApps, previouslyAvailableDebuggableApps, "appIdentifier");
+			let notAvailableAppsForDebugging = _.differenceBy(previouslyAvailableDebuggableApps, currentlyAvailableDebuggableApps, "appIdentifier");
 
 			this.lastAvailableDebuggableApps = currentlyAvailableDebuggableApps;
 

--- a/test/unit-tests/appbuilder/device-emitter.ts
+++ b/test/unit-tests/appbuilder/device-emitter.ts
@@ -1,0 +1,350 @@
+import {Yok} from "../../../yok";
+import {assert} from "chai";
+import { CommonLoggerStub } from "../stubs";
+import Future = require("fibers/future");
+import { EventEmitter } from "events";
+import { ProjectConstants } from "../../../appbuilder/project-constants";
+import { DeviceEmitter } from "../../../appbuilder/device-emitter";
+
+class AndroidDeviceDiscoveryMock extends EventEmitter {
+	public ensureAdbServerStarted(): IFuture<void> {
+		return Future.fromResult();
+	}
+}
+
+let companionAppIdentifiers = {
+	"cordova": {
+		"android": "cordova-android",
+		"ios": "cordova-ios",
+		"wp8": "cordova-wp8"
+	},
+
+	"nativescript": {
+		"android": "nativescript-android",
+		"ios": "nativescript-ios"
+	}
+};
+
+function createTestInjector(): IInjector {
+	let testInjector = new Yok();
+	testInjector.register("androidDeviceDiscovery", AndroidDeviceDiscoveryMock);
+	testInjector.register("iOSDeviceDiscovery", EventEmitter);
+	testInjector.register("iOSSimulatorDiscovery", EventEmitter);
+	testInjector.register("devicesService", {
+		initialize: (opts: { skipInferPlatform: boolean }) => Future.fromResult()
+	});
+	testInjector.register("deviceLogProvider", EventEmitter);
+	testInjector.register("companionAppsService", {
+		getAllCompanionAppIdentifiers: () => companionAppIdentifiers
+	});
+
+	testInjector.register("projectConstants", ProjectConstants);
+	testInjector.register("logger", CommonLoggerStub);
+
+	testInjector.register("deviceEmitter", DeviceEmitter);
+
+	return testInjector;
+}
+
+describe("deviceEmitter", () => {
+	let testInjector: IInjector,
+		deviceEmitter: any,
+		isOpenDeviceLogStreamCalled = false;
+
+	beforeEach(() => {
+		testInjector = createTestInjector();
+		deviceEmitter = testInjector.resolve("deviceEmitter");
+		isOpenDeviceLogStreamCalled = false;
+	});
+
+	describe("initialize", () => {
+		it("does not throw when ensureAdbServerStarted throws", () => {
+			let androidDeviceDiscovery = testInjector.resolve("androidDeviceDiscovery"),
+				logger: CommonLoggerStub = testInjector.resolve("logger");
+
+			androidDeviceDiscovery.ensureAdbServerStarted = () => {
+				return (() => {
+					throw new Error("error1");
+				}).future<void>()();
+			};
+
+			let warnOutput = "";
+			logger.warn = (warnMsg: string) => { warnOutput += warnMsg; };
+
+			deviceEmitter.initialize().wait();
+			assert.isTrue(warnOutput.indexOf("Unable to start adb server") !== -1, "When ensureAdbServerStarted throws, the string 'Unable to start adb server' must be shown as warning.");
+			assert.isTrue(warnOutput.indexOf("error1") !== -1, "When ensureAdbServerStarted throws, the error message must be shown as warning.");
+		});
+	});
+
+	describe("raises correct events after initialize is called:", () => {
+		let androidDeviceDiscovery: EventEmitter,
+			iOSDeviceDiscovery: EventEmitter,
+			iOSSimulatorDiscovery: EventEmitter,
+			androidDevice: any,
+			iOSDevice: any,
+			iOSSimulator: any;
+
+		beforeEach(() => {
+			deviceEmitter.initialize().wait();
+			androidDeviceDiscovery = testInjector.resolve("androidDeviceDiscovery");
+			iOSDeviceDiscovery = testInjector.resolve("iOSDeviceDiscovery");
+			iOSSimulatorDiscovery = testInjector.resolve("iOSSimulatorDiscovery");
+
+			androidDevice = {
+				deviceInfo: {
+					"identifier": "androidDeviceId",
+					"platform": "android"
+				},
+				applicationManager: new EventEmitter(),
+				openDeviceLogStream: () => isOpenDeviceLogStreamCalled = true
+			};
+
+			iOSDevice = {
+				deviceInfo: {
+					"identifier": "iOSDeviceId",
+					"platform": "iOS"
+				},
+				applicationManager: new EventEmitter(),
+				openDeviceLogStream: () => isOpenDeviceLogStreamCalled = true
+			};
+			iOSSimulator = {
+				deviceInfo: {
+					"identifier": "iOSSimulatorDeviceId",
+					"platform": "iOS"
+				},
+				applicationManager: new EventEmitter(),
+				openDeviceLogStream: () => isOpenDeviceLogStreamCalled = true
+			};
+		});
+
+		_.each(["deviceFound", "deviceLost"], (deviceEvent: string) => {
+			describe(deviceEvent, () => {
+				let attachDeviceEventVerificationHandler = (expectedDeviceInfo: any, done: mocha.Done) => {
+					deviceEmitter.on(deviceEvent, (deviceInfo: Mobile.IDeviceInfo) => {
+						assert.deepEqual(deviceInfo, expectedDeviceInfo);
+						// Wait for all operations to be completed and call done after that.
+						setTimeout(() => done(), 0);
+					});
+				};
+
+				it("is raised when working with android device", (done) => {
+					attachDeviceEventVerificationHandler(androidDevice.deviceInfo, done);
+					androidDeviceDiscovery.emit(deviceEvent, androidDevice);
+				});
+
+				it("is raised when working with iOS device", (done) => {
+					attachDeviceEventVerificationHandler(iOSDevice.deviceInfo, done);
+					iOSDeviceDiscovery.emit(deviceEvent, iOSDevice);
+				});
+
+				it("is raised when working with iOS simulator", (done) => {
+					attachDeviceEventVerificationHandler(iOSSimulator.deviceInfo, done);
+					iOSSimulatorDiscovery.emit(deviceEvent, iOSSimulator);
+				});
+
+			});
+		});
+
+		describe("openDeviceLogStream", () => {
+			let attachDeviceEventVerificationHandler = (expectedDeviceInfo: any, done: mocha.Done) => {
+				deviceEmitter.on("deviceFound", (deviceInfo: Mobile.IDeviceInfo) => {
+					assert.deepEqual(deviceInfo, expectedDeviceInfo);
+
+					// Wait for all operations to be completed and call done after that.
+					setTimeout(() => {
+						assert.isTrue(isOpenDeviceLogStreamCalled, "When device is found, openDeviceLogStream must be called immediately.");
+						done();
+					}, 0);
+				});
+			};
+
+			it("is called when working with android device", (done) => {
+				attachDeviceEventVerificationHandler(androidDevice.deviceInfo, done);
+				androidDeviceDiscovery.emit("deviceFound", androidDevice);
+			});
+
+			it("is called when working with iOS device", (done) => {
+				attachDeviceEventVerificationHandler(iOSDevice.deviceInfo, done);
+				iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
+			});
+
+			it("is called when working with iOS simulator", (done) => {
+				attachDeviceEventVerificationHandler(iOSSimulator.deviceInfo, done);
+				iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
+			});
+
+		});
+
+		describe("deviceLogProvider on data", () => {
+			let deviceLogProvider: EventEmitter;
+
+			beforeEach(() => {
+				deviceLogProvider = testInjector.resolve("deviceLogProvider");
+			});
+
+			describe("raises deviceLogData with correct identifier and data", () => {
+				let expectedDeviceLogData = "This is some log data from device.";
+
+				let attachDeviceLogDataVerificationHandler = (expectedDeviceIdentifier: string, done: mocha.Done) => {
+					deviceEmitter.on("deviceLogData", (identifier: string, data: any) => {
+						assert.deepEqual(identifier, expectedDeviceIdentifier);
+						assert.deepEqual(data, expectedDeviceLogData);
+						// Wait for all operations to be completed and call done after that.
+						setTimeout(() => done(), 0);
+					});
+				};
+
+				it("is called when android device reports data", (done) => {
+					attachDeviceLogDataVerificationHandler(androidDevice.deviceInfo.identifier, done);
+					androidDeviceDiscovery.emit("deviceFound", androidDevice);
+					deviceLogProvider.emit("data", androidDevice.deviceInfo.identifier, expectedDeviceLogData);
+				});
+
+				it("is called when iOS device reports data", (done) => {
+					attachDeviceLogDataVerificationHandler(iOSDevice.deviceInfo.identifier, done);
+					iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
+					deviceLogProvider.emit("data", iOSDevice.deviceInfo.identifier, expectedDeviceLogData);
+				});
+
+				it("is called when iOS simulator reports data", (done) => {
+					attachDeviceLogDataVerificationHandler(iOSSimulator.deviceInfo.identifier, done);
+					iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
+					deviceLogProvider.emit("data", iOSSimulator.deviceInfo.identifier, expectedDeviceLogData);
+				});
+
+			});
+		});
+
+		_.each(["applicationInstalled", "applicationUninstalled"], (applicationEvent: string) => {
+			describe(applicationEvent, () => {
+				let expectedApplicationIdentifier = "application identifier";
+
+				let attachApplicationEventVerificationHandler = (expectedDeviceIdentifier: string, done: mocha.Done) => {
+					deviceEmitter.on(applicationEvent, (deviceIdentifier: string, appIdentifier: string) => {
+						assert.deepEqual(deviceIdentifier, expectedDeviceIdentifier);
+						assert.deepEqual(appIdentifier, expectedApplicationIdentifier);
+
+						// Wait for all operations to be completed and call done after that.
+						setTimeout(() => done(), 0);
+					});
+				};
+
+				it("is raised when working with android device", (done) => {
+					attachApplicationEventVerificationHandler(androidDevice.deviceInfo.identifier, done);
+					androidDeviceDiscovery.emit("deviceFound", androidDevice);
+					androidDevice.applicationManager.emit(applicationEvent, expectedApplicationIdentifier);
+				});
+
+				it("is raised when working with iOS device", (done) => {
+					attachApplicationEventVerificationHandler(iOSDevice.deviceInfo.identifier, done);
+					iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
+					iOSDevice.applicationManager.emit(applicationEvent, expectedApplicationIdentifier);
+				});
+
+				it("is raised when working with iOS simulator", (done) => {
+					attachApplicationEventVerificationHandler(iOSSimulator.deviceInfo.identifier, done);
+					iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
+					iOSSimulator.applicationManager.emit(applicationEvent, expectedApplicationIdentifier);
+				});
+			});
+		});
+
+		_.each(["debuggableAppFound", "debuggableAppLost"], (applicationEvent: string) => {
+			describe(applicationEvent, () => {
+				// deviceIdentifier, appIdentifier, framework
+
+				let attachDebuggableEventVerificationHandler = (expectedDebuggableAppInfo: Mobile.IDeviceApplicationInformation, done: mocha.Done) => {
+					deviceEmitter.on(applicationEvent, (debuggableAppInfo: Mobile.IDeviceApplicationInformation) => {
+						assert.deepEqual(debuggableAppInfo, expectedDebuggableAppInfo);
+
+						// Wait for all operations to be completed and call done after that.
+						setTimeout(() => done(), 0);
+					});
+				};
+
+				it("is raised when working with android device", (done) => {
+					let debuggableAppInfo: Mobile.IDeviceApplicationInformation = {
+						appIdentifier: "app identifier",
+						deviceIdentifier: androidDevice.deviceInfo.identifier,
+						framework: "cordova"
+					};
+
+					attachDebuggableEventVerificationHandler(debuggableAppInfo, done);
+					androidDeviceDiscovery.emit("deviceFound", androidDevice);
+					androidDevice.applicationManager.emit(applicationEvent, debuggableAppInfo);
+				});
+
+				it("is raised when working with iOS device", (done) => {
+					let debuggableAppInfo: Mobile.IDeviceApplicationInformation = {
+						appIdentifier: "app identifier",
+						deviceIdentifier: iOSDevice.deviceInfo.identifier,
+						framework: "cordova"
+					};
+
+					attachDebuggableEventVerificationHandler(debuggableAppInfo, done);
+					iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
+					iOSDevice.applicationManager.emit(applicationEvent, debuggableAppInfo);
+				});
+
+				it("is raised when working with iOS simulator", (done) => {
+					let debuggableAppInfo: Mobile.IDeviceApplicationInformation = {
+						appIdentifier: "app identifier",
+						deviceIdentifier: iOSSimulator.deviceInfo.identifier,
+						framework: "cordova"
+					};
+
+					attachDebuggableEventVerificationHandler(debuggableAppInfo, done);
+					iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
+					iOSSimulator.applicationManager.emit(applicationEvent, debuggableAppInfo);
+				});
+			});
+		});
+
+		_.each(["companionAppInstalled", "companionAppUninstalled"], (applicationEvent: string) => {
+			describe(applicationEvent, () => {
+				_.each(companionAppIdentifiers, (companionAppIdentifersForPlatform: any, applicationFramework: string) => {
+					describe(`is raised for ${applicationFramework}`, () => {
+						let attachCompanionEventVerificationHandler = (expectedDeviceIdentifier: string, done: mocha.Done) => {
+							deviceEmitter.on(applicationEvent, (deviceIdentifier: string, framework: string) => {
+								assert.deepEqual(deviceIdentifier, expectedDeviceIdentifier);
+								assert.deepEqual(framework, applicationFramework);
+
+								// Wait for all operations to be completed and call done after that.
+								setTimeout(() => done(), 0);
+							});
+						};
+
+						it("when working with android device", (done) => {
+							attachCompanionEventVerificationHandler(androidDevice.deviceInfo.identifier, done);
+							androidDeviceDiscovery.emit("deviceFound", androidDevice);
+							androidDevice.applicationManager.emit("applicationInstalled", companionAppIdentifersForPlatform["android"]);
+							if (applicationEvent === "companionAppUninstalled") {
+								androidDevice.applicationManager.emit("applicationUninstalled", companionAppIdentifersForPlatform["android"]);
+							}
+						});
+
+						it("when working with iOS device", (done) => {
+							attachCompanionEventVerificationHandler(iOSDevice.deviceInfo.identifier, done);
+							iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
+							iOSDevice.applicationManager.emit("applicationInstalled", companionAppIdentifersForPlatform["ios"]);
+							if (applicationEvent === "companionAppUninstalled") {
+								iOSDevice.applicationManager.emit("applicationUninstalled", companionAppIdentifersForPlatform["ios"]);
+							}
+						});
+
+						it("when working with iOS simulator", (done) => {
+							attachCompanionEventVerificationHandler(iOSSimulator.deviceInfo.identifier, done);
+							iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
+							iOSSimulator.applicationManager.emit("applicationInstalled", companionAppIdentifersForPlatform["ios"]);
+							if (applicationEvent === "companionAppUninstalled") {
+								iOSSimulator.applicationManager.emit("applicationUninstalled", companionAppIdentifersForPlatform["ios"]);
+							}
+						});
+					});
+				});
+			});
+		});
+
+	});
+});

--- a/test/unit-tests/mobile/application-manager-base.ts
+++ b/test/unit-tests/mobile/application-manager-base.ts
@@ -1,0 +1,610 @@
+import {Yok} from "../../../yok";
+import {assert} from "chai";
+import { CommonLoggerStub } from "../stubs";
+import { ApplicationManagerBase } from "../../../mobile/application-manager-base";
+import Future = require("fibers/future");
+
+let currentlyAvailableAppsForDebugging: Mobile.IDeviceApplicationInformation[],
+	currentlyInstalledApps: string[];
+
+class ApplicationManager extends ApplicationManagerBase {
+	constructor($logger: ILogger) {
+		super($logger);
+	}
+
+	public isLiveSyncSupported(appIdentifier: string): IFuture<boolean> {
+		return Future.fromResult(true);
+	}
+
+	public installApplication(packageFilePath: string): IFuture<void> {
+		return Future.fromResult();
+	}
+
+	public uninstallApplication(appIdentifier: string): IFuture<void> {
+		return Future.fromResult();
+	}
+
+	public startApplication(appIdentifier: string, framework?: string): IFuture<void> {
+		return Future.fromResult();
+	}
+
+	public stopApplication(appIdentifier: string): IFuture<void> {
+		return Future.fromResult();
+	}
+
+	public getInstalledApplications(): IFuture<string[]> {
+		return Future.fromResult(_.cloneDeep(currentlyInstalledApps));
+	}
+
+	public getApplicationInfo(applicationIdentifier: string): IFuture<Mobile.IApplicationInfo> {
+		return Future.fromResult(null);
+	}
+
+	public canStartApplication(): boolean {
+		return true;
+	}
+
+	public getDebuggableApps(): IFuture<Mobile.IDeviceApplicationInformation[]> {
+		return Future.fromResult(currentlyAvailableAppsForDebugging);
+	}
+}
+
+function createTestInjector(): IInjector {
+	let testInjector = new Yok();
+	testInjector.register("logger", CommonLoggerStub);
+	testInjector.register("applicationManager", ApplicationManager);
+	return testInjector;
+}
+
+function createAppsAvailableForDebugging(count: number): Mobile.IDeviceApplicationInformation[] {
+	return _.times(count, (index: number) => ({
+		deviceIdentifier: "deviceId",
+		appIdentifier: `appId_${index}`,
+		framework: "framework"
+	}));
+}
+
+describe("ApplicationManagerBase", () => {
+	let applicationManager: ApplicationManager,
+		testInjector: IInjector;
+
+	beforeEach(() => {
+		testInjector = createTestInjector();
+		currentlyAvailableAppsForDebugging = null;
+		applicationManager = testInjector.resolve("applicationManager");
+	});
+
+	describe("checkForApplicationUpdates", () => {
+		describe("debuggableApps", () => {
+			it("emits debuggableAppFound when new application is available for debugging", (done) => {
+				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
+				let foundAppsForDebug: Mobile.IDeviceApplicationInformation[] = [];
+
+				applicationManager.on("debuggableAppFound", (d: Mobile.IDeviceApplicationInformation) => {
+					foundAppsForDebug.push(d);
+					if (foundAppsForDebug.length === currentlyAvailableAppsForDebugging.length) {
+						_.each(foundAppsForDebug, (f: Mobile.IDeviceApplicationInformation, index: number) => {
+							assert.deepEqual(f, currentlyAvailableAppsForDebugging[index]);
+						});
+						done();
+					}
+				});
+
+				applicationManager.checkForApplicationUpdates().wait();
+			});
+
+			it("emits debuggableAppFound when new application is available for debugging (several calls)", (done) => {
+				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(1);
+				let foundAppsForDebug: Mobile.IDeviceApplicationInformation[] = [],
+					isFinalCheck = false;
+
+				applicationManager.on("debuggableAppFound", (d: Mobile.IDeviceApplicationInformation) => {
+					foundAppsForDebug.push(d);
+					if (foundAppsForDebug.length === currentlyAvailableAppsForDebugging.length) {
+						_.each(foundAppsForDebug, (f: Mobile.IDeviceApplicationInformation, index: number) => {
+							assert.deepEqual(f, currentlyAvailableAppsForDebugging[index]);
+						});
+
+						if (isFinalCheck) {
+							done();
+						}
+					}
+				});
+
+				applicationManager.checkForApplicationUpdates().wait();
+				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
+				applicationManager.checkForApplicationUpdates().wait();
+				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(4);
+				isFinalCheck = true;
+				applicationManager.checkForApplicationUpdates().wait();
+			});
+
+			it("emits debuggableAppLost when application cannot be debugged anymore", (done) => {
+				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
+				let expectedAppsToBeLost = currentlyAvailableAppsForDebugging,
+					lostAppsForDebug: Mobile.IDeviceApplicationInformation[] = [];
+
+				applicationManager.on("debuggableAppLost", (d: Mobile.IDeviceApplicationInformation) => {
+					lostAppsForDebug.push(d);
+
+					if (lostAppsForDebug.length === expectedAppsToBeLost.length) {
+						_.each(lostAppsForDebug, (f: Mobile.IDeviceApplicationInformation, index: number) => {
+							assert.deepEqual(f, expectedAppsToBeLost[index]);
+						});
+
+						done();
+					}
+				});
+
+				// First call will raise debuggableAppFound two times.
+				applicationManager.checkForApplicationUpdates().wait();
+				currentlyAvailableAppsForDebugging = [];
+				// This call should raise debuggableAppLost two times.
+				applicationManager.checkForApplicationUpdates().wait();
+			});
+
+			it("emits debuggableAppLost when application cannot be debugged anymore (several calls)", (done) => {
+				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(4);
+				let lostAppsForDebug: Mobile.IDeviceApplicationInformation[] = [],
+					isFinalCheck = false,
+					initialAppsAvailableForDebug = currentlyAvailableAppsForDebugging;
+
+				applicationManager.on("debuggableAppLost", (d: Mobile.IDeviceApplicationInformation) => {
+					lostAppsForDebug.push(d);
+					_.each(lostAppsForDebug, (f: Mobile.IDeviceApplicationInformation, index: number) => {
+						assert.deepEqual(f, _.find(initialAppsAvailableForDebug, t => t.appIdentifier === f.appIdentifier));
+					});
+
+					if (lostAppsForDebug.length === initialAppsAvailableForDebug.length && isFinalCheck) {
+						done();
+					}
+				});
+
+				applicationManager.checkForApplicationUpdates().wait();
+				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
+				applicationManager.checkForApplicationUpdates().wait();
+				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(0);
+				isFinalCheck = true;
+				applicationManager.checkForApplicationUpdates().wait();
+			});
+
+			it("emits debuggableAppFound and debuggableAppLost when applications are changed", () => {
+				let allAppsForDebug = createAppsAvailableForDebugging(4);
+				currentlyAvailableAppsForDebugging = _.take(allAppsForDebug, 2);
+				let remainingAppsForDebugging = _.difference(allAppsForDebug, currentlyAvailableAppsForDebugging);
+
+				let foundAppsForDebug: Mobile.IDeviceApplicationInformation[] = [],
+					futures: IFuture<void>[] = [];
+
+				// This will raise debuggableAppFound 2 times.
+				applicationManager.checkForApplicationUpdates().wait();
+
+				let foundAppsFuture = new Future<void>();
+				futures.push(foundAppsFuture);
+
+				applicationManager.on("debuggableAppFound", (d: Mobile.IDeviceApplicationInformation) => {
+					foundAppsForDebug.push(d);
+					if (foundAppsForDebug.length === remainingAppsForDebugging.length) {
+						_.each(foundAppsForDebug, (f: Mobile.IDeviceApplicationInformation, index: number) => {
+							assert.deepEqual(f, remainingAppsForDebugging[index]);
+						});
+
+						foundAppsFuture.return();
+					}
+				});
+
+				let lostAppsFuture = new Future<void>();
+				futures.push(lostAppsFuture);
+
+				applicationManager.on("debuggableAppLost", (d: Mobile.IDeviceApplicationInformation) => {
+					assert.deepEqual(d, allAppsForDebug[0], "Debuggable app lost does not match.");
+					lostAppsFuture.return();
+				});
+
+				currentlyAvailableAppsForDebugging = _.drop(allAppsForDebug, 1);
+				applicationManager.checkForApplicationUpdates().wait();
+				Future.wait(futures);
+			});
+		});
+
+		describe("installed and uninstalled apps", () => {
+			it("reports installed applications when initially there are apps", () => {
+				currentlyInstalledApps = ["app1", "app2", "app3"];
+
+				let reportedInstalledApps: string[] = [],
+					future = new Future<void>();
+
+				applicationManager.on("applicationInstalled", (app: string) => {
+					reportedInstalledApps.push(app);
+					if (reportedInstalledApps.length === currentlyInstalledApps.length) {
+						future.return();
+					}
+				});
+
+				applicationManager.checkForApplicationUpdates().wait();
+				future.wait();
+
+				_.each(currentlyInstalledApps, (c: string, index: number) => {
+					assert.deepEqual(c, reportedInstalledApps[index]);
+				});
+
+				assert.deepEqual(reportedInstalledApps.length, currentlyInstalledApps.length);
+			});
+
+			it("reports installed applications when apps are changed between executions", () => {
+				currentlyInstalledApps = ["app1", "app2", "app3"];
+
+				let reportedInstalledApps: string[] = [],
+					future: IFuture<void>;
+
+				applicationManager.on("applicationInstalled", (app: string) => {
+					reportedInstalledApps.push(app);
+					if (reportedInstalledApps.length === currentlyInstalledApps.length) {
+						future.return();
+					}
+				});
+
+				let testInstalledAppsResults = () => {
+					future = new Future<void>();
+					applicationManager.checkForApplicationUpdates().wait();
+					future.wait();
+
+					_.each(currentlyInstalledApps, (c: string, index: number) => {
+						assert.deepEqual(c, reportedInstalledApps[index]);
+					});
+
+					assert.deepEqual(reportedInstalledApps.length, currentlyInstalledApps.length);
+				};
+				testInstalledAppsResults();
+
+				currentlyInstalledApps.push("app4", "app5");
+				testInstalledAppsResults();
+
+				currentlyInstalledApps.push("app6", "app7");
+				testInstalledAppsResults();
+			});
+
+			it("reports uninstalled applications when initially there are apps and all are uninstalled", () => {
+				currentlyInstalledApps = ["app1", "app2", "app3"];
+
+				let reportedUninstalledApps: string[] = [],
+					initiallyInstalledApps = _.cloneDeep(currentlyInstalledApps),
+					future = new Future<void>();
+				applicationManager.checkForApplicationUpdates().wait();
+				currentlyInstalledApps = [];
+
+				applicationManager.on("applicationUninstalled", (app: string) => {
+					reportedUninstalledApps.push(app);
+					if (reportedUninstalledApps.length === initiallyInstalledApps.length) {
+						future.return();
+					}
+				});
+
+				applicationManager.checkForApplicationUpdates().wait();
+				future.wait();
+
+				_.each(initiallyInstalledApps, (c: string, index: number) => {
+					assert.deepEqual(c, reportedUninstalledApps[index]);
+				});
+
+				assert.deepEqual(reportedUninstalledApps.length, initiallyInstalledApps.length);
+			});
+
+			it("reports uninstalled applications when apps are changed between executions", () => {
+				currentlyInstalledApps = ["app1", "app2", "app3", "app4", "app5", "app6"];
+
+				let reportedUninstalledApps: string[] = [],
+					removedApps: string[] = [],
+					future: IFuture<void>;
+
+				// Initialize - all apps are marked as installed.
+				applicationManager.checkForApplicationUpdates().wait();
+				applicationManager.on("applicationUninstalled", (app: string) => {
+					reportedUninstalledApps.push(app);
+					if (reportedUninstalledApps.length === removedApps.length) {
+						future.return();
+					}
+				});
+
+				let testInstalledAppsResults = () => {
+					future = new Future<void>();
+					applicationManager.checkForApplicationUpdates().wait();
+					future.wait();
+
+					_.each(removedApps, (c: string, index: number) => {
+						assert.deepEqual(c, reportedUninstalledApps[index]);
+					});
+
+					assert.deepEqual(reportedUninstalledApps.length, removedApps.length);
+				};
+
+				while (currentlyInstalledApps.length) {
+					let currentlyRemovedApps = currentlyInstalledApps.splice(0, 2);
+					removedApps.push(...currentlyRemovedApps);
+					testInstalledAppsResults();
+				}
+			});
+
+			it("reports installed and uninstalled apps when apps are changed between executions", () => {
+				currentlyInstalledApps = ["app1", "app2", "app3", "app4", "app5", "app6"];
+
+				let reportedUninstalledApps: string[] = [],
+					reportedInstalledApps: string[] = [],
+					installedApps: string[] = [],
+					removedApps: string[] = [],
+					appUninstalledFuture: IFuture<void>,
+					appInstalledFuture: IFuture<void>,
+					waitForAppInstalledFuture = true;
+
+				// Initialize - all apps are marked as installed.
+				applicationManager.checkForApplicationUpdates().wait();
+				applicationManager.on("applicationUninstalled", (app: string) => {
+					reportedUninstalledApps.push(app);
+					if (reportedUninstalledApps.length === removedApps.length) {
+						appUninstalledFuture.return();
+					}
+				});
+
+				applicationManager.on("applicationInstalled", (app: string) => {
+					reportedInstalledApps.push(app);
+					if (reportedInstalledApps.length === installedApps.length) {
+						appInstalledFuture.return();
+					}
+				});
+
+				let testInstalledAppsResults = () => {
+					appInstalledFuture = new Future<void>();
+					appUninstalledFuture = new Future<void>();
+					applicationManager.checkForApplicationUpdates().wait();
+
+					if (!waitForAppInstalledFuture) {
+						appInstalledFuture.return();
+					}
+
+					Future.wait([appInstalledFuture, appUninstalledFuture]);
+
+					_.each(removedApps, (c: string, index: number) => {
+						assert.deepEqual(c, reportedUninstalledApps[index]);
+					});
+
+					assert.deepEqual(reportedUninstalledApps.length, removedApps.length);
+
+					_.each(installedApps, (c: string, index: number) => {
+						assert.deepEqual(c, reportedInstalledApps[index]);
+					});
+
+					assert.deepEqual(reportedInstalledApps.length, installedApps.length);
+				};
+
+				for (let index = 10; index < 13; index++) {
+					let currentlyRemovedApps = currentlyInstalledApps.splice(0, 2);
+					removedApps.push(...currentlyRemovedApps);
+
+					let currentlyAddedApps = [`app${index}`];
+					currentlyInstalledApps.push(...currentlyAddedApps);
+					installedApps.push(...currentlyAddedApps);
+
+					testInstalledAppsResults();
+				}
+			});
+		});
+	});
+
+	describe("isApplicationInstalled", () => {
+		it("returns true when app is installed", () => {
+			currentlyInstalledApps = ["app1", "app2"];
+			assert.isTrue(applicationManager.isApplicationInstalled("app1").wait(), "app1 is installed, so result of isAppInstalled must be true.");
+			assert.isTrue(applicationManager.isApplicationInstalled("app2").wait(), "app2 is installed, so result of isAppInstalled must be true.");
+		});
+
+		it("returns false when app is NOT installed", () => {
+			currentlyInstalledApps = ["app1", "app2"];
+			assert.isFalse(applicationManager.isApplicationInstalled("app3").wait(), "app3 is NOT installed, so result of isAppInstalled must be false.");
+			assert.isFalse(applicationManager.isApplicationInstalled("app4").wait(), "app4 is NOT installed, so result of isAppInstalled must be false.");
+		});
+	});
+
+	describe("restartApplication", () => {
+		it("calls stopApplication with correct arguments", () => {
+			let stopApplicationParam: string;
+			applicationManager.stopApplication = (appId: string) => {
+				stopApplicationParam = appId;
+				return Future.fromResult();
+			};
+
+			applicationManager.restartApplication("appId").wait();
+			assert.deepEqual(stopApplicationParam, "appId", "When bundleIdentifier is not passed to restartApplication, stopApplication must be called with application identifier.");
+
+			applicationManager.restartApplication("appId", "bundleIdentifier").wait();
+			assert.deepEqual(stopApplicationParam, "bundleIdentifier", "When bundleIdentifier is passed to restartApplication, stopApplication must be called with bundleIdentifier.");
+		});
+
+		it("calls startApplication with correct arguments", () => {
+			let startApplicationAppIdParam: string,
+				startApplicationFrameworkParam: string;
+			applicationManager.startApplication = (appId: string, framework: string) => {
+				startApplicationAppIdParam = appId;
+				startApplicationFrameworkParam = framework;
+				return Future.fromResult();
+			};
+
+			applicationManager.restartApplication("appId").wait();
+			assert.deepEqual(startApplicationAppIdParam, "appId", "startApplication must be called with application identifier.");
+			assert.deepEqual(startApplicationFrameworkParam, undefined, "When framework is not passed to restartApplication, startApplication must be called with undefined framework.");
+
+			applicationManager.restartApplication("appId", null, "cordova").wait();
+			assert.deepEqual(startApplicationAppIdParam, "appId", "startApplication must be called with application identifier.");
+			assert.deepEqual(startApplicationFrameworkParam, "cordova", "When framework is passed to restartApplication, startApplication must be called with this framework.");
+		});
+
+		it("calls stopApplication and startApplication in correct order", () => {
+			let isStartApplicationCalled = false,
+				isStopApplicationCalled = false;
+
+			applicationManager.stopApplication = (appId: string) => {
+				isStopApplicationCalled = true;
+				return Future.fromResult();
+			};
+
+			applicationManager.startApplication = (appId: string, framework: string) => {
+				assert.isTrue(isStopApplicationCalled, "When startApplication is called, stopApplication must have been resolved.");
+				isStartApplicationCalled = true;
+				return Future.fromResult();
+			};
+
+			applicationManager.restartApplication("appId").wait();
+			assert.isTrue(isStopApplicationCalled, "stopApplication must be called.");
+			assert.isTrue(isStartApplicationCalled, "startApplication must be called.");
+		});
+	});
+
+	describe("tryStartApplication", () => {
+		it("calls startApplication, when application is installed and canStartApplication returns true", () => {
+			let startApplicationAppIdParam: string,
+				startApplicationFrameworkParam: string;
+
+			applicationManager.canStartApplication = () => true;
+			applicationManager.isApplicationInstalled = (appId: string) => Future.fromResult(true);
+			applicationManager.startApplication = (appId: string, framework: string) => {
+				startApplicationAppIdParam = appId;
+				startApplicationFrameworkParam = framework;
+				return Future.fromResult();
+			};
+
+			applicationManager.tryStartApplication("appId").wait();
+			assert.deepEqual(startApplicationAppIdParam, "appId");
+			assert.deepEqual(startApplicationFrameworkParam, undefined);
+
+			applicationManager.tryStartApplication("appId2", "framework").wait();
+			assert.deepEqual(startApplicationAppIdParam, "appId2");
+			assert.deepEqual(startApplicationFrameworkParam, "framework");
+		});
+
+		it("does not call startApplication, when application is NOT installed", () => {
+			let isStartApplicationCalled = false;
+			applicationManager.canStartApplication = () => true;
+			applicationManager.isApplicationInstalled = (appId: string) => Future.fromResult(false);
+			applicationManager.startApplication = (appId: string, framework: string) => {
+				isStartApplicationCalled = true;
+				return Future.fromResult();
+			};
+
+			applicationManager.tryStartApplication("appId").wait();
+			assert.isFalse(isStartApplicationCalled, "startApplication must not be called when app is not installed");
+		});
+
+		it("does not call startApplication, when application is installed, but canStartApplication returns false", () => {
+			let isStartApplicationCalled = false;
+			applicationManager.canStartApplication = () => false;
+			applicationManager.isApplicationInstalled = (appId: string) => Future.fromResult(true);
+			applicationManager.startApplication = (appId: string, framework: string) => {
+				isStartApplicationCalled = true;
+				return Future.fromResult();
+			};
+
+			applicationManager.tryStartApplication("appId").wait();
+			assert.isFalse(isStartApplicationCalled, "startApplication must not be called when canStartApplication returns false.");
+		});
+
+		describe("does not throw Error", () => {
+			let error = new Error("Throw!");
+			let isStartApplicationCalled = false;
+			let logger: CommonLoggerStub;
+
+			beforeEach(() => {
+				isStartApplicationCalled = false;
+				logger = testInjector.resolve("logger");
+			});
+
+			let assertDoesNotThrow = (opts?: { shouldStartApplicatinThrow: boolean }) => {
+				assert.deepEqual(logger.traceOutput, "");
+				applicationManager.startApplication = (appId: string, framework: string) => {
+					return (() => {
+						if (opts && opts.shouldStartApplicatinThrow) {
+							throw error;
+						}
+
+						isStartApplicationCalled = true;
+					}).future<void>()();
+				};
+
+				applicationManager.tryStartApplication("appId").wait();
+				assert.isFalse(isStartApplicationCalled, "startApplication must not be called when there's an error.");
+				assert.isTrue(logger.traceOutput.indexOf("Throw!") !== -1, "Error message must be shown in trace output.");
+				assert.isTrue(logger.traceOutput.indexOf("Unable to start application") !== -1, "'Unable to start application' must be shown in trace output.");
+			};
+
+			it("when isApplicationInstalled throws error", () => {
+				applicationManager.canStartApplication = () => true;
+				applicationManager.isApplicationInstalled = (appId: string) => {
+					return (() => {
+						throw error;
+					}).future<boolean>()();
+				};
+
+				assertDoesNotThrow();
+			});
+
+			it("when canStartApplication throws error", () => {
+				applicationManager.canStartApplication = (): boolean => {
+					throw error;
+				};
+				applicationManager.isApplicationInstalled = (appId: string) => Future.fromResult(true);
+				assertDoesNotThrow();
+			});
+
+			it("when startApplications throws", () => {
+				applicationManager.canStartApplication = () => true;
+				applicationManager.isApplicationInstalled = (appId: string) => Future.fromResult(true);
+				assertDoesNotThrow({shouldStartApplicatinThrow: true});
+			});
+		});
+
+	});
+
+	describe("reinstallApplication", () => {
+		it("calls uninstallApplication with correct arguments", () => {
+			let uninstallApplicationAppIdParam: string;
+			applicationManager.uninstallApplication = (appId: string) => {
+				uninstallApplicationAppIdParam = appId;
+				return Future.fromResult();
+			};
+
+			applicationManager.reinstallApplication("appId", "packageFilePath").wait();
+			assert.deepEqual(uninstallApplicationAppIdParam, "appId");
+		});
+
+		it("calls installApplication with correct arguments", () => {
+			let installApplicationPackageFilePathParam: string;
+			applicationManager.installApplication = (packageFilePath: string) => {
+				installApplicationPackageFilePathParam = packageFilePath;
+				return Future.fromResult();
+			};
+
+			applicationManager.reinstallApplication("appId", "packageFilePath").wait();
+			assert.deepEqual(installApplicationPackageFilePathParam, "packageFilePath");
+		});
+
+		it("calls uninstallApplication and installApplication in correct order", () => {
+			let isInstallApplicationCalled = false,
+				isUninstallApplicationCalled = false;
+
+			applicationManager.uninstallApplication = (appId: string) => {
+				assert.isFalse(isInstallApplicationCalled, "When uninstallApplication is called, installApplication should not have been called.");
+				isUninstallApplicationCalled = true;
+				return Future.fromResult();
+			};
+
+			applicationManager.installApplication = (packageFilePath: string) => {
+				assert.isTrue(isUninstallApplicationCalled, "When installApplication is called, uninstallApplication should have been called.");
+				isInstallApplicationCalled = true;
+				return Future.fromResult();
+			};
+
+			applicationManager.reinstallApplication("appId", "packageFilePath").wait();
+
+			assert.isTrue(isUninstallApplicationCalled, "uninstallApplication should have been called.");
+			assert.isTrue(isInstallApplicationCalled, "installApplication should have been called.");
+		});
+	});
+});


### PR DESCRIPTION
### Fix debuggableAppFound and debuggableAppLost events
Detecting found and lost debuggable apps is depending on lodash's `differenceBy` method. It's been using old value of property name for comparison ("packageId" instead of "appIdentifier").
Use correct property which fixes debuggableAppFound and debuggableAppLost event.

### Add unit tests for ApplicationManagerBase.
Add unit tests for ApplicationManagerBase.

- Fix type of object used in deviceEmitter's handler for "debuggableAppFound" and "debuggableAppLost" events.

### Add unit tests for deviceEmitter
Add unit tests for deviceEmitter
