### PR TITLE
Fix device run command

### DIFF
--- a/commands/device/run-application.ts
+++ b/commands/device/run-application.ts
@@ -5,7 +5,6 @@ export class RunApplicationOnDeviceCommand implements ICommand {
 		private $stringParameter: ICommandParameter,
 		private $staticConfig: Config.IStaticConfig,
 		private $options: ICommonOptions,
-		private $projectConstants: Project.IConstants,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	allowedParameters: ICommandParameter[] = [this.$stringParameter];


### PR DESCRIPTION
Fix `tns device run` command by removing `$projectConstants` dependency, which is not available in NativeScirpt CLI. It has not been used in the command, only declared in the constructor.