### PR TITLE
Fix maximum call stack size exceeded when reading project data 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.17.1
+Latest version: 0.17.2
 
 Release date: 2016, July 11
 

--- a/appbuilder/project/project-base.ts
+++ b/appbuilder/project/project-base.ts
@@ -104,7 +104,7 @@ export abstract class ProjectBase implements Project.IProjectBase {
 							let configurationName = configMatch[1];
 							let configProjectContent = this.$fs.readJson(configProjectFile).wait(),
 								configurationLowerCase = configurationName.toLowerCase();
-							this.configurationSpecificData[configurationLowerCase] = <any>_.merge(_.cloneDeep(this.projectData), configProjectContent);
+							this.configurationSpecificData[configurationLowerCase] = <any>_.merge(_.cloneDeep(this._projectData), configProjectContent);
 							this._hasBuildConfigurations = true;
 						}
 					});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.17.1",
+  "version": "0.17.2",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
Fix maximum call stack size exceeded when reading project data. Clone the cached object, not the one that calls the same method.