### PR TITLE
Fix debug operations for Proton

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -118,3 +118,4 @@ $injector.require("iOSLogFilter", "./mobile/ios/ios-log-filter");
 
 $injector.require("projectFilesManager", "./services/project-files-manager");
 $injector.require("xcodeSelectService", "./services/xcode-select-service");
+$injector.require("net", "./services/net-service");

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1150,3 +1150,15 @@ interface IVersionData {
 	minor: string;
 	patch: string;
 }
+
+/**
+ * Wrapper for net module of Node.js.
+ */
+interface INet {
+
+	/**
+	 * Get free port on your local machine.
+	 * @return {IFuture<number>} The port.
+	 */
+	getFreePort(): IFuture<number>;
+}

--- a/services/net-service.ts
+++ b/services/net-service.ts
@@ -1,0 +1,32 @@
+import * as net from "net";
+import Future = require("fibers/future");
+
+export class Net implements INet {
+	constructor(private $logger: ILogger) { }
+
+	public getFreePort(): IFuture<number> {
+		return ((): number => {
+			let server = net.createServer((sock: string) => { /* empty - noone will connect here */ });
+
+			let createServerFuture = new Future<number>();
+
+			server.listen(0, () => {
+				let portUsed = server.address().port;
+				server.close();
+
+				if (!createServerFuture.isResolved()) {
+					createServerFuture.return(portUsed);
+				}
+			});
+
+			server.on("error", (err: Error) => {
+				if (!createServerFuture.isResolved()) {
+					createServerFuture.throw(err);
+				}
+			});
+
+			return createServerFuture.wait();
+		}).future<number>()();
+	}
+}
+$injector.register("net", Net);


### PR DESCRIPTION
Fix mapAbstractToTcpPort, which was incorrectly reading device files instead of getting them from local machine.
`mapAbstractToTcpPort` must return the same port in case there's already forwarded port for this application - call `adb -s <device id> forward --list` and parse result in order to return the already created one.
Fix returning multiple `chrome` apps when getting debuggable applications. In fact they are all the same, so we can just return the unique values.
Fix getting PIDs of processes, which was returning incorrect results when we have apps with similar names (com.telerik.Debugger and com.telerikDebuggerTests).

In order to get free port on local machine, introduce `$net` dependency, which is wrapper for Node.js's net module. Use OS's logic that prevents EADDRINUSE error - tell the OS that we need free port (pass 0) and it will return the first free one.