### PR TITLE
Allow debugging of WebViews inside NativeScript applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Contains common infrastructure for CLIs - mainly AppBuilder and NativeScript.
 Installation
 ===
 
-Latest version: 0.18.0
+Latest version: 0.19.0
 
-Release date: 2016, July 14
+Release date: 2016, July 19
 
 ### System Requirements
 

--- a/README.md
+++ b/README.md
@@ -551,11 +551,11 @@ Sample result will be:
 ```
 
 
-* `mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string): Promise<string>` - This function forwards the abstract port of the web view on the device to available tcp port on the host and returns the tcp port.
+* `mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string, framework: string): Promise<string>` - This function forwards the abstract port of the web view on the device to available tcp port on the host and returns the tcp port.
 
 Sample usage:
 ```JavaScript
-require("mobile-cli-lib").devicesService.mapAbstractToTcpPort("4df18f307d8a8f1b", "com.telerik.test")
+require("mobile-cli-lib").devicesService.mapAbstractToTcpPort("4df18f307d8a8f1b", "com.telerik.test", "Cordova")
 	.then(function(port) {
 		console.log(port);
 	}, function(err) {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -299,7 +299,7 @@ declare module Mobile {
 		startDeviceDetectionInterval(): void;
 		stopDeviceDetectionInterval(): IFuture<void>;
 		getDeviceByIdentifier(identifier: string): Mobile.IDevice;
-		mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string): IFuture<string>;
+		mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string, framework: string): IFuture<string>;
 		detectCurrentlyAttachedDevices(): IFuture<void>;
 		startEmulator(platform?: string): IFuture<void>;
 	}
@@ -312,9 +312,10 @@ declare module Mobile {
 		 * Checks for available ports and forwards the current abstract port to one of the available ports.
 		 * @param deviceIdentifier The identifier of the device.
 		 * @param appIdentifier The identifier of the application.
+		 * @param framework {string} The framework of the application. Could be Cordova or NativeScript.
 		 * @return {string} Returns the tcp port number which is mapped to the abstract port.
 		 */
-		mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string): IFuture<string>;
+		mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string, framework: string): IFuture<string>;
 
 		/**
 		 * Gets the applications which are available for debugging on the specified device.
@@ -327,9 +328,10 @@ declare module Mobile {
 		 * Gets all mapped abstract to tcp ports for specified device id and application identifiers.
 		 * @param deviceIdentifier {string} The identifier of the device.
 		 * @param appIdentifiers {string[]} Application identifiers that will be checked.
+		 * @param framework {string} The framework of the application. Could be Cordova or NativeScript.
 		 * @return {IFuture<IDictionary<number>>} Dictionary, where the keys are app identifiers and the values are local ports.
 		 */
-		getMappedAbstractToTcpPorts(deviceIdentifier: string, appIdentifiers: string[]): IFuture<IDictionary<number>>;
+		getMappedAbstractToTcpPorts(deviceIdentifier: string, appIdentifiers: string[], framework: string): IFuture<IDictionary<number>>;
 	}
 
 	/**

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -86,7 +86,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 
 	public getDebuggableAppViews(appIdentifiers: string[]): IFuture<IDictionary<Mobile.IDebugWebViewInfo[]>> {
 		return ((): IDictionary<Mobile.IDebugWebViewInfo[]> => {
-			let mappedAppIdentifierPorts = this.$androidProcessService.getMappedAbstractToTcpPorts(this.identifier, appIdentifiers).wait(),
+			let mappedAppIdentifierPorts = this.$androidProcessService.getMappedAbstractToTcpPorts(this.identifier, appIdentifiers, TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait(),
 				applicationViews: IDictionary<Mobile.IDebugWebViewInfo[]> = {};
 
 			_.each(mappedAppIdentifierPorts, (port: number, appIdentifier: string) => {

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -398,8 +398,8 @@ export class DevicesService implements Mobile.IDevicesService {
 	}
 
 	@exportedPromise("devicesService")
-	public mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string): IFuture<string> {
-		return this.$androidProcessService.mapAbstractToTcpPort(deviceIdentifier, appIdentifier);
+	public mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string, framework: string): IFuture<string> {
+		return this.$androidProcessService.mapAbstractToTcpPort(deviceIdentifier, appIdentifier, framework);
 	}
 
 	@exportedPromise("devicesService")

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-cli-lib",
   "preferGlobal": false,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "author": "Telerik <support@telerik.com>",
   "description": "common lib used by different CLI",
   "bin": {


### PR DESCRIPTION
When there are webviews inside NativeScript application, mobile-cli-lib does not return them in getDebuggableApps as they have the same appIdentifier.
Also when trying to map abstract port for NativeScript application with WebViews, mobile-cli-lib finds the WebView first and maps port for it. In order to fix this, add `framework` parameter that will be passed from Proton.