### PR TITLE
Fix starting of NativeScript applications

### DIFF
--- a/appbuilder/project/project-base.ts
+++ b/appbuilder/project/project-base.ts
@@ -61,7 +61,13 @@ export abstract class ProjectBase implements Project.IProjectBase {
 		return null;
 	}
 
-	public startPackageActivity = startPackageActivityNames[TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()];
+	public get startPackageActivity(): string {
+		let projectData = this.projectData;
+
+		return projectData && projectData.Framework ?
+			startPackageActivityNames[projectData.Framework.toLowerCase()] :
+			startPackageActivityNames[TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()];
+	}
 
 	public get hasBuildConfigurations(): boolean {
 		return this._hasBuildConfigurations;


### PR DESCRIPTION
Fix starting of NativeScript applications by passing correct startPackageActivityName. Use the framework from projectData in case it exists in order to determine the startPackageActivity.