### PR TITLE
Fix start package activity name

### DIFF
--- a/appbuilder/project/project-base.ts
+++ b/appbuilder/project/project-base.ts
@@ -64,9 +64,7 @@ export abstract class ProjectBase implements Project.IProjectBase {
 	public get startPackageActivity(): string {
 		let projectData = this.projectData;
 
-		return projectData && projectData.Framework ?
-			startPackageActivityNames[projectData.Framework.toLowerCase()] :
-			startPackageActivityNames[TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()];
+		return projectData && projectData.Framework ? startPackageActivityNames[projectData.Framework.toLowerCase()] : null;
 	}
 
 	public get hasBuildConfigurations(): boolean {


### PR DESCRIPTION
We do not need to default to the Cordova start package activity name when we don't have project data because we can try to start NS application and the Cordova name will not work.