### PR TITLE
NativeScript LiveSyncServiceBase refactoring

### DIFF
--- a/appbuilder/providers/appbuilder-livesync-provider-base.ts
+++ b/appbuilder/providers/appbuilder-livesync-provider-base.ts
@@ -4,15 +4,19 @@ export abstract class AppBuilderLiveSyncProviderBase implements ILiveSyncProvide
 	constructor(private $androidLiveSyncServiceLocator: {factory: Function},
 		private $iosLiveSyncServiceLocator: {factory: Function}) { }
 
-	public get platformSpecificLiveSyncServices(): IDictionary<any> {
+	public get deviceSpecificLiveSyncServices(): IDictionary<any> {
 		return {
-			android: (_device: Mobile.IDevice, $injector: IInjector): IPlatformLiveSyncService => {
+			android: (_device: Mobile.IDevice, $injector: IInjector): IDeviceLiveSyncService => {
 				return $injector.resolve(this.$androidLiveSyncServiceLocator.factory, {_device: _device});
 			},
 			ios: (_device: Mobile.IDevice, $injector: IInjector) => {
 				return $injector.resolve(this.$iosLiveSyncServiceLocator.factory, {_device: _device});
 			}
 		};
+	}
+
+	public get platformSpecificLiveSyncServices(): IDictionary<any> {
+		return {};
 	}
 
 	public abstract buildForDevice(device: Mobile.IDevice): IFuture<string>;

--- a/appbuilder/services/livesync/android-livesync-service.ts
+++ b/appbuilder/services/livesync/android-livesync-service.ts
@@ -2,7 +2,7 @@ import { AndroidLiveSyncService } from "../../../mobile/android/android-livesync
 import * as path from "path";
 import * as helpers from "../../../helpers";
 
-export class AppBuilderAndroidLiveSyncService extends AndroidLiveSyncService implements IPlatformLiveSyncService {
+export class AppBuilderAndroidLiveSyncService extends AndroidLiveSyncService implements IDeviceLiveSyncService {
 	constructor(private _device: Mobile.IAndroidDevice,
 	 	$fs: IFileSystem,
 		$mobileHelper: Mobile.IMobileHelper,

--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -5,7 +5,7 @@ let osenv = require("osenv");
 import { LiveSyncConstants } from "../../../constants";
 import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../../constants";
 
-export class IOSLiveSyncService implements IPlatformLiveSyncService {
+export class IOSLiveSyncService implements IDeviceLiveSyncService {
 	private get $project(): any {
 		return this.$injector.resolve("project");
 	}

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -467,12 +467,6 @@ interface IXcodeSelectService {
 
 interface ILiveSyncServiceBase {
 	/**
-	 * If platform parameter is specified returns it
-	 * If platform parameter is not specified returns the platform of the connected device(s)
-	 * If devices from different platforms are connected throws an error
-	 */
-	getPlatform(platform?: string): IFuture<string>;
-	/**
 	 * If watch option is not specified executes full sync
 	 * If watch option is specified executes partial sync
 	 */
@@ -560,7 +554,7 @@ interface ILiveSyncData {
 	canExecute?(device: Mobile.IDevice): boolean;
 }
 
-interface IPlatformLiveSyncService {
+interface IDeviceLiveSyncService {
 	/**
 	 * Refreshes the application's content on a device
 	 */
@@ -1113,6 +1107,10 @@ interface IProjectFilesConfig {
 
 interface ILiveSyncProvider {
 	/**
+	 * Returns a dictionary that map platform to device specific livesync service
+	 */
+	deviceSpecificLiveSyncServices: IDictionary<any>;
+		/**
 	 * Returns a dictionary that map platform to platform specific livesync service
 	 */
 	platformSpecificLiveSyncServices: IDictionary<any>;

--- a/services/livesync-service-base.ts
+++ b/services/livesync-service-base.ts
@@ -30,13 +30,6 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 		this.fileHashes = Object.create(null);
 	}
 
-	public getPlatform(platform?: string): IFuture<string> { // gets the platform and ensures that the devicesService is initialized
-		return (() => {
-			this.$devicesService.initialize({ platform: platform, deviceId: this.$options.device }).wait();
-			return platform || this.$devicesService.platform;
-		}).future<string>()();
-	}
-
 	public sync(data: ILiveSyncData[], filePaths?: string[]): IFuture<void> {
 		return (() => {
 			this.syncCore(data, filePaths).wait();
@@ -276,7 +269,7 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 		}
 	}
 
-	private resolvePlatformLiveSyncService(platform: string, device: Mobile.IDevice): IPlatformLiveSyncService {
+	private resolvePlatformLiveSyncService(platform: string, device: Mobile.IDevice): IDeviceLiveSyncService {
 		return this.$injector.resolve(this.$liveSyncProvider.platformSpecificLiveSyncServices[platform.toLowerCase()], { _device: device });
 	}
 


### PR DESCRIPTION
Introduce platformSpecificLiveSyncServices map that is used in {N} live sync service
Rename the IPlatformLiveSyncService interface because it is more device oriented that platform