### PR TITLE
Remove the check whether the application is installed

### DIFF
--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -65,7 +65,7 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 	public tryStartApplication(appIdentifier: string, framework?: string): IFuture<void> {
 		return (() => {
 			try {
-				if (this.isApplicationInstalled(appIdentifier).wait() && this.canStartApplication()) {
+				if (this.canStartApplication()) {
 					this.startApplication(appIdentifier, framework).wait();
 				}
 			} catch (err) {

--- a/test/unit-tests/mobile/application-manager-base.ts
+++ b/test/unit-tests/mobile/application-manager-base.ts
@@ -651,12 +651,11 @@ describe("ApplicationManagerBase", () => {
 	});
 
 	describe("tryStartApplication", () => {
-		it("calls startApplication, when application is installed and canStartApplication returns true", () => {
+		it("calls startApplication, when canStartApplication returns true", () => {
 			let startApplicationAppIdParam: string,
 				startApplicationFrameworkParam: string;
 
 			applicationManager.canStartApplication = () => true;
-			applicationManager.isApplicationInstalled = (appId: string) => Future.fromResult(true);
 			applicationManager.startApplication = (appId: string, framework: string) => {
 				startApplicationAppIdParam = appId;
 				startApplicationFrameworkParam = framework;
@@ -672,23 +671,9 @@ describe("ApplicationManagerBase", () => {
 			assert.deepEqual(startApplicationFrameworkParam, "framework");
 		});
 
-		it("does not call startApplication, when application is NOT installed", () => {
-			let isStartApplicationCalled = false;
-			applicationManager.canStartApplication = () => true;
-			applicationManager.isApplicationInstalled = (appId: string) => Future.fromResult(false);
-			applicationManager.startApplication = (appId: string, framework: string) => {
-				isStartApplicationCalled = true;
-				return Future.fromResult();
-			};
-
-			applicationManager.tryStartApplication("appId").wait();
-			assert.isFalse(isStartApplicationCalled, "startApplication must not be called when app is not installed");
-		});
-
-		it("does not call startApplication, when application is installed, but canStartApplication returns false", () => {
+		it("does not call startApplication, when canStartApplication returns false", () => {
 			let isStartApplicationCalled = false;
 			applicationManager.canStartApplication = () => false;
-			applicationManager.isApplicationInstalled = (appId: string) => Future.fromResult(true);
 			applicationManager.startApplication = (appId: string, framework: string) => {
 				isStartApplicationCalled = true;
 				return Future.fromResult();
@@ -725,17 +710,6 @@ describe("ApplicationManagerBase", () => {
 				assert.isTrue(logger.traceOutput.indexOf("Throw!") !== -1, "Error message must be shown in trace output.");
 				assert.isTrue(logger.traceOutput.indexOf("Unable to start application") !== -1, "'Unable to start application' must be shown in trace output.");
 			};
-
-			it("when isApplicationInstalled throws error", () => {
-				applicationManager.canStartApplication = () => true;
-				applicationManager.isApplicationInstalled = (appId: string) => {
-					return (() => {
-						throw error;
-					}).future<boolean>()();
-				};
-
-				assertDoesNotThrow();
-			});
 
 			it("when canStartApplication throws error", () => {
 				applicationManager.canStartApplication = (): boolean => {


### PR DESCRIPTION
When this method is executed right after the application is installed, the isApplicationInstalled returns false so we have to explicitly call checkForApplicationUpdates to update the application list. Since the tryStartApplication would fail if the app is not installed, and the exception would be caught, remove the isApplicationInstalled check