### PR TITLE
Fix process service unit test

### DIFF
--- a/test/unit-tests/process-service.ts
+++ b/test/unit-tests/process-service.ts
@@ -83,7 +83,8 @@ describe("Process service", () => {
 		$processService.attachToProcessExitSignals({}, secondListener);
 		$processService.attachToProcessExitSignals({}, thirdListener);
 
-		global.process.emit("SIGINT");
+		// Do not use exit or SIGINT because the tests after this one will not be executed.
+		global.process.emit("SIGTERM");
 
 		assert.isTrue(hasCalledFirstListener);
 		assert.isTrue(hasCalledSecondListener);


### PR DESCRIPTION
When we test the execution of all attached listeners we need to emit SIGTERM because if we emit exit or SIGINT the execution of the tests after this one will fail.