### PR TITLE
Add support for installing npm modules and @types

### DIFF
--- a/appbuilder/appbuilder-bootstrap.ts
+++ b/appbuilder/appbuilder-bootstrap.ts
@@ -10,3 +10,4 @@ $injector.requirePublic("companionAppsService", "./appbuilder/services/livesync/
 $injector.require("nativeScriptProjectCapabilities", "./appbuilder/project/nativescript-project-capabilities");
 $injector.require("cordovaProjectCapabilities", "./appbuilder/project/cordova-project-capabilities");
 $injector.require("mobilePlatformsCapabilities", "./appbuilder/mobile-platforms-capabilities");
+$injector.requirePublic("npmService", "./appbuilder/services/npm-service");

--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -305,7 +305,7 @@ interface INpmService {
 
 	/**
 	 * Installs everything from package.json or specified dependency.
-	 * In case there's information which dependency to install, the method will check it and install only this dependency and possibly it's @types.
+	 * In case there's information which dependency to install, the method will check it and install only this dependency and possibly its @types.
 	 * @param {string} projectDir Directory of the project, where package.json is located.
 	 * @param @optional {INpmDependency} dependency Description of the dependency that has to be installed.
 	 * @return {IFuture<INpmInstallResult>} Returns object that will have error in case something fails.

--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -10,23 +10,24 @@ interface IDeployHelper {
 
 declare module Project {
 	interface IConstants {
-		PROJECT_FILE: string;
-		PROJECT_IGNORE_FILE: string;
+		ADDITIONAL_FILES_DIRECTORY: string;
+		ADDITIONAL_FILE_DISPOSITION: string;
+		APPBUILDER_PROJECT_PLATFORMS_NAMES: IDictionary<string>;
+		APPIDENTIFIER_PROPERTY_NAME: string;
+		CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME: string;
+		CORE_PLUGINS_PROPERTY_NAME: string;
 		DEBUG_CONFIGURATION_NAME: string;
 		DEBUG_PROJECT_FILE_NAME: string;
+		EXPERIMENTAL_TAG: string;
+		IMAGE_DEFINITIONS_FILE_NAME: string;
+		IONIC_PROJECT_PLATFORMS_NAMES: IDictionary<string>;
+		NATIVESCRIPT_APP_DIR_NAME: string;
+		PACKAGE_JSON_NAME: string;
+		PROJECT_FILE: string;
+		PROJECT_IGNORE_FILE: string;
+		REFERENCES_FILE_NAME: string;
 		RELEASE_CONFIGURATION_NAME: string;
 		RELEASE_PROJECT_FILE_NAME: string;
-		CORE_PLUGINS_PROPERTY_NAME: string;
-		CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME: string;
-		APPIDENTIFIER_PROPERTY_NAME: string;
-		EXPERIMENTAL_TAG: string;
-		NATIVESCRIPT_APP_DIR_NAME: string;
-		IMAGE_DEFINITIONS_FILE_NAME: string;
-		PACKAGE_JSON_NAME: string;
-		ADDITIONAL_FILE_DISPOSITION: string;
-		ADDITIONAL_FILES_DIRECTORY: string;
-		APPBUILDER_PROJECT_PLATFORMS_NAMES: IDictionary<string>;
-		IONIC_PROJECT_PLATFORMS_NAMES: IDictionary<string>;
 	}
 
 	interface ICapabilities {
@@ -237,4 +238,87 @@ interface ICompanionAppsService {
 	 * @return {IDictionary<IStringDictionary>} Companion appIdentifiers separated in different properties of object.
 	 */
 	getAllCompanionAppIdentifiers(): IDictionary<IStringDictionary>;
+}
+
+/**
+ * Describes information for single npm dependency that has to be installed.
+ */
+interface INpmDependency {
+	/**
+	 * Name of the dependency.
+	 */
+	name: string;
+
+	/**
+	 * @optional The version of the dependency that has to be installed.
+	 */
+	version?: string;
+
+	/**
+	 * Defines if @types/<name> should be installed as well.
+	 */
+	installTypes: boolean;
+}
+
+
+/**
+ * Describes the result of npm install <dependency> and npm install @types/<dependency> command.
+ */
+interface INpmInstallDependencyResult {
+	/**
+	 * Defines if the dependency is installed successfully.
+	 */
+	isInstalled: boolean;
+	/**
+	 * Defines if the @types/<dependency> is installed successfully.
+	 */
+	isTypesInstalled: boolean;
+}
+
+/**
+ * Describes the result of npm install command.
+ */
+interface INpmInstallResult {
+	/**
+	 * The result of installing a single dependency.
+	 */
+	result?: INpmInstallDependencyResult,
+
+	/**
+	 * The error that occurred during the operation.
+	 */
+	error?: Error;
+}
+
+/**
+ * Describes methods for working with npm.
+ */
+interface INpmService {
+	/**
+	 * Uninstalls the dependency and the @types/<dependency> devDependency.
+	 * The method will remove them from package.json and from node_modules dir.
+	 * @param {string} projectDir Directory of the project, where package.json is located.
+	 * @param {string} dependency The name of the dependency that has to be removed.
+	 * @return {IFuture<void>}
+	 */
+	uninstall(projectDir: string, dependency: string): IFuture<void>;
+
+	/**
+	 * Installs everything from package.json or specified dependency.
+	 * In case there's information which dependency to install, the method will check it and install only this dependency and possibly it's @types.
+	 * @param {string} projectDir Directory of the project, where package.json is located.
+	 * @param @optional {INpmDependency} dependency Description of the dependency that has to be installed.
+	 * @return {IFuture<INpmInstallResult>} Returns object that will have error in case something fails.
+	 * In case there's no specific dependency that has to be installed and everything is installed successfully, the result will be empty object.
+	 * In case there's dependency that has to be installed, the result object will contain information for the successfull installation of the dependency and the @types reference.
+	 */
+	install(projectDir: string, dependencyToInstall?: INpmDependency): IFuture<INpmInstallResult>;
+
+	/**
+	 * Gets package.json of a specific dependency from registry.npmjs.org.
+	 * @param {string} packageName The name of the dependency.
+	 * @param {string} version The version that has to be taken from registry. "latest" will be used in case there's no version passed.
+	 * @return {any} package.json of a dependency or null in case such dependency or version does not exist.
+	 */
+	getPackageJsonFromNpmRegistry(packageName: string, version?: string): IFuture<any>;
 }

--- a/appbuilder/project-constants.ts
+++ b/appbuilder/project-constants.ts
@@ -14,6 +14,7 @@ export class ProjectConstants implements Project.IConstants {
 	public PACKAGE_JSON_NAME = "package.json";
 	public ADDITIONAL_FILE_DISPOSITION = "AdditionalFile";
 	public ADDITIONAL_FILES_DIRECTORY = ".ab";
+	public REFERENCES_FILE_NAME = ".abreferences.d.ts";
 
 	public APPBUILDER_PROJECT_PLATFORMS_NAMES: IDictionary<string> = {
 		android: "Android",

--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -157,7 +157,7 @@ export class NpmService implements INpmService {
 								(file, stat) => _.endsWith(file, constants.FileExtensions.TYPESCRIPT_DEFINITION_FILE) || stat.isDirectory(), { enumerateDirectories: false });
 
 							let defs = _.map(definitionFiles, def => {
-								return this.getReferenceLine(fromWindowsRelativePathToUnix(path.relative(nodeModulesDirectory, def)));
+								return this.getReferenceLine(fromWindowsRelativePathToUnix(path.relative(projectDir, def)));
 							});
 
 							this.$logger.trace(`Adding lines for definition files: ${definitionFiles.join(", ")}`);
@@ -200,7 +200,7 @@ export class NpmService implements INpmService {
 
 	private getNpmArguments(command: string, npmArguments?: string[]): string[] {
 		let args: string[] = npmArguments || [];
-		return args.concat([ command ]);
+		return args.concat([command]);
 	}
 
 	private npmInstall(projectDir: string, dependency?: string, version?: string, npmArguments?: string[]): IFuture<void> {

--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -1,0 +1,233 @@
+import * as path from "path";
+import * as os from "os";
+import { fromWindowsRelativePathToUnix } from "../../helpers";
+import * as constants from "../../constants";
+import { exportedPromise } from "../../decorators";
+
+export class NpmService implements INpmService {
+	private static TYPES_DIRECTORY = "@types/";
+	private static TNS_CORE_MODULES_DEFINITION_FILE_NAME = `${constants.TNS_CORE_MODULES}${constants.FileExtensions.TYPESCRIPT_DEFINITION_FILE}`;
+	private static NPM_REGISTRY_URL = "https://registry.npmjs.org";
+
+	private _npmExecutableName: string;
+
+	constructor(private $childProcess: IChildProcess,
+		private $errors: IErrors,
+		private $fs: IFileSystem,
+		private $hostInfo: IHostInfo,
+		private $httpClient: Server.IHttpClient,
+		private $logger: ILogger,
+		private $projectConstants: Project.IConstants) { }
+
+	@exportedPromise("npmService")
+	public install(projectDir: string, dependencyToInstall?: INpmDependency): IFuture<INpmInstallResult> {
+		return (() => {
+			let npmInstallResult: INpmInstallResult = {};
+
+			if (dependencyToInstall) {
+				npmInstallResult.result = {
+					isInstalled: false,
+					isTypesInstalled: false
+				};;
+
+				try {
+					this.npmInstall(projectDir, dependencyToInstall.name, dependencyToInstall.version, ["--save", "--save-exact"]).wait();
+					npmInstallResult.result.isInstalled = true;
+				} catch (err) {
+					npmInstallResult.error = err;
+				}
+
+				if (dependencyToInstall.installTypes && npmInstallResult.result.isInstalled && this.hasTypesForDependency(dependencyToInstall.name).wait()) {
+					try {
+						this.installTypingsForDependency(projectDir, dependencyToInstall.name).wait();
+						npmInstallResult.result.isTypesInstalled = true;
+					} catch (err) {
+						npmInstallResult.error = err;
+					}
+				}
+			} else {
+				try {
+					this.npmPrune(projectDir).wait();
+					this.npmInstall(projectDir).wait();
+				} catch (err) {
+					npmInstallResult.error = err;
+				}
+			}
+
+			this.generateReferencesFile(projectDir).wait();
+
+			return npmInstallResult;
+		}).future<INpmInstallResult>()();
+	}
+
+	@exportedPromise("npmService")
+	public uninstall(projectDir: string, dependency: string): IFuture<void> {
+		return (() => {
+			let packageJsonContent = this.getPackageJsonContent(projectDir).wait();
+
+			if (packageJsonContent && packageJsonContent.dependencies && packageJsonContent.dependencies[dependency]) {
+				this.npmUninstall(projectDir, dependency, ["--save"]).wait();
+			}
+
+			if (packageJsonContent && packageJsonContent.devDependencies && packageJsonContent.devDependencies[`${NpmService.TYPES_DIRECTORY}${dependency}`]) {
+				this.npmUninstall(projectDir, `${NpmService.TYPES_DIRECTORY}${dependency}`, ["--save-dev"]).wait();
+			}
+		}).future<void>()();
+	}
+
+	public getPackageJsonFromNpmRegistry(packageName: string, version?: string): IFuture<any> {
+		return (() => {
+			let packageJsonContent: any;
+			version = version || "latest";
+			try {
+				let url = this.buildNpmRegistryUrl(packageName, version);
+				// This call will return error with message '{}' in case there's no such package.
+				let result = this.$httpClient.httpRequest(url).wait().body;
+				packageJsonContent = JSON.parse(result);
+			} catch (err) {
+				this.$logger.trace("Error caught while checking the NPM Registry for plugin with id: %s", packageName);
+				this.$logger.trace(err.message);
+			}
+
+			return packageJsonContent;
+		}).future<any>()();
+	}
+
+	private hasTypesForDependency(packageName: string): IFuture<boolean> {
+		return (() => {
+			return !!this.getPackageJsonFromNpmRegistry(`${NpmService.TYPES_DIRECTORY}${packageName}`).wait();
+		}).future<boolean>()();
+	}
+
+	private buildNpmRegistryUrl(packageName: string, version: string): string {
+		return `${NpmService.NPM_REGISTRY_URL}/${packageName.replace("/", "%2F")}?version=${encodeURIComponent(version)}`;
+	}
+
+	private getPackageJsonContent(projectDir: string): IFuture<any> {
+		return (() => {
+			let pathToPackageJson = this.getPathToPackageJson(projectDir);
+
+			try {
+				return this.$fs.readJson(pathToPackageJson).wait();
+			} catch (err) {
+				if (err.code === "ENOENT") {
+					this.$errors.failWithoutHelp(`Unable to find ${this.$projectConstants.PACKAGE_JSON_NAME} in ${projectDir}.`);
+				}
+
+				throw err;
+			}
+
+		}).future<any>()();
+	}
+
+	private getPathToPackageJson(projectDir: string): string {
+		return path.join(projectDir, this.$projectConstants.PACKAGE_JSON_NAME);
+	}
+
+	private getPathToReferencesFile(projectDir: string): string {
+		return path.join(projectDir, this.$projectConstants.REFERENCES_FILE_NAME);
+	}
+
+	private installTypingsForDependency(projectDir: string, dependency: string): IFuture<void> {
+		return this.npmInstall(projectDir, `${NpmService.TYPES_DIRECTORY}${dependency}`, null, ["--save-dev", "--save-exact"]);
+	}
+
+	private generateReferencesFile(projectDir: string): IFuture<void> {
+		return (() => {
+			let packageJsonContent = this.getPackageJsonContent(projectDir).wait();
+
+			let pathToReferenceFile = this.getPathToReferencesFile(projectDir),
+				lines: string[] = [];
+
+			if (packageJsonContent && packageJsonContent.dependencies && packageJsonContent.dependencies[constants.TNS_CORE_MODULES]) {
+				let relativePathToTnsCoreModulesDts = `./${constants.NODE_MODULES_DIR_NAME}/${constants.TNS_CORE_MODULES}/${NpmService.TNS_CORE_MODULES_DEFINITION_FILE_NAME}`;
+
+				if (this.$fs.exists(path.join(projectDir, relativePathToTnsCoreModulesDts)).wait()) {
+					lines.push(this.getReferenceLine(relativePathToTnsCoreModulesDts));
+				}
+			}
+
+			if (packageJsonContent && packageJsonContent.devDependencies) {
+				_(packageJsonContent.devDependencies)
+					.keys()
+					.each(devDependency => {
+						if (this.isFromTypesRepo(devDependency)) {
+							let nodeModulesDirectory = path.join(projectDir, constants.NODE_MODULES_DIR_NAME);
+							let definitionFiles = this.$fs.enumerateFilesInDirectorySync(path.join(nodeModulesDirectory, devDependency),
+								(file, stat) => _.endsWith(file, constants.FileExtensions.TYPESCRIPT_DEFINITION_FILE) || stat.isDirectory(), { enumerateDirectories: false });
+
+							let defs = _.map(definitionFiles, def => {
+								return this.getReferenceLine(fromWindowsRelativePathToUnix(path.relative(nodeModulesDirectory, def)));
+							});
+
+							this.$logger.trace(`Adding lines for definition files: ${definitionFiles.join(", ")}`);
+							lines.push(...defs);
+						}
+					});
+			}
+
+			// TODO: Make sure the android17.d.ts and ios.d.ts are added.
+
+			if (lines.length) {
+				this.$logger.trace("Updating reference file with new entries...");
+				this.$fs.writeFile(pathToReferenceFile, lines.join(os.EOL), "utf8").wait();
+			} else {
+				this.$logger.trace(`Could not find any .d.ts files for ${this.$projectConstants.REFERENCES_FILE_NAME} file. Deleting the old file.`);
+				this.$fs.deleteFile(pathToReferenceFile).wait();
+			}
+		}).future<void>()();
+	}
+
+	private isFromTypesRepo(dependency: string): boolean {
+		return !!dependency.match(/^@types\//);
+	}
+
+	private getReferenceLine(pathToReferencedFile: string): string {
+		return `/// <reference path="${pathToReferencedFile}" />`;
+	}
+
+	private get npmExecutableName(): string {
+		if (!this._npmExecutableName) {
+			this._npmExecutableName = "npm";
+
+			if (this.$hostInfo.isWindows) {
+				this._npmExecutableName += ".cmd";
+			}
+		}
+
+		return this._npmExecutableName;
+	}
+
+	private getNpmArguments(command: string, npmArguments?: string[]): string[] {
+		let args: string[] = npmArguments || [];
+		return args.concat([ command ]);
+	}
+
+	private npmInstall(projectDir: string, dependency?: string, version?: string, npmArguments?: string[]): IFuture<void> {
+		return this.executeNpmCommand(projectDir, this.getNpmArguments("install", npmArguments), dependency, version);
+	}
+
+	private npmUninstall(projectDir: string, dependency?: string, npmArguments?: string[]): IFuture<void> {
+		return this.executeNpmCommand(projectDir, this.getNpmArguments("uninstall", npmArguments), dependency, null);
+	}
+
+	private npmPrune(projectDir: string, dependency?: string, version?: string): IFuture<void> {
+		return this.executeNpmCommand(projectDir, this.getNpmArguments("prune"), dependency, version);
+	}
+
+	private executeNpmCommand(projectDir: string, npmArguments: string[], dependency: string, version?: string): IFuture<void> {
+		return (() => {
+			if (dependency) {
+				let dependencyToInstall = dependency;
+				if (version) {
+					dependencyToInstall += `@${version}`;
+				}
+
+				npmArguments.push(dependencyToInstall);
+			}
+
+			this.$childProcess.spawnFromEvent(this.npmExecutableName, npmArguments, "close", { cwd: projectDir }).wait();
+		}).future<void>()();
+	}
+}
+$injector.register("npmService", NpmService);

--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -28,7 +28,7 @@ export class NpmService implements INpmService {
 				npmInstallResult.result = {
 					isInstalled: false,
 					isTypesInstalled: false
-				};;
+				};
 
 				try {
 					this.npmInstall(projectDir, dependencyToInstall.name, dependencyToInstall.version, ["--save", "--save-exact"]).wait();
@@ -147,24 +147,20 @@ export class NpmService implements INpmService {
 				}
 			}
 
-			if (packageJsonContent && packageJsonContent.devDependencies) {
-				_(packageJsonContent.devDependencies)
-					.keys()
-					.each(devDependency => {
-						if (this.isFromTypesRepo(devDependency)) {
-							let nodeModulesDirectory = path.join(projectDir, constants.NODE_MODULES_DIR_NAME);
-							let definitionFiles = this.$fs.enumerateFilesInDirectorySync(path.join(nodeModulesDirectory, devDependency),
-								(file, stat) => _.endsWith(file, constants.FileExtensions.TYPESCRIPT_DEFINITION_FILE) || stat.isDirectory(), { enumerateDirectories: false });
+			_(packageJsonContent.devDependencies)
+				.keys()
+				.each(devDependency => {
+					if (this.isFromTypesRepo(devDependency)) {
+						let nodeModulesDirectory = path.join(projectDir, constants.NODE_MODULES_DIR_NAME);
+						let definitionFiles = this.$fs.enumerateFilesInDirectorySync(path.join(nodeModulesDirectory, devDependency),
+							(file, stat) => _.endsWith(file, constants.FileExtensions.TYPESCRIPT_DEFINITION_FILE) || stat.isDirectory(), { enumerateDirectories: false });
 
-							let defs = _.map(definitionFiles, def => {
-								return this.getReferenceLine(fromWindowsRelativePathToUnix(path.relative(projectDir, def)));
-							});
+						let defs = _.map(definitionFiles, def => this.getReferenceLine(fromWindowsRelativePathToUnix(path.relative(projectDir, def))));
 
-							this.$logger.trace(`Adding lines for definition files: ${definitionFiles.join(", ")}`);
-							lines.push(...defs);
-						}
-					});
-			}
+						this.$logger.trace(`Adding lines for definition files: ${definitionFiles.join(", ")}`);
+						lines.push(...defs);
+					}
+				});
 
 			// TODO: Make sure the android17.d.ts and ios.d.ts are added.
 
@@ -198,9 +194,8 @@ export class NpmService implements INpmService {
 		return this._npmExecutableName;
 	}
 
-	private getNpmArguments(command: string, npmArguments?: string[]): string[] {
-		let args: string[] = npmArguments || [];
-		return args.concat([command]);
+	private getNpmArguments(command: string, npmArguments: string[] = []): string[] {
+		return npmArguments.concat([command]);
 	}
 
 	private npmInstall(projectDir: string, dependency?: string, version?: string, npmArguments?: string[]): IFuture<void> {

--- a/constants.ts
+++ b/constants.ts
@@ -39,3 +39,10 @@ export class Configurations {
 	static Release = "Release";
 }
 
+export let NODE_MODULES_DIR_NAME = "node_modules";
+export let TNS_CORE_MODULES = "tns-core-modules";
+
+export class FileExtensions {
+	static TYPESCRIPT_DEFINITION_FILE = ".d.ts";
+	static TYPESCRIPT_FILE = ".ts";
+}


### PR DESCRIPTION
Add support for installing npm dependencies. Provide two methods for public API:
 - install - installs everything from package.json. In case a specific dependency must be installed, it's described as second argument with its name, version and should `@types` be installed.
 - uninstall - uninstalls the specified dependency from both node_modules and package.json. The call will also remove `@types/<dependency>` entry from devDependencies.

Still to do (in separate PRs)
* Add android17.d.ts and ios.d.ts to the project and reference them in .abreferences.d.ts
* Add unit tests
* Update README for new public API (requires bump of version in package.json)