### PR TITLE
Fix resolve livesync service

### DIFF
--- a/appbuilder/providers/appbuilder-livesync-provider-base.ts
+++ b/appbuilder/providers/appbuilder-livesync-provider-base.ts
@@ -9,14 +9,10 @@ export abstract class AppBuilderLiveSyncProviderBase implements ILiveSyncProvide
 			android: (_device: Mobile.IDevice, $injector: IInjector): IDeviceLiveSyncService => {
 				return $injector.resolve(this.$androidLiveSyncServiceLocator.factory, {_device: _device});
 			},
-			ios: (_device: Mobile.IDevice, $injector: IInjector) => {
+			ios: (_device: Mobile.IDevice, $injector: IInjector): IDeviceLiveSyncService => {
 				return $injector.resolve(this.$iosLiveSyncServiceLocator.factory, {_device: _device});
 			}
 		};
-	}
-
-	public get platformSpecificLiveSyncServices(): IDictionary<any> {
-		return {};
 	}
 
 	public abstract buildForDevice(device: Mobile.IDevice): IFuture<string>;

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1110,10 +1110,6 @@ interface ILiveSyncProvider {
 	 * Returns a dictionary that map platform to device specific livesync service
 	 */
 	deviceSpecificLiveSyncServices: IDictionary<any>;
-		/**
-	 * Returns a dictionary that map platform to platform specific livesync service
-	 */
-	platformSpecificLiveSyncServices: IDictionary<any>;
 	/**
 	 * Builds the application and returns the package file path
 	 */

--- a/services/livesync-service-base.ts
+++ b/services/livesync-service-base.ts
@@ -119,15 +119,15 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 							this.$dispatcher.dispatch(() => (() => {
 								try {
 									for (let platformName in this.batch) {
-									    let batch = this.batch[platformName];
+										let batch = this.batch[platformName];
 										let livesyncData = this.livesyncData[platformName];
-										batch.syncFiles(((filesToSync:string[]) => {
+										batch.syncFiles(((filesToSync: string[]) => {
 											this.$liveSyncProvider.preparePlatformForSync(platformName).wait();
-										 	this.syncCore([livesyncData], filesToSync);
+											this.syncCore([livesyncData], filesToSync);
 										}).future<void>()).wait();
 									}
 								} catch (err) {
-								 	this.$logger.warn(`Unable to sync files. Error is:`, err.message);
+									this.$logger.warn(`Unable to sync files. Error is:`, err.message);
 								}
 							}).future<void>()());
 
@@ -153,7 +153,7 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 
 	public getSyncRemovedFilesAction(data: ILiveSyncData): (device: Mobile.IDevice, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => IFuture<void> {
 		return (device: Mobile.IDevice, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => {
-			let platformLiveSyncService = this.resolvePlatformLiveSyncService(data.platform, device);
+			let platformLiveSyncService = this.resolveDeviceLiveSyncService(data.platform, device);
 			return platformLiveSyncService.removeFiles(data.appIdentifier, localToDevicePaths);
 		};
 	}
@@ -170,7 +170,7 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 				let shouldRefreshApplication = true;
 				let deviceAppData = this.$deviceAppDataFactory.create(appIdentifier, this.$mobileHelper.normalizePlatformName(platform), device, liveSyncOptions);
 				if (deviceAppData.isLiveSyncSupported().wait()) {
-					let platformLiveSyncService = this.resolvePlatformLiveSyncService(platform, device);
+					let platformLiveSyncService = this.resolveDeviceLiveSyncService(platform, device);
 
 					if (platformLiveSyncService.beforeLiveSyncAction) {
 						platformLiveSyncService.beforeLiveSyncAction(deviceAppData).wait();
@@ -269,8 +269,8 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 		}
 	}
 
-	private resolvePlatformLiveSyncService(platform: string, device: Mobile.IDevice): IDeviceLiveSyncService {
-		return this.$injector.resolve(this.$liveSyncProvider.platformSpecificLiveSyncServices[platform.toLowerCase()], { _device: device });
+	private resolveDeviceLiveSyncService(platform: string, device: Mobile.IDevice): IDeviceLiveSyncService {
+		return this.$injector.resolve(this.$liveSyncProvider.deviceSpecificLiveSyncServices[platform.toLowerCase()], { _device: device });
 	}
 
 	public getCanExecuteAction(platform: string, appIdentifier: string, canExecute: (dev: Mobile.IDevice) => boolean): (dev: Mobile.IDevice) => boolean {


### PR DESCRIPTION
After `platformSpecificLiveSyncServices` was renamed to `deviceSpecificLiveSyncServices` when we try to resolve livesync service we need to use `deviceSpecificLiveSyncServices` instead of the empty `platformSpecificLiveSyncServices`.