### PR TITLE
Get the correct app identifier

### DIFF
--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -27,6 +27,10 @@ declare module Project {
 		ADDITIONAL_FILES_DIRECTORY: string;
 		APPBUILDER_PROJECT_PLATFORMS_NAMES: IDictionary<string>;
 		IONIC_PROJECT_PLATFORMS_NAMES: IDictionary<string>;
+		BUILD_RESULT_DISPOSITION: string;
+		ANDROID_PLATFORM_NAME: string;
+		IOS_PLATFORM_NAME: string;
+		WP8_PLATFORM_NAME: string;
 	}
 
 	interface ICapabilities {
@@ -94,6 +98,18 @@ declare module Project {
 		 * @type {Project.IProjectInformation}
 		 */
 		projectInformation: Project.IProjectInformation;
+
+		/**
+		 * Gets the app identifier which is going to be used to build the application.
+		 * @parameter Optional parameter the platform for which the app identifier will be returned.
+		 * @return {IFuture<string>} the app identifier which will be used to build the application.
+		 */
+		getAppIdentifierForPlatform(platform?: string): IFuture<string>;
+
+		/**
+		 * Checks if the app identifier is valid and if it is not - this method will throw an exception.
+		 */
+		validateAppIdentifier(platform?: string): IFuture<void>;
 	}
 
 	/**

--- a/appbuilder/project-constants.ts
+++ b/appbuilder/project-constants.ts
@@ -13,12 +13,16 @@ export class ProjectConstants implements Project.IConstants {
 	public IMAGE_DEFINITIONS_FILE_NAME = 'image-definitions.json';
 	public PACKAGE_JSON_NAME = "package.json";
 	public ADDITIONAL_FILE_DISPOSITION = "AdditionalFile";
+	public BUILD_RESULT_DISPOSITION = "BuildResult";
 	public ADDITIONAL_FILES_DIRECTORY = ".ab";
+	public ANDROID_PLATFORM_NAME = "Android";
+	public IOS_PLATFORM_NAME = "iOS";
+	public WP8_PLATFORM_NAME = "WP8";
 
 	public APPBUILDER_PROJECT_PLATFORMS_NAMES: IDictionary<string> = {
-		android: "Android",
-		ios: "iOS",
-		wp8: "WP8"
+		android: this.ANDROID_PLATFORM_NAME,
+		ios: this.IOS_PLATFORM_NAME,
+		wp8: this.WP8_PLATFORM_NAME
 	};
 
 	public IONIC_PROJECT_PLATFORMS_NAMES: IDictionary<string> = {

--- a/appbuilder/services/livesync/livesync-service.ts
+++ b/appbuilder/services/livesync/livesync-service.ts
@@ -17,7 +17,7 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 		private $logger: ILogger,
 		private $companionAppsService: ICompanionAppsService) { }
 
-	@exportedPromise("liveSyncService", function() {
+	@exportedPromise("liveSyncService", function () {
 		this.$devicesService.startDeviceDetectionInterval();
 	})
 	public livesync(deviceDescriptors: IDeviceLiveSyncInfo[], projectDir: string, filePaths?: string[]): IFuture<IDeviceLiveSyncResult>[] {
@@ -30,7 +30,7 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 	public deleteFiles(deviceDescriptors: IDeviceLiveSyncInfo[], projectDir: string, filePaths: string[]): IFuture<IDeviceLiveSyncResult>[] {
 		this.$project.projectDir = projectDir;
 		this.$logger.trace(`Called deleteFiles for identifiers ${_.map(deviceDescriptors, d => d.deviceIdentifier)}. Project dir is ${projectDir}. Files are: ${filePaths}`);
-		return _.map(deviceDescriptors, deviceDescriptor => this.liveSyncOnDevice(deviceDescriptor, filePaths, { isForDeletedFiles: true}));
+		return _.map(deviceDescriptors, deviceDescriptor => this.liveSyncOnDevice(deviceDescriptor, filePaths, { isForDeletedFiles: true }));
 	}
 
 	private liveSyncOnDevice(deviceDescriptor: IDeviceLiveSyncInfo, filePaths: string[], liveSyncOptions?: ILiveSyncDeletionOptions): IFuture<IDeviceLiveSyncResult> {
@@ -43,7 +43,7 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 			};
 
 			let device = _.find(this.$devicesService.getDeviceInstances(), d => d.deviceInfo.identifier === deviceDescriptor.deviceIdentifier);
-			if(!device) {
+			if (!device) {
 				result.liveSyncToApp = result.liveSyncToCompanion = {
 					isResolved: false,
 					error: new Error(`Cannot find connected device with identifier ${deviceDescriptor.deviceIdentifier}. Available device identifiers are: ${this.$devicesService.getDeviceInstances()}`)
@@ -73,7 +73,7 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 				}
 			}
 
-			let appIdentifier = this.$project.projectData.AppIdentifier,
+			let appIdentifier = this.$project.getAppIdentifierForPlatform(this.$devicesService.platform).wait(),
 				canExecute = (d: Mobile.IDevice) => d.deviceInfo.identifier === device.deviceInfo.identifier,
 				livesyncData: ILiveSyncData = {
 					platform: device.deviceInfo.platform,
@@ -85,11 +85,11 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 
 			let canExecuteAction = this.$liveSyncServiceBase.getCanExecuteAction(device.deviceInfo.platform, appIdentifier, canExecute);
 
-			if(deviceDescriptor.syncToApp) {
+			if (deviceDescriptor.syncToApp) {
 				result.liveSyncToApp = this.liveSyncCore(livesyncData, device, appIdentifier, canExecuteAction, { isForCompanionApp: false, isForDeletedFiles: isForDeletedFiles }, filePaths).wait();
 			}
 
-			if(deviceDescriptor.syncToCompanion) {
+			if (deviceDescriptor.syncToCompanion) {
 				result.liveSyncToCompanion = this.liveSyncCore(livesyncData, device, appIdentifier, canExecuteAction, { isForCompanionApp: true, isForDeletedFiles: isForDeletedFiles }, filePaths).wait();
 			}
 
@@ -103,14 +103,14 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 				isResolved: false
 			};
 
-			if(liveSyncOptions.isForCompanionApp) {
+			if (liveSyncOptions.isForCompanionApp) {
 				// We should check if the companion app is installed, not the real application.
 				livesyncData.appIdentifier = appIdentifier = this.$companionAppsService.getCompanionAppIdentifier(this.$project.projectData.Framework, device.deviceInfo.platform);
 			}
 
-			if(device.applicationManager.isApplicationInstalled(appIdentifier).wait()) {
+			if (device.applicationManager.isApplicationInstalled(appIdentifier).wait()) {
 
-				let deletedFilesAction: any =  liveSyncOptions && liveSyncOptions.isForDeletedFiles ? this.$liveSyncServiceBase.getSyncRemovedFilesAction(livesyncData) : null;
+				let deletedFilesAction: any = liveSyncOptions && liveSyncOptions.isForDeletedFiles ? this.$liveSyncServiceBase.getSyncRemovedFilesAction(livesyncData) : null;
 				let action: any = this.$liveSyncServiceBase.getSyncAction(livesyncData, filePaths, deletedFilesAction, liveSyncOptions);
 				try {
 					this.$devicesService.execute(action, canExecuteAction).wait();


### PR DESCRIPTION
Cherry-pick from master:

#### Get the correct app identifier
Since the users can change the app identifier for Android in Cordova projects by modifying the AndroidManifest.xml and config.xml we need to use the correct id which will be used to build the application on our server.