### PR TITLE
Delete typings dir if it is empty

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -202,6 +202,12 @@ interface IFileSystem {
 	 * @param (string[]) files files and direcories to delete
 	 */
 	rm(options: string, ...files: string[]): void;
+
+	/**
+	 * Deletes all empty parent directories.
+	 * @param {string} directory The directory from which this method will start looking for empty parents.
+	 */
+	deleteEmptyParents(directory: string): IFuture<void>;
 }
 
 // duplicated from fs.Stats, because I cannot import it here

--- a/file-system.ts
+++ b/file-system.ts
@@ -26,7 +26,7 @@ export class FileSystem implements IFileSystem {
 		let fileIdx = -1;
 		let zipCallback = () => {
 			fileIdx++;
-			if(fileIdx < files.length) {
+			if (fileIdx < files.length) {
 				let file = files[fileIdx];
 
 				let relativePath = zipPathCallback(file);
@@ -51,8 +51,8 @@ export class FileSystem implements IFileSystem {
 		return result;
 	}
 
-	public unzip(zipFile: string, destinationDir: string, options?: { overwriteExisitingFiles?: boolean; caseSensitive?: boolean},
-			fileFilters?: string[]): IFuture<void> {
+	public unzip(zipFile: string, destinationDir: string, options?: { overwriteExisitingFiles?: boolean; caseSensitive?: boolean },
+		fileFilters?: string[]): IFuture<void> {
 		return (() => {
 			let shouldOverwriteFiles = !(options && options.overwriteExisitingFiles === false);
 			let isCaseSensitive = !(options && options.caseSensitive === false);
@@ -73,7 +73,7 @@ export class FileSystem implements IFileSystem {
 				zipFile = this.findFileCaseInsensitive(zipFile);
 			}
 
-			let args =  _.flatten<string>(["-b",
+			let args = _.flatten<string>(["-b",
 				shouldOverwriteFiles ? "-o" : "-n",
 				isCaseSensitive ? [] : "-C",
 				zipFile,
@@ -90,7 +90,7 @@ export class FileSystem implements IFileSystem {
 		let dir = path.dirname(file);
 		let basename = path.basename(file);
 		let entries = this.readDirectory(dir).wait();
-		let match = minimatch.match(entries, basename, {nocase:true, nonegate: true, nonull: true})[0];
+		let match = minimatch.match(entries, basename, { nocase: true, nonegate: true, nonull: true })[0];
 		let result = path.join(dir, match);
 		return result;
 	}
@@ -105,9 +105,9 @@ export class FileSystem implements IFileSystem {
 		return (() => {
 			try {
 				operation().wait();
-			} catch(e) {
+			} catch (e) {
 				this.$injector.resolve("$logger").trace("tryExecuteFileOperation failed with error %s.", e);
-				if(enoentErrorMessage) {
+				if (enoentErrorMessage) {
 					let message = (e.code === "ENOENT") ? enoentErrorMessage : e.message;
 					this.$injector.resolve("$errors").failWithoutHelp(message);
 				}
@@ -118,7 +118,7 @@ export class FileSystem implements IFileSystem {
 	public deleteFile(path: string): IFuture<void> {
 		let future = new Future<void>();
 		fs.unlink(path, (err: any) => {
-			if(err && err.code !== "ENOENT") {  // ignore "file doesn't exist" error
+			if (err && err.code !== "ENOENT") {  // ignore "file doesn't exist" error
 				future.throw(err);
 			} else {
 				future.return();
@@ -151,16 +151,16 @@ export class FileSystem implements IFileSystem {
 
 	public futureFromEvent(eventEmitter: any, event: string): IFuture<any> {
 		let future = new Future();
-		eventEmitter.once(event, function() {
+		eventEmitter.once(event, function () {
 			let args = _.toArray(arguments);
 
-			if(event === "error") {
+			if (event === "error") {
 				let err = <Error>args[0];
 				future.throw(err);
 				return;
 			}
 
-			switch(args.length) {
+			switch (args.length) {
 				case 0:
 					future.return();
 					break;
@@ -177,8 +177,8 @@ export class FileSystem implements IFileSystem {
 
 	public createDirectory(path: string): IFuture<void> {
 		let future = new Future<void>();
-		(<any> require("mkdirp"))(path, (err: Error) => {
-			if(err) {
+		(<any>require("mkdirp"))(path, (err: Error) => {
+			if (err) {
 				future.throw(err);
 			} else {
 				future.return();
@@ -190,7 +190,7 @@ export class FileSystem implements IFileSystem {
 	public readDirectory(path: string): IFuture<string[]> {
 		let future = new Future<string[]>();
 		fs.readdir(path, (err: Error, files: string[]) => {
-			if(err) {
+			if (err) {
 				future.throw(err);
 			} else {
 				future.return(files);
@@ -202,7 +202,7 @@ export class FileSystem implements IFileSystem {
 	public readFile(filename: string): IFuture<NodeBuffer> {
 		let future = new Future<NodeBuffer>();
 		fs.readFile(filename, (err: Error, data: NodeBuffer) => {
-			if(err) {
+			if (err) {
 				future.throw(err);
 			} else {
 				future.return(data);
@@ -222,7 +222,7 @@ export class FileSystem implements IFileSystem {
 
 		let future = new Future<string>();
 		fs.readFile(filename, options, (err: Error, data: string) => {
-			if(err) {
+			if (err) {
 				future.throw(err);
 			} else {
 				future.return(data);
@@ -234,7 +234,7 @@ export class FileSystem implements IFileSystem {
 	public readJson(filename: string, encoding?: string): IFuture<any> {
 		return (() => {
 			let data = this.readText(filename, encoding).wait();
-			if(data) {
+			if (data) {
 				// Replace BOM from the header of the file if it exists
 				return JSON.parse(data.replace(/^\uFEFF/, ""));
 			}
@@ -247,7 +247,7 @@ export class FileSystem implements IFileSystem {
 			this.createDirectory(path.dirname(filename)).wait();
 			let future = new Future<void>();
 			fs.writeFile(filename, data, { encoding: encoding }, (err: Error) => {
-				if(err) {
+				if (err) {
 					future.throw(err);
 				} else {
 					future.return();
@@ -259,8 +259,8 @@ export class FileSystem implements IFileSystem {
 
 	public appendFile(filename: string, data: any, encoding?: string): IFuture<void> {
 		let future = new Future<void>();
-		fs.appendFile(filename, data, { encoding: encoding },(err: Error) => {
-			if(err) {
+		fs.appendFile(filename, data, { encoding: encoding }, (err: Error) => {
+			if (err) {
 				future.throw(err);
 			} else {
 				future.return();
@@ -274,7 +274,7 @@ export class FileSystem implements IFileSystem {
 	}
 
 	public copyFile(sourceFileName: string, destinationFileName: string): IFuture<void> {
-		if(path.resolve(sourceFileName) === path.resolve(destinationFileName)) {
+		if (path.resolve(sourceFileName) === path.resolve(destinationFileName)) {
 			return Future.fromResult();
 		}
 
@@ -294,15 +294,15 @@ export class FileSystem implements IFileSystem {
 				res.return();
 			}
 		})
-		.on("error", (e: Error) => {
-			if (!res.isResolved()) {
-				res.throw(e);
-			}
-		});
+			.on("error", (e: Error) => {
+				if (!res.isResolved()) {
+					res.throw(e);
+				}
+			});
 
 		source.pipe(target);
 		return res;
-	 }
+	}
 
 	public createReadStream(path: string, options?: {
 		flags?: string;
@@ -325,7 +325,7 @@ export class FileSystem implements IFileSystem {
 	public chmod(path: string, mode: any): IFuture<void> {
 		let future = new Future<void>();
 		fs.chmod(path, mode, (err: Error) => {
-			if(err) {
+			if (err) {
 				future.throw(err);
 			} else {
 				future.return();
@@ -337,7 +337,7 @@ export class FileSystem implements IFileSystem {
 	public getFsStats(path: string): IFuture<fs.Stats> {
 		let future = new Future<fs.Stats>();
 		fs.stat(path, (err: Error, data: fs.Stats) => {
-			if(err) {
+			if (err) {
 				future.throw(err);
 			} else {
 				future.return(data);
@@ -348,15 +348,15 @@ export class FileSystem implements IFileSystem {
 
 	public getUniqueFileName(baseName: string): IFuture<string> {
 		return ((): string => {
-			if(!this.exists(baseName).wait()) {
+			if (!this.exists(baseName).wait()) {
 				return baseName;
 			}
 			let extension = path.extname(baseName);
 			let prefix = path.basename(baseName, extension);
 
-			for(let i = 2; ; ++i) {
+			for (let i = 2; ; ++i) {
 				let numberedName = prefix + i + extension;
-				if(!this.exists(numberedName).wait()) {
+				if (!this.exists(numberedName).wait()) {
 					return numberedName;
 				}
 			}
@@ -378,7 +378,7 @@ export class FileSystem implements IFileSystem {
 
 	public ensureDirectoryExists(directoryPath: string): IFuture<void> {
 		return (() => {
-			if(!this.exists(directoryPath).wait()) {
+			if (!this.exists(directoryPath).wait()) {
 				this.createDirectory(directoryPath).wait();
 			}
 		}).future<void>()();
@@ -387,7 +387,7 @@ export class FileSystem implements IFileSystem {
 	public rename(oldPath: string, newPath: string): IFuture<void> {
 		let future = new Future<void>();
 		fs.rename(oldPath, newPath, (err: Error) => {
-			if(err) {
+			if (err) {
 				future.throw(err);
 			} else {
 				future.return();
@@ -402,7 +402,7 @@ export class FileSystem implements IFileSystem {
 			try {
 				this.rename(oldPath, newPath).wait();
 				return true;
-			} catch(e) {
+			} catch (e) {
 				if (e.code === "ENOENT") {
 					return false;
 				}
@@ -414,7 +414,7 @@ export class FileSystem implements IFileSystem {
 	public symlink(sourcePath: string, destinationPath: string, type?: string): IFuture<void> {
 		let future = new Future<void>();
 		fs.symlink(sourcePath, destinationPath, type, (err: Error) => {
-			if(err) {
+			if (err) {
 				future.throw(err);
 			} else {
 				future.return();
@@ -426,7 +426,7 @@ export class FileSystem implements IFileSystem {
 	public closeStream(stream: any): IFuture<void> {
 		let future = new Future<void>();
 		stream.close((err: Error, data: any) => {
-			if(err) {
+			if (err) {
 				future.throw(err);
 			} else {
 				future.return();
@@ -439,7 +439,7 @@ export class FileSystem implements IFileSystem {
 		return (() => {
 			let $childProcess = this.$injector.resolve("childProcess");
 
-			if(!this.$injector.resolve("$hostInfo").isWindows) {
+			if (!this.$injector.resolve("$hostInfo").isWindows) {
 				let chown = $childProcess.spawn("chown", ["-R", owner, path],
 					{ stdio: "ignore", detached: true });
 				this.futureFromEvent(chown, "close").wait();
@@ -448,10 +448,10 @@ export class FileSystem implements IFileSystem {
 		}).future<void>()();
 	}
 
-// filterCallback: function(path: String, stat: fs.Stats): Boolean
+	// filterCallback: function(path: String, stat: fs.Stats): Boolean
 	public enumerateFilesInDirectorySync(directoryPath: string,
-			filterCallback?: (_file: string, _stat: IFsStats) => boolean,
-			opts?: { enumerateDirectories?: boolean, includeEmptyDirectories?: boolean }, foundFiles?: string[]): string[] {
+		filterCallback?: (_file: string, _stat: IFsStats) => boolean,
+		opts?: { enumerateDirectories?: boolean, includeEmptyDirectories?: boolean }, foundFiles?: string[]): string[] {
 		foundFiles = foundFiles || [];
 		let contents = this.readDirectory(directoryPath).wait();
 		for (let i = 0; i < contents.length; ++i) {
@@ -462,7 +462,7 @@ export class FileSystem implements IFileSystem {
 			}
 
 			if (stat.isDirectory()) {
-				if(opts && opts.enumerateDirectories) {
+				if (opts && opts.enumerateDirectories) {
 					foundFiles.push(file);
 				}
 				if (opts && opts.includeEmptyDirectories && this.readDirectory(file).wait().length === 0) {
@@ -511,5 +511,16 @@ export class FileSystem implements IFileSystem {
 
 	public rm(options: string = undefined, ...files: string[]): void {
 		shelljs.rm(options, files);
+	}
+
+	public deleteEmptyParents(directory: string): IFuture<void> {
+		return (() => {
+			let parent = this.exists(directory).wait() ? directory : path.dirname(directory);
+
+			while (this.isEmptyDir(parent).wait()) {
+				this.deleteDirectory(parent).wait();
+				parent = path.dirname(parent);
+			}
+		}).future<void>()();
 	}
 }


### PR DESCRIPTION
After we migrate TS projects we should delete the typings directory if it is empty after we remove the tns-core-modules directory.