### PR TITLE
Regenerate .abreferences.d.ts file on plugin remove

### DIFF
--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -107,6 +107,8 @@ export class NpmService implements INpmService {
 			if (packageJsonContent && packageJsonContent.devDependencies && packageJsonContent.devDependencies[`${NpmService.TYPES_DIRECTORY}${dependency}`]) {
 				this.npmUninstall(projectDir, `${NpmService.TYPES_DIRECTORY}${dependency}`, ["--save-dev"]).wait();
 			}
+
+			this.generateReferencesFile(projectDir).wait();
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
When uninstalling plugin, the .abreferences.d.ts file must be regenerated in order to remove the entries from @types, which are removed from the file system.