### PR TITLE
Improve fetched plugins operations

### DIFF
--- a/appbuilder/declarations.d.ts
+++ b/appbuilder/declarations.d.ts
@@ -356,11 +356,11 @@ interface INpmService {
 	isScopedDependency(dependency: string): boolean;
 
 	/**
-	 * Gets the name of the dependency and the version if it is specified.
+	 * Gets the name of dependency and the version if it is specified.
 	 * @param {string} dependency The dependency to check.
 	 * @return {IScopedDependencyInformation} the name of the dependency and the version if it is specified.
 	*/
-	getScopedDependencyInformation(dependency: string): IScopedDependencyInformation;
+	getDependencyInformation(dependency: string): IDependencyInformation;
 }
 
 /**

--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -10,6 +10,7 @@ export class NpmService implements INpmService {
 	private static TNS_CORE_MODULES_DEFINITION_FILE_NAME = `${constants.TNS_CORE_MODULES}${constants.FileExtensions.TYPESCRIPT_DEFINITION_FILE}`;
 	private static NPM_REGISTRY_URL = "https://registry.npmjs.org";
 	private static SCOPED_DEPENDENCY_REGEXP = /^(@.+?)(?:@(.+?))?$/;
+	private static DEPENDENCY_REGEXP = /^(.+?)(?:@(.+?))?$/;
 
 	private _npmExecutableName: string;
 	private _npmBinary: string;
@@ -129,7 +130,7 @@ export class NpmService implements INpmService {
 			// Need to split the result only by \n because the npm result contains only \n and on Windows it will not split correctly when using EOL.
 			// Sample output:
 			// NAME                    DESCRIPTION             AUTHOR        DATE       VERSION  KEYWORDS
-			// cordova-plugin-console  Cordova Console Plugin  =csantanapr…  2016-04-20 1.0.3    cordova console ecosystem:cordova cordova-ios
+			// cordova-plugin-console  Cordova Console Plugin  =csantanaprâ€¦  2016-04-20 1.0.3    cordova console ecosystem:cordova cordova-ios
 			let pluginsRows: string[] = spawnResult.stdout.split("\n");
 
 			// Remove the table headers row.
@@ -186,8 +187,9 @@ export class NpmService implements INpmService {
 		return !!(matches && matches[0]);
 	}
 
-	public getScopedDependencyInformation(dependency: string): IScopedDependencyInformation {
-		let matches = dependency.match(NpmService.SCOPED_DEPENDENCY_REGEXP);
+	public getDependencyInformation(dependency: string): IDependencyInformation {
+		let regExp = this.isScopedDependency(dependency) ? NpmService.SCOPED_DEPENDENCY_REGEXP : NpmService.DEPENDENCY_REGEXP;
+		let matches = dependency.match(regExp);
 
 		return {
 			name: matches[1],

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1229,7 +1229,7 @@ interface IBasicPluginInformation {
 	author?: string;
 }
 
-interface IScopedDependencyInformation {
+interface IDependencyInformation {
 	name: string;
 	version?: string;
 }

--- a/services/plugins/npm-plugins-source.ts
+++ b/services/plugins/npm-plugins-source.ts
@@ -2,25 +2,28 @@ import {PluginsSourceBase} from "./plugins-source-base";
 import Future = require("fibers/future");
 
 export class NpmPluginsSource extends PluginsSourceBase implements IPluginsSource {
-	constructor(private $childProcess: IChildProcess,
+	constructor($progressIndicator: IProgressIndicator,
+		$logger: ILogger,
+		private $childProcess: IChildProcess,
 		private $hostInfo: IHostInfo,
 		private $npmService: INpmService,
-		private $logger: ILogger,
 		private $errors: IErrors) {
-		super();
+		super($progressIndicator, $logger);
 	}
 
-	public initialize(projectDir: string, keywords: string[]): IFuture<void> {
-		return (() => {
-			super.initialize(projectDir, keywords).wait();
-
-			this._plugins = this.$npmService.search(this._projectDir, keywords).wait();
-		}).future<void>()();
+	protected get progressIndicatorMessage(): string {
+		return "Searching for plugins with npm search command.";
 	}
 
 	public getPlugins(page: number, count: number): IFuture<IBasicPluginInformation[]> {
 		let skip = page * count;
 
-		return Future.fromResult(_.slice(this._plugins, skip, skip + count));
+		return Future.fromResult(_.slice(this.plugins, skip, skip + count));
+	}
+
+	protected initializeCore(projectDir: string, keywords: string[]): IFuture<void> {
+		return (() => {
+			this.plugins = this.$npmService.search(this.projectDir, keywords).wait();
+		}).future<void>()();
 	}
 }

--- a/services/plugins/print-plugins-service.ts
+++ b/services/plugins/print-plugins-service.ts
@@ -2,13 +2,11 @@ import { createTable, isInteractive } from "../../helpers";
 
 export class PrintPluginsService implements IPrintPluginsService {
 	private static COUNT_OF_PLUGINS_TO_DISPLAY: number = 10;
-	private static PROGRESS_INDICATOR_TIMEOUT = 2000;
 
 	private _page: number;
 
 	constructor(private $errors: IErrors,
 		private $logger: ILogger,
-		private $progressIndicator: IProgressIndicator,
 		private $prompter: IPrompter) {
 		this._page = 1;
 	}
@@ -22,19 +20,13 @@ export class PrintPluginsService implements IPrintPluginsService {
 
 			let count: number = options.count || PrintPluginsService.COUNT_OF_PLUGINS_TO_DISPLAY;
 
-			this.$logger.printInfoMessageOnSameLine("Searching for plugins in npm, please wait.");
 			if (!isInteractive() || options.showAllPlugins) {
-				let getAllPluginsFuture = pluginsSource.getAllPlugins();
-				this.$progressIndicator.showProgressIndicator(getAllPluginsFuture, PrintPluginsService.PROGRESS_INDICATOR_TIMEOUT).wait();
-				this.displayTableWithPlugins(getAllPluginsFuture.get());
+				let allPlugins = pluginsSource.getAllPlugins().wait();
+				this.displayTableWithPlugins(allPlugins);
 				return;
 			}
 
-			let pluginsSearchFuture = pluginsSource.getPlugins(this._page++, count);
-
-			this.$progressIndicator.showProgressIndicator(pluginsSearchFuture, PrintPluginsService.PROGRESS_INDICATOR_TIMEOUT).wait();
-
-			let pluginsToDisplay: IBasicPluginInformation[] = pluginsSearchFuture.get();
+			let pluginsToDisplay: IBasicPluginInformation[] = pluginsSource.getPlugins(this._page++, count).wait();
 			let shouldDisplayMorePlugins = true;
 
 			this.$logger.out("Available plugins:");


### PR DESCRIPTION
Display fetched plugins.
We should display the fetched plugins in Cordova projects when we list the installed plugins.

Move the prompter in the plugin source and add version parameter when fetching plugin.