### PR TITLE
Improve logging in iOS

### DIFF
--- a/mobile/ios/device/ios-core.ts
+++ b/mobile/ios/device/ios-core.ts
@@ -1112,6 +1112,23 @@ class GDBStandardOutputAdapter extends stream.Transform {
 				}
 			}
 
+			if (result.indexOf("NativeScript loaded bundle") >= 0) {
+				result = "";
+			}
+
+			// CONSOLE LOG messages comme in the following form:
+ 			// <date> <domain> <app>[pid] CONSOLE LOG file:///location:row:column: <actual message goes here>
+ 			// This code removes the first part and leaves only the message as specified by the call to console.log function.
+ 			// This removes the unnecessary information and makes the log consistent with Android.
+			if (result.indexOf("CONSOLE LOG") >= 0) {
+				let i = 4;
+				let index = 0;
+				while(i) { index = result.indexOf(":", index+1); i--; }
+				if (index > 0) {
+					result = "JS" + result.substring(index, result.length);
+				}
+			}
+
 			done(null, result);
 		} catch (e) {
 			done(e);

--- a/mobile/ios/device/ios-device.ts
+++ b/mobile/ios/device/ios-device.ts
@@ -98,7 +98,7 @@ export class IOSDevice implements Mobile.IiOSDevice {
 		let logger: ILogger = $injector.resolve("logger");
 
 		let jsDictionary = coreFoundation.cfTypeTo(dictionary);
-		logger.info("[Mounting] %s", jsDictionary["Status"]);
+		logger.debug("[Mounting] %s", jsDictionary["Status"]);
 	}
 
 	private getValue(value: string): string {
@@ -297,7 +297,7 @@ export class IOSDevice implements Mobile.IiOSDevice {
 				let func = () => {
 					let developerDiskImageDirectoryPath = this.findDeveloperDiskImageDirectoryPath().wait();
 					imagePath = path.join(developerDiskImageDirectoryPath, "DeveloperDiskImage.dmg");
-					this.$logger.info("Mounting %s", imagePath);
+					this.$logger.debug("Mounting %s", imagePath);
 
 					let signature = this.$fs.readFile(util.format("%s.signature", imagePath)).wait();
 					let cfImagePath = this.$coreFoundation.createCFString(imagePath);


### PR DESCRIPTION
- Excluded "NativeScript loaded bundle" messages from console output. Those messages occur only when running on device. Probably we could define an option (e.g. --log debug)
- Excluded file:row:column info from console log messages for device in iOS. This syncs the output with iOS simulator and Android.
- Changed the `Mounting` message from info to debug. This way it can be hidden by default, it will be visible when running the cli with option --log debug