### PR TITLE
Print the device log for specific duration

### DIFF
--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -57,7 +57,6 @@ export class IOSLiveSyncService implements IDeviceLiveSyncService {
 				notificationProxyClient.postNotification(notification);
 				notificationProxyClient.closeSocket();
 			}
-
 		}).future<void>()();
 	}
 

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -124,3 +124,5 @@ $injector.require("net", "./services/net-service");
 
 $injector.require("printPluginsService", "./services/plugins/print-plugins-service");
 $injector.require("npmPluginsService", "./services/plugins/npm-plugins-service");
+
+$injector.require("deviceLogService", "./services/device-log-service");

--- a/commands/device/device-log-stream.ts
+++ b/commands/device/device-log-stream.ts
@@ -5,6 +5,7 @@ export class OpenDeviceLogStreamCommand implements ICommand {
 		private $errors: IErrors,
 		private $commandsService: ICommandsService,
 		private $options: ICommonOptions,
+		private $loggingLevels: Mobile.ILoggingLevels,
 		private $deviceLogService: IDeviceLogService) { }
 
 	allowedParameters: ICommandParameter[] = [];
@@ -19,7 +20,7 @@ export class OpenDeviceLogStreamCommand implements ICommand {
 				this.$errors.fail(OpenDeviceLogStreamCommand.NOT_SPECIFIED_DEVICE_ERROR_MESSAGE);
 			}
 
-			this.$deviceLogService.printDeviceLog(deviceId, this.$options.duration).wait();
+			this.$deviceLogService.printDeviceLog(deviceId, this.$options.duration, this.$loggingLevels.full).wait();
 		}).future<void>()();
 	}
 }

--- a/commands/device/device-log-stream.ts
+++ b/commands/device/device-log-stream.ts
@@ -5,24 +5,21 @@ export class OpenDeviceLogStreamCommand implements ICommand {
 		private $errors: IErrors,
 		private $commandsService: ICommandsService,
 		private $options: ICommonOptions,
-		private $deviceLogProvider: Mobile.IDeviceLogProvider,
-		private $loggingLevels: Mobile.ILoggingLevels) { }
+		private $deviceLogService: IDeviceLogService) { }
 
 	allowedParameters: ICommandParameter[] = [];
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
-			this.$deviceLogProvider.setLogLevel(this.$loggingLevels.full);
-
-			this.$devicesService.initialize({ deviceId: this.$options.device, skipInferPlatform: true }).wait();
+			let deviceId = this.$options.device;
+			this.$devicesService.initialize({ deviceId, skipInferPlatform: true }).wait();
 
 			if (this.$devicesService.deviceCount > 1) {
 				this.$commandsService.tryExecuteCommand("device", []).wait();
 				this.$errors.fail(OpenDeviceLogStreamCommand.NOT_SPECIFIED_DEVICE_ERROR_MESSAGE);
 			}
 
-			let action = (device: Mobile.IDevice) =>  { return (() => device.openDeviceLogStream()).future<void>()(); };
-			this.$devicesService.execute(action).wait();
+			this.$deviceLogService.printDeviceLog(deviceId, this.$options.duration).wait();
 		}).future<void>()();
 	}
 }

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1363,8 +1363,11 @@ interface ITypeScriptTranspileOptions {
 interface IDeviceLogService {
 	/**
 	 * Starts printing the log of the device until the process is killed or until the specified duration expires.
+	 * @param {string} deviceId The identifier of the device whose log will be displayed.
+	 * @param @optional {string} duration The duration for which the log will be printed.
+	 * @param @optional {string} loggingLevel The log level.
 	 */
-	printDeviceLog(deviceId: string, duration?: number): IFuture<void>;
+	printDeviceLog(deviceId: string, duration?: number, loggingLevel?: string): IFuture<void>;
 }
 
 /**
@@ -1380,4 +1383,13 @@ interface IProxySettings {
 	 * Port of the machine used for proxy that allows connections.
 	 */
 	port: string;
+}
+
+/**
+ * Describes method with its context and arguments.
+ */
+interface IMethodDescription {
+	method: () => IFuture<void>;
+	context: any;
+	args?: any[];
 }

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -757,6 +757,7 @@ interface ICommonOptions {
 	default: Boolean;
 	release: boolean;
 	count: number;
+	duration: number;
 	hooks: boolean;
 	debug: boolean;
 }
@@ -1354,6 +1355,16 @@ interface ITypeScriptTranspileOptions {
 	 * Use the typescript compiler which is installed localy for the project.
 	 */
 	useLocalTypeScriptCompiler?: boolean;
+}
+
+/**
+ * Describes methods for working with the device log.
+ */
+interface IDeviceLogService {
+	/**
+	 * Starts printing the log of the device until the process is killed or until the specified duration expires.
+	 */
+	printDeviceLog(deviceId: string, duration?: number): IFuture<void>;
 }
 
 /**

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -191,8 +191,9 @@ declare module Mobile {
 		/**
 		 * Starts the process for getting simulator logs and sends collected data to deviceLogProvider, which should decide how to show it to the user.
 		 * @param {string} deviceIdentifier The unique identifier of the device.
+		 * @return {any} The child process which is used to get the simulator logs.
 		 */
-		startLogProcess(deviceIdentifier: string): void;
+		startLogProcess(deviceIdentifier: string): any;
 	}
 
 	/**

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -91,6 +91,7 @@ declare module Mobile {
 		fileSystem: Mobile.IDeviceFileSystem;
 		isEmulator: boolean;
 		openDeviceLogStream(): void;
+		closeDeviceLogStream(): void;
 		getApplicationInfo(applicationIdentifier: string): IFuture<Mobile.IApplicationInfo>;
 	}
 
@@ -137,6 +138,7 @@ declare module Mobile {
 
 	interface ILogcatHelper {
 		start(deviceIdentifier: string): void;
+		stop(deviceIdentifier: string): void;
 	}
 
 	/**

--- a/definitions/node.d.ts
+++ b/definitions/node.d.ts
@@ -29,7 +29,7 @@ declare function clearImmediate(immediateId: any): void;
 
 declare var require: {
     (id: string): any;
-    resolve(id:string): string;
+    resolve(id: string): string;
     cache: any;
     extensions: any;
     main: any;
@@ -60,7 +60,7 @@ declare var SlowBuffer: {
 
 
 // Buffer class
-interface Buffer extends NodeBuffer {}
+interface Buffer extends NodeBuffer { }
 declare var Buffer: {
     new (str: string, encoding?: string): Buffer;
     new (size: number): Buffer;
@@ -108,10 +108,10 @@ declare module NodeJS {
         unshift(chunk: Buffer): void;
         wrap(oldStream: ReadableStream): ReadableStream;
 
-		// HACK: process.stdin is incorrectly declared as a ReadableStream, instead of as a "tty".ReadStream,
-		// hence the need to add these declarations here.
-		isTTY: boolean;
-		setRawMode(value: boolean):void;
+        // HACK: process.stdin is incorrectly declared as a ReadableStream, instead of as a "tty".ReadStream,
+        // hence the need to add these declarations here.
+        isTTY: boolean;
+        setRawMode(value: boolean): void;
     }
 
     export interface WritableStream extends EventEmitter {
@@ -124,14 +124,14 @@ declare module NodeJS {
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
 
-		// HACK: process.stdout is incorrectly declared as a WritableStream, instead of as a "tty".WriteStream,
-		// hence the need to add these declarations here.
-		rows: number;
-		columns: number;
-		isTTY: boolean;
+        // HACK: process.stdout is incorrectly declared as a WritableStream, instead of as a "tty".WriteStream,
+        // hence the need to add these declarations here.
+        rows: number;
+        columns: number;
+        isTTY: boolean;
     }
 
-    export interface ReadWriteStream extends ReadableStream, WritableStream {}
+    export interface ReadWriteStream extends ReadableStream, WritableStream { }
 
     export interface Process extends EventEmitter {
         stdout: WritableStream;
@@ -195,15 +195,15 @@ declare module NodeJS {
         nextTick(callback: Function): void;
         umask(mask?: number): number;
         uptime(): number;
-        hrtime(time?:number[]): number[];
+        hrtime(time?: number[]): number[];
 
         // Worker
         send?(message: any, sendHandle?: any): void;
     }
 
     export interface Timer {
-        ref() : void;
-        unref() : void;
+        ref(): void;
+        unref(): void;
     }
 }
 
@@ -277,7 +277,7 @@ declare module "events" {
         setMaxListeners(n: number): void;
         listeners(event: string): Function[];
         emit(event: string, ...args: any[]): boolean;
-   }
+    }
 }
 
 declare module "http" {
@@ -366,7 +366,7 @@ declare module "http" {
         [errorCode: number]: string;
         [errorCode: string]: string;
     };
-    export function createServer(requestListener?: (request: ServerRequest, response: ServerResponse) =>void ): Server;
+    export function createServer(requestListener?: (request: ServerRequest, response: ServerResponse) => void): Server;
     export function createClient(port?: number, host?: string): any;
     export function request(options: any, callback?: Function): ClientRequest;
     export function get(options: any, callback?: Function): ClientRequest;
@@ -374,7 +374,7 @@ declare module "http" {
 }
 
 declare module "cluster" {
-    import child  = require("child_process");
+    import child = require("child_process");
     import events = require("events");
 
     export interface ClusterSettings {
@@ -433,13 +433,13 @@ declare module "zlib" {
     export function createInflateRaw(options?: ZlibOptions): InflateRaw;
     export function createUnzip(options?: ZlibOptions): Unzip;
 
-    export function deflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function deflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function gzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function gunzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function inflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function inflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function unzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function deflate(buf: Buffer, callback: (error: Error, result: any) => void): void;
+    export function deflateRaw(buf: Buffer, callback: (error: Error, result: any) => void): void;
+    export function gzip(buf: Buffer, callback: (error: Error, result: any) => void): void;
+    export function gunzip(buf: Buffer, callback: (error: Error, result: any) => void): void;
+    export function inflate(buf: Buffer, callback: (error: Error, result: any) => void): void;
+    export function inflateRaw(buf: Buffer, callback: (error: Error, result: any) => void): void;
+    export function unzip(buf: Buffer, callback: (error: Error, result: any) => void): void;
 
     // Constants
     export var Z_NO_FLUSH: number;
@@ -539,8 +539,8 @@ declare module "https" {
     };
     export interface Server extends tls.Server { }
     export function createServer(options: ServerOptions, requestListener?: Function): Server;
-    export function request(options: RequestOptions, callback?: (res: events.EventEmitter) =>void ): http.ClientRequest;
-    export function get(options: RequestOptions, callback?: (res: events.EventEmitter) =>void ): http.ClientRequest;
+    export function request(options: RequestOptions, callback?: (res: events.EventEmitter) => void): http.ClientRequest;
+    export function get(options: RequestOptions, callback?: (res: events.EventEmitter) => void): http.ClientRequest;
     export var globalAgent: Agent;
 }
 
@@ -615,7 +615,7 @@ declare module "child_process" {
     import stream = require("stream");
 
     export interface ChildProcess extends events.EventEmitter {
-        stdin:  stream.Writable;
+        stdin: stream.Writable;
         stdout: stream.Readable;
         stderr: stream.Readable;
         pid: number;
@@ -640,8 +640,8 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
-    export function exec(command: string, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
+    export function exec(command: string, callback: (error: Error, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
     export function execFile(file: string, args: string[], options?: {
         cwd?: string;
         stdio?: any;
@@ -651,7 +651,7 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: string;
         killSignal?: string;
-    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
         cwd?: string;
         env?: any;
@@ -688,24 +688,24 @@ declare module "url" {
         path?: string;
     }
 
-    export function parse(urlStr: string, parseQueryString?: boolean , slashesDenoteHost?: boolean ): Url;
+    export function parse(urlStr: string, parseQueryString?: boolean, slashesDenoteHost?: boolean): Url;
     export function format(url: UrlOptions): string;
     export function resolve(from: string, to: string): string;
 }
 
 declare module "dns" {
-    export function lookup(domain: string, family: number, callback: (err: Error, address: string, family: number) =>void ): string;
-    export function lookup(domain: string, callback: (err: Error, address: string, family: number) =>void ): string;
-    export function resolve(domain: string, rrtype: string, callback: (err: Error, addresses: string[]) =>void ): string[];
-    export function resolve(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
-    export function resolve4(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
-    export function resolve6(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
-    export function resolveMx(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
-    export function resolveTxt(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
-    export function resolveSrv(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
-    export function resolveNs(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
-    export function resolveCname(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
-    export function reverse(ip: string, callback: (err: Error, domains: string[]) =>void ): string[];
+    export function lookup(domain: string, family: number, callback: (err: Error, address: string, family: number) => void): string;
+    export function lookup(domain: string, callback: (err: Error, address: string, family: number) => void): string;
+    export function resolve(domain: string, rrtype: string, callback: (err: Error, addresses: string[]) => void): string[];
+    export function resolve(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
+    export function resolve4(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
+    export function resolve6(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
+    export function resolveMx(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
+    export function resolveTxt(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
+    export function resolveSrv(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
+    export function resolveNs(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
+    export function resolveCname(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
+    export function reverse(ip: string, callback: (err: Error, domains: string[]) => void): string[];
 }
 
 declare module "net" {
@@ -724,7 +724,7 @@ declare module "net" {
         bufferSize: number;
         setEncoding(encoding?: string): void;
         write(data: any, encoding?: string, callback?: Function): void;
-        destroy(): void;
+        destroy(err?: Error): void;
         pause(): void;
         resume(): void;
         setTimeout(timeout: number, callback?: Function): void;
@@ -757,8 +757,8 @@ declare module "net" {
         maxConnections: number;
         connections: number;
     }
-    export function createServer(connectionListener?: (socket: Socket) =>void ): Server;
-    export function createServer(options?: { allowHalfOpen?: boolean; }, connectionListener?: (socket: Socket) =>void ): Server;
+    export function createServer(connectionListener?: (socket: Socket) => void): Server;
+    export function createServer(options?: { allowHalfOpen?: boolean; }, connectionListener?: (socket: Socket) => void): Server;
     export function connect(options: { allowHalfOpen?: boolean; }, connectionListener?: Function): Socket;
     export function connect(port: number, host?: string, connectionListener?: Function): Socket;
     export function connect(path: string, connectionListener?: Function): Socket;
@@ -831,8 +831,8 @@ declare module "fs" {
         close(): void;
     }
 
-    export interface ReadStream extends stream.Readable {}
-    export interface WriteStream extends stream.Writable {}
+    export interface ReadStream extends stream.Readable { }
+    export interface WriteStream extends stream.Writable { }
 
     export function rename(oldPath: string, newPath: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function renameSync(oldPath: string, newPath: string): void;
@@ -873,8 +873,8 @@ declare module "fs" {
     export function readlink(path: string, callback?: (err: NodeJS.ErrnoException, linkString: string) => any): void;
     export function readlinkSync(path: string): string;
     export function realpath(path: string, callback?: (err: NodeJS.ErrnoException, resolvedPath: string) => any): void;
-    export function realpath(path: string, cache: {[path: string]: string}, callback: (err: NodeJS.ErrnoException, resolvedPath: string) =>any): void;
-    export function realpathSync(path: string, cache?: {[path: string]: string}): string;
+    export function realpath(path: string, cache: { [path: string]: string }, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => any): void;
+    export function realpathSync(path: string, cache?: { [path: string]: string }): string;
     export function unlink(path: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function unlinkSync(path: string): void;
     export function rmdir(path: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
@@ -903,14 +903,14 @@ declare module "fs" {
     export function futimesSync(fd: number, atime: Date, mtime: Date): void;
     export function fsync(fd: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function fsyncSync(fd: number): void;
-    export function write(fd: number, buffer: Buffer|string, offset: number, length: number, position: number, callback?: (err: NodeJS.ErrnoException, written: number, buffer: Buffer) => void): void;
+    export function write(fd: number, buffer: Buffer | string, offset: number, length: number, position: number, callback?: (err: NodeJS.ErrnoException, written: number, buffer: Buffer) => void): void;
     export function writeSync(fd: number, buffer: Buffer, offset: number, length: number, position: number): number;
     export function read(fd: number, buffer: Buffer, offset: number, length: number, position: number, callback?: (err: NodeJS.ErrnoException, bytesRead: number, buffer: Buffer) => void): void;
     export function readSync(fd: number, buffer: Buffer, offset: number, length: number, position: number): number;
     export function readFile(filename: string, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
     export function readFile(filename: string, options: { encoding: string; flag?: string; }, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
     export function readFile(filename: string, options: { flag?: string; }, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
-    export function readFile(filename: string, callback: (err: NodeJS.ErrnoException, data: Buffer) => void ): void;
+    export function readFile(filename: string, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
     export function readFileSync(filename: string, encoding: string): string;
     export function readFileSync(filename: string, options: { encoding: string; flag?: string; }): string;
     export function readFileSync(filename: string, options?: { flag?: string; }): Buffer;
@@ -1050,10 +1050,10 @@ declare module "tls" {
         cleartext: any;
     }
 
-    export function createServer(options: TlsOptions, secureConnectionListener?: (cleartextStream: ClearTextStream) =>void ): Server;
-    export function connect(options: TlsOptions, secureConnectionListener?: () =>void ): ClearTextStream;
-    export function connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () =>void ): ClearTextStream;
-    export function connect(port: number, options?: ConnectionOptions, secureConnectListener?: () =>void ): ClearTextStream;
+    export function createServer(options: TlsOptions, secureConnectionListener?: (cleartextStream: ClearTextStream) => void): Server;
+    export function connect(options: TlsOptions, secureConnectionListener?: () => void): ClearTextStream;
+    export function connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () => void): ClearTextStream;
+    export function connect(port: number, options?: ConnectionOptions, secureConnectListener?: () => void): ClearTextStream;
     export function createSecurePair(credentials?: crypto.Credentials, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
 }
 
@@ -1122,11 +1122,11 @@ declare module "crypto" {
     }
     export function getDiffieHellman(group_name: string): DiffieHellman;
     export function pbkdf2(password: string, salt: string, iterations: number, keylen: number, callback: (err: Error, derivedKey: Buffer) => any): void;
-    export function pbkdf2Sync(password: string, salt: string, iterations: number, keylen: number) : Buffer;
+    export function pbkdf2Sync(password: string, salt: string, iterations: number, keylen: number): Buffer;
     export function randomBytes(size: number): Buffer;
-    export function randomBytes(size: number, callback: (err: Error, buf: Buffer) =>void ): void;
+    export function randomBytes(size: number, callback: (err: Error, buf: Buffer) => void): void;
     export function pseudoRandomBytes(size: number): Buffer;
-    export function pseudoRandomBytes(size: number, callback: (err: Error, buf: Buffer) =>void ): void;
+    export function pseudoRandomBytes(size: number, callback: (err: Error, buf: Buffer) => void): void;
 }
 
 declare module "stream" {
@@ -1157,10 +1157,10 @@ declare module "stream" {
         wrap(oldStream: NodeJS.ReadableStream): NodeJS.ReadableStream;
         push(chunk: any, encoding?: string): boolean;
 
-		// HACK: process.stdin is incorrectly declared as a ReadableStream, instead of as a "tty".ReadStream,
-		// hence the need to add these declarations here.
-		isTTY: boolean;
-		setRawMode(value: boolean):void;
+        // HACK: process.stdin is incorrectly declared as a ReadableStream, instead of as a "tty".ReadStream,
+        // hence the need to add these declarations here.
+        isTTY: boolean;
+        setRawMode(value: boolean): void;
     }
 
     export interface WritableOptions {
@@ -1181,11 +1181,11 @@ declare module "stream" {
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
 
-		// HACK: process.stdout is incorrectly declared as a WritableStream, instead of as a "tty".WriteStream,
-		// hence the need to add these declarations here.
-		rows: number;
-		columns: number;
-		isTTY: boolean;
+        // HACK: process.stdout is incorrectly declared as a WritableStream, instead of as a "tty".WriteStream,
+        // hence the need to add these declarations here.
+        rows: number;
+        columns: number;
+        isTTY: boolean;
     }
 
     export interface DuplexOptions extends ReadableOptions, WritableOptions {
@@ -1206,15 +1206,15 @@ declare module "stream" {
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
 
-		// HACK: process.stdout is incorrectly declared as a WritableStream, instead of as a "tty".WriteStream,
-		// hence the need to add these declarations here.
-		rows: number;
-		columns: number;
-		setRawMode(value: boolean):void;
-		isTTY: boolean;
+        // HACK: process.stdout is incorrectly declared as a WritableStream, instead of as a "tty".WriteStream,
+        // hence the need to add these declarations here.
+        rows: number;
+        columns: number;
+        setRawMode(value: boolean): void;
+        isTTY: boolean;
     }
 
-    export interface TransformOptions extends ReadableOptions, WritableOptions {}
+    export interface TransformOptions extends ReadableOptions, WritableOptions { }
 
     // Note: Transform lacks the _read and _write methods of Readable/Writable.
     export class Transform extends events.EventEmitter implements NodeJS.ReadWriteStream {
@@ -1242,15 +1242,15 @@ declare module "stream" {
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
 
-		// HACK: process.stdout is incorrectly declared as a WritableStream, instead of as a "tty".WriteStream,
-		// hence the need to add these declarations here.
-		rows: number;
-		columns: number;
-		setRawMode(value: boolean):void;
-		isTTY: boolean;
+        // HACK: process.stdout is incorrectly declared as a WritableStream, instead of as a "tty".WriteStream,
+        // hence the need to add these declarations here.
+        rows: number;
+        columns: number;
+        setRawMode(value: boolean): void;
+        isTTY: boolean;
     }
 
-    export class PassThrough extends Transform {}
+    export class PassThrough extends Transform { }
 }
 
 declare module "util" {
@@ -1293,7 +1293,7 @@ declare module "util" {
 }
 
 declare module "assert" {
-    function internal (value: any, message?: string): void;
+    function internal(value: any, message?: string): void;
     module internal {
         export class AssertionError implements Error {
             name: string;
@@ -1303,11 +1303,13 @@ declare module "assert" {
             operator: string;
             generatedMessage: boolean;
 
-            constructor(options?: {message?: string; actual?: any; expected?: any;
-                                  operator?: string; stackStartFunction?: Function});
+            constructor(options?: {
+                message?: string; actual?: any; expected?: any;
+                operator?: string; stackStartFunction?: Function
+            });
 
-			// HACK
-			stack: string;
+            // HACK
+            stack: string;
         }
 
         export function fail(actual?: any, expected?: any, message?: string, operator?: string): void;
@@ -1345,12 +1347,12 @@ declare module "tty" {
     export interface ReadStream extends net.Socket {
         isRaw: boolean;
         setRawMode(mode: boolean): void;
-		isTTY: boolean;
+        isTTY: boolean;
     }
     export interface WriteStream extends net.Socket {
         columns: number;
         rows: number;
-		isTTY: boolean;
+        isTTY: boolean;
     }
 }
 

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -9,7 +9,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		private identifier: string,
 		private $staticConfig: Config.IStaticConfig,
 		private $options: ICommonOptions,
-		private $logcatHelper: Mobile.ILogcatHelper,
+		private $deviceLogService: IDeviceLogService,
 		private $androidProcessService: Mobile.IAndroidProcessService,
 		private $httpClient: Server.IHttpClient,
 		$logger: ILogger) {
@@ -46,8 +46,8 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 				"-c", "android.intent.category.LAUNCHER",
 				"1"]).wait();
 
-			if (!this.$options.justlaunch) {
-				this.$logcatHelper.start(this.identifier);
+			if (!this.$options.justlaunch || this.$options.duration) {
+				this.$deviceLogService.printDeviceLog(this.identifier, this.$options.duration).wait();
 			}
 		}).future<void>()();
 	}

--- a/mobile/android/android-device.ts
+++ b/mobile/android/android-device.ts
@@ -66,11 +66,11 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 		let details: IAndroidDeviceDetails;
 		try {
 			details = this.getDeviceDetails(["getprop"]).wait();
-		} catch(err) {
+		} catch (err) {
 			this.$logger.trace(`Error while calling getprop: ${err.message}`);
 		}
 
-		if(!details || !details.name) {
+		if (!details || !details.name) {
 			// In older CLI versions we are calling cat /system/build.prop to get details.
 			// Keep this logic for compatibility and possibly for devices for which getprop is not working
 			details = this.getDeviceDetails(["cat", "/system/build.prop"]).wait();
@@ -118,9 +118,13 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 	}
 
 	public openDeviceLogStream(): void {
-		if(this.deviceInfo.status === constants.CONNECTED_STATUS) {
+		if (this.deviceInfo.status === constants.CONNECTED_STATUS) {
 			this.$logcatHelper.start(this.identifier);
 		}
+	}
+
+	public closeDeviceLogStream(): void {
+		this.$logcatHelper.stop(this.identifier);
 	}
 
 	private getDeviceDetails(shellCommandArgs: string[]): IFuture<IAndroidDeviceDetails> {
@@ -145,7 +149,7 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 
 	private getIsTablet(details: any): boolean {
 		//version 3.x.x (also known as Honeycomb) is a tablet only version
-		return details && ( _.startsWith(details.release, "3.") || _.includes((details.characteristics || '').toLowerCase(), "tablet") );
+		return details && (_.startsWith(details.release, "3.") || _.includes((details.characteristics || '').toLowerCase(), "tablet"));
 	}
 
 	private getType(): IFuture<string> {

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -37,7 +37,7 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 		private $fs: IFileSystem,
 		private $staticConfig: Config.IStaticConfig,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-		private $logcatHelper: Mobile.ILogcatHelper,
+		private $deviceLogService: IDeviceLogService,
 		private $options: ICommonOptions,
 		private $utils: IUtils,
 		private $injector: IInjector) {
@@ -177,8 +177,8 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 			childProcess = adb.executeShellCommand(["monkey", "-p", appId, "-c", "android.intent.category.LAUNCHER", "1"], androidDebugBridgeCommandOptions).wait();
 			this.$fs.futureFromEvent(childProcess, "close").wait();
 
-			if (!this.$options.justlaunch) {
-				this.$logcatHelper.start(emulatorId);
+			if (!this.$options.justlaunch || this.$options.duration) {
+				this.$deviceLogService.printDeviceLog(emulatorId, this.$options.duration);
 			}
 		}).future<void>()();
 	}

--- a/mobile/android/logcat-helper.ts
+++ b/mobile/android/logcat-helper.ts
@@ -3,6 +3,7 @@ import {DeviceAndroidDebugBridge} from "./device-android-debug-bridge";
 
 export class LogcatHelper implements Mobile.ILogcatHelper {
 	private mapDeviceToLoggingStarted: IDictionary<boolean>;
+	private adbLogCats: IDictionary<any>;
 
 	constructor(private $childProcess: IChildProcess,
 		private $deviceLogProvider: Mobile.IDeviceLogProvider,
@@ -11,6 +12,7 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 		private $injector: IInjector,
 		private $processService: IProcessService) {
 		this.mapDeviceToLoggingStarted = Object.create(null);
+		this.adbLogCats = {};
 	}
 
 	public start(deviceIdentifier: string): void {
@@ -21,6 +23,7 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 			adb.executeCommand(["logcat", "-c"]).wait();
 
 			let adbLogcat = adb.executeCommand(["logcat"], { returnChildProcess: true }).wait();
+			this.adbLogCats[deviceIdentifier] = adbLogcat;
 			let lineStream = byline(adbLogcat.stdout);
 
 			adbLogcat.stderr.on("data", (data: NodeBuffer) => {
@@ -46,6 +49,14 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 			this.$processService.attachToProcessExitSignals(this, adbLogcat.kill);
 
 			this.mapDeviceToLoggingStarted[deviceIdentifier] = true;
+		}
+	}
+
+	public stop(deviceIdentifier: string): void {
+		let adbLogcat = this.adbLogCats[deviceIdentifier];
+		if (adbLogcat) {
+			adbLogcat.kill();
+			delete this.adbLogCats[deviceIdentifier];
 		}
 	}
 }

--- a/mobile/ios/device/ios-device.ts
+++ b/mobile/ios/device/ios-device.ts
@@ -21,7 +21,7 @@ export class IOSDevice implements Mobile.IiOSDevice {
 	public deviceInfo: Mobile.IDeviceInfo;
 
 	private mountImageCallbackPtr: NodeBuffer = null;
-	private iOSSystemLog: any;
+	private iOSSystemLog: iOSProxyServices.IOSSyslog;
 
 	private _socket: net.Socket;
 

--- a/mobile/ios/device/ios-proxy-services.ts
+++ b/mobile/ios/device/ios-proxy-services.ts
@@ -82,7 +82,7 @@ export class AfcFile extends AfcBase implements Mobile.IAfcFile {
 			this.$mobileDevice.afcFileRefRead(this.afcConnection, this.afcFile, data, readLengthRef);
 		});
 
-		if(result !== 0) {
+		if (result !== 0) {
 			this.$errors.fail("Unable to read data from file '%s'. Result is: '%s'", this.afcFile, result);
 		}
 
@@ -138,7 +138,7 @@ export class AfcClient extends AfcBase implements Mobile.IAfcClient {
 	}
 
 	public open(path: string, mode: string): Mobile.IAfcFile {
-		return this.$injector.resolve(AfcFile, {path: path, mode: mode, afcConnection: this.afcConnection});
+		return this.$injector.resolve(AfcFile, { path: path, mode: mode, afcConnection: this.afcConnection });
 	}
 
 	public mkdir(path: string) {
@@ -195,11 +195,11 @@ export class AfcClient extends AfcBase implements Mobile.IAfcClient {
 	}
 
 	public transfer(localFilePath: string, devicePath: string): IFuture<void> {
-		return(() => {
+		return (() => {
 			let future = new Future<void>();
 			try {
 				this.ensureDevicePathExist(path.dirname(devicePath));
-				let reader = this.$fs.createReadStream(localFilePath, { bufferSize: 1024*1024*15, highWaterMark: 1024*1024*15 });
+				let reader = this.$fs.createReadStream(localFilePath, { bufferSize: 1024 * 1024 * 15, highWaterMark: 1024 * 1024 * 15 });
 				devicePath = helpers.fromWindowsRelativePathToUnix(devicePath);
 
 				this.deleteFile(devicePath);
@@ -217,8 +217,8 @@ export class AfcClient extends AfcBase implements Mobile.IAfcClient {
 						target.write(data, data.length);
 						this.$logger.trace("transfer-> localFilePath: '%s', devicePath: '%s', localFilePathSize: '%s', transferred bytes: '%s'",
 							localFilePath, devicePath, localFilePathSize.toString(), data.length.toString());
-					} catch(err) {
-						if(err.message.indexOf("Result is: '21'") !== -1) {
+					} catch (err) {
+						if (err.message.indexOf("Result is: '21'") !== -1) {
 							// Error code 21 is kAFCInterruptedError. It looks like in most cases it is raised during package transfer.
 							// However ignoring this error, does not prevent the application from installing and working correctly.
 							this.$logger.warn(err.message);
@@ -235,13 +235,13 @@ export class AfcClient extends AfcBase implements Mobile.IAfcClient {
 				reader.on("end", () => target.close());
 
 				reader.on("close", () => {
-					if(!future.isResolved()) {
+					if (!future.isResolved()) {
 						future.return();
 					}
 				});
 			} catch (err) {
 				this.$logger.trace("Error while transferring files. Error is: ", err);
-				if(!future.isResolved()) {
+				if (!future.isResolved()) {
 					future.throw(err);
 				}
 			}
@@ -270,10 +270,10 @@ export class InstallationProxyClient {
 		private $injector: IInjector,
 		private $errors: IErrors) { }
 
-	public deployApplication(packageFile: string) : IFuture<void>  {
-		return(() => {
+	public deployApplication(packageFile: string): IFuture<void> {
+		return (() => {
 			let service = this.device.startService(MobileServices.APPLE_FILE_CONNECTION);
-			let afcClient = this.$injector.resolve(AfcClient, {service: service});
+			let afcClient = this.$injector.resolve(AfcClient, { service: service });
 			let devicePath = path.join("PublicStaging", path.basename(packageFile));
 
 			afcClient.transferPackage(packageFile, devicePath).wait();
@@ -293,7 +293,7 @@ export class InstallationProxyClient {
 			this.plistService.sendMessage(message);
 
 			let response = this.plistService.receiveMessage().wait();
-			if(response.Error) {
+			if (response.Error) {
 				this.$errors.failWithoutHelp(response.Error);
 			}
 
@@ -309,7 +309,7 @@ export class InstallationProxyClient {
 
 	private getPlistService(): Mobile.IiOSDeviceSocket {
 		let service = this.getInstallationService();
-		return this.$injector.resolve(iOSCore.PlistService, { service: service,  format: iOSCore.CoreTypes.kCFPropertyListBinaryFormat_v1_0 });
+		return this.$injector.resolve(iOSCore.PlistService, { service: service, format: iOSCore.CoreTypes.kCFPropertyListBinaryFormat_v1_0 });
 	}
 
 	private getInstallationService(): number {
@@ -460,7 +460,7 @@ export class HouseArrestClient implements Mobile.IHouseArrestClient {
 
 	private getAfcClientCore(command: string, applicationIdentifier: string): Mobile.IAfcClient {
 		let service = this.device.startService(MobileServices.HOUSE_ARREST);
-		this.plistService = this.$injector.resolve(iOSCore.PlistService, {service: service, format: iOSCore.CoreTypes.kCFPropertyListXMLFormat_v1_0});
+		this.plistService = this.$injector.resolve(iOSCore.PlistService, { service: service, format: iOSCore.CoreTypes.kCFPropertyListXMLFormat_v1_0 });
 
 		this.plistService.sendMessage({
 			"Command": command,
@@ -468,11 +468,11 @@ export class HouseArrestClient implements Mobile.IHouseArrestClient {
 		});
 
 		let response = this.plistService.receiveMessage().wait();
-		if(response.Error) {
+		if (response.Error) {
 			this.$errors.failWithoutHelp(HouseArrestClient.PREDEFINED_ERRORS[response.Error] || response.Error);
 		}
 
-		return this.$injector.resolve(AfcClient, {service: service});
+		return this.$injector.resolve(AfcClient, { service: service });
 	}
 
 	public getAfcClientForAppContainer(applicationIdentifier: string): Mobile.IAfcClient {
@@ -492,13 +492,23 @@ export class IOSSyslog {
 		private $injector: IInjector,
 		private $deviceLogProvider: Mobile.IDeviceLogProvider,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
-		this.plistService = this.$injector.resolve(iOSCore.PlistService, {service: this.device.startService(MobileServices.SYSLOG), format: undefined});
+		this.plistService = this.$injector.resolve(iOSCore.PlistService, { service: this.device.startService(MobileServices.SYSLOG), format: undefined });
 	}
 
 	public read(): void {
 		let printData = (data: string) => {
 			this.$deviceLogProvider.logData(data, this.$devicePlatformsConstants.iOS, this.device.deviceInfo.identifier);
 		};
+
+		if (!this.plistService) {
+			throw new Error("Cannot read system logs after the socket was closed.");
+		}
+
 		this.plistService.readSystemLog(printData);
+	}
+
+	public close(): void {
+		this.plistService.close();
+		this.plistService = null;
 	}
 }

--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -9,7 +9,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		private $options: ICommonOptions,
 		private $fs: IFileSystem,
 		private $bplistParser: IBinaryPlistParser,
-		private $iOSSimulatorLogProvider: Mobile.IiOSSimulatorLogProvider,
+		private $deviceLogService: IDeviceLogService,
 		private $deviceLogProvider: Mobile.IDeviceLogProvider,
 		$logger: ILogger) {
 		super($logger);
@@ -43,10 +43,10 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		return (() => {
 			let launchResult = this.iosSim.startApplication(this.identifier, appIdentifier).wait();
 
-			if (!this.$options.justlaunch) {
+			if (!this.$options.justlaunch || this.$options.duration) {
 				let pid = launchResult.split(":")[1].trim();
 				this.$deviceLogProvider.setApplictionPidForDevice(this.identifier, pid);
-				this.$iOSSimulatorLogProvider.startLogProcess(this.identifier);
+				this.$deviceLogService.printDeviceLog(this.identifier, this.$options.duration).wait();
 			}
 
 		}).future<void>()();

--- a/mobile/ios/simulator/ios-simulator-device.ts
+++ b/mobile/ios/simulator/ios-simulator-device.ts
@@ -53,7 +53,7 @@ export class IOSSimulator implements Mobile.IiOSSimulator {
 	}
 
 	public openDeviceLogStream(): void {
-		this.$iOSSimulatorLogProvider.startLogProcess(this.simulator.id);
+		this._deviceLogStreamChildProcess = this.$iOSSimulatorLogProvider.startLogProcess(this.simulator.id);
 	}
 
 	public closeDeviceLogStream(): void {

--- a/mobile/ios/simulator/ios-simulator-device.ts
+++ b/mobile/ios/simulator/ios-simulator-device.ts
@@ -5,6 +5,7 @@ import * as constants from "../../../constants";
 export class IOSSimulator implements Mobile.IiOSSimulator {
 	private _applicationManager: Mobile.IDeviceApplicationManager;
 	private _fileSystem: Mobile.IDeviceFileSystem;
+	private _deviceLogStreamChildProcess: any;
 
 	constructor(private simulator: Mobile.IiSimDevice,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
@@ -53,5 +54,12 @@ export class IOSSimulator implements Mobile.IiOSSimulator {
 
 	public openDeviceLogStream(): void {
 		this.$iOSSimulatorLogProvider.startLogProcess(this.simulator.id);
+	}
+
+	public closeDeviceLogStream(): void {
+		if (this._deviceLogStreamChildProcess) {
+			this._deviceLogStreamChildProcess.kill();
+			this._deviceLogStreamChildProcess = null;
+		}
 	}
 }

--- a/options.ts
+++ b/options.ts
@@ -76,6 +76,7 @@ export class OptionsBase {
 			var: { type: OptionType.Object },
 			default: { type: OptionType.Boolean },
 			count: { type: OptionType.Number },
+			duration: { type: OptionType.Number },
 			hooks: { type: OptionType.Boolean, default: true }
 		};
 	}

--- a/services/device-log-service.ts
+++ b/services/device-log-service.ts
@@ -1,0 +1,36 @@
+import Future = require("fibers/future");
+import * as fiberBootstrap from "../fiber-bootstrap";
+
+export class DeviceLogService implements IDeviceLogService {
+	constructor(private $deviceLogProvider: Mobile.IDeviceLogProvider,
+		private $loggingLevels: Mobile.ILoggingLevels,
+		private $devicesService: Mobile.IDevicesService) { }
+
+	public printDeviceLog(deviceId: string, duration?: number): IFuture<void> {
+		return (() => {
+			this.$devicesService.initialize({ deviceId, skipInferPlatform: true }).wait();
+			this.$deviceLogProvider.setLogLevel(this.$loggingLevels.full);
+
+			if (duration) {
+				this.printDeviceLogCore().wait();
+				setTimeout(() => {
+					fiberBootstrap.run(() => {
+						let action = (device: Mobile.IDevice) => Future.fromResult(device.closeDeviceLogStream());
+						this.$devicesService.execute(action).wait();
+					});
+				}, duration);
+			} else {
+				this.printDeviceLogCore().wait();
+			}
+		}).future<void>()();
+	}
+
+	private printDeviceLogCore(): IFuture<void> {
+		return (() => {
+			let action = (device: Mobile.IDevice) => Future.fromResult(device.openDeviceLogStream());
+			this.$devicesService.execute(action).wait();
+		}).future<void>()();
+	}
+}
+
+$injector.register("deviceLogService", DeviceLogService);


### PR DESCRIPTION
Since the device log command does not end unless the process is killed by the user we need to provide a way to execute it for specific duration.
This way it can be used in tests without blocking them.

Merge after https://github.com/telerik/ios-sim-portable/pull/76 is merged.
