### PR TITLE
Remove redundant code for validation of AndroidManifest vs config.xml

### DIFF
--- a/appbuilder/project/project-base.ts
+++ b/appbuilder/project/project-base.ts
@@ -7,7 +7,6 @@ export abstract class ProjectBase implements Project.IProjectBase {
 	private static VALID_CONFIGURATION_CHARACTERS_REGEX = "[-_A-Za-z0-9]";
 	private static CONFIGURATION_FROM_FILE_NAME_REGEX = new RegExp(`^[.](${ProjectBase.VALID_CONFIGURATION_CHARACTERS_REGEX}+?)[.]abproject$`, "i");
 	private static ANDROID_MANIFEST_NAME = "AndroidManifest.xml";
-	private static CONFIG_XML_NAME = "config.xml";
 	private static APP_IDENTIFIER_PLACEHOLDER = "$AppIdentifier$";
 
 	private _platformSpecificAppIdentifier: string;
@@ -98,19 +97,8 @@ export abstract class ProjectBase implements Project.IProjectBase {
 					let pathToAndroidManifest = path.join(pathToAndroidResources, ProjectBase.ANDROID_MANIFEST_NAME);
 					let appIdentifierInAndroidManifest = this.getAppIdentifierFromConfigFile(pathToAndroidManifest, /package\s*=\s*"(\S*)"/).wait();
 
-					let pathToConfigXml = path.join(pathToAndroidResources, "xml", ProjectBase.CONFIG_XML_NAME);
-
-					let appIdentifierInConfigXml = this.getAppIdentifierFromConfigFile(pathToConfigXml, /id\s*=\s*"(\S*)"/).wait();
-
-					let appId = appIdentifierInAndroidManifest || appIdentifierInConfigXml;
-					let changedId = !appIdentifierInAndroidManifest || appIdentifierInAndroidManifest === ProjectBase.APP_IDENTIFIER_PLACEHOLDER ? appIdentifierInConfigXml : appIdentifierInAndroidManifest;
-
-					if ((appIdentifierInAndroidManifest && appIdentifierInConfigXml) &&
-						(appIdentifierInAndroidManifest === appIdentifierInConfigXml) &&
-						(appId !== ProjectBase.APP_IDENTIFIER_PLACEHOLDER)) {
+					if (appIdentifierInAndroidManifest && appIdentifierInAndroidManifest !== ProjectBase.APP_IDENTIFIER_PLACEHOLDER) {
 						this._platformSpecificAppIdentifier = appIdentifierInAndroidManifest;
-					} else if (changedId && changedId !== ProjectBase.APP_IDENTIFIER_PLACEHOLDER && changedId !== this.projectData.AppIdentifier) {
-						this.$errors.failWithoutHelp(`Your package in ${ProjectBase.ANDROID_MANIFEST_NAME} and id in ${ProjectBase.CONFIG_XML_NAME} do not match. They must be the same to be able to build your application.`);
 					}
 				}
 			}


### PR DESCRIPTION
The application identifier written in AndroidManifest is the single source of truth. Ignore the one in config.xml - server will take care of it.
Part of [Set id property in android's config xml automatically](http://teampulse.telerik.com/view#item/320940)

Merge along with https://github.com/Icenium/Ice/pull/6234