### PR TITLE
Fix get plugin author

### DIFF
--- a/services/plugins/npm-registry-plugins-source.ts
+++ b/services/plugins/npm-registry-plugins-source.ts
@@ -43,7 +43,7 @@ export class NpmRegistryPluginsSource extends PluginsSourceBase implements IPlug
 				return null;
 			}
 
-			result.author = result.author.name || result.author;
+			result.author = (result.author && result.author.name) || result.author;
 			return result;
 		}).future<IBasicPluginInformation>()();
 	}


### PR DESCRIPTION
When we get the author of the plugin first we need to check if there is one.