### PR TITLE
Fix get first page plugins trom npmjs twice

### DIFF
--- a/services/plugins/npmjs-plugins-source.ts
+++ b/services/plugins/npmjs-plugins-source.ts
@@ -62,7 +62,7 @@ export class NpmjsPluginsSource extends PluginsSourceBase implements IPluginsSou
 			let result: IBasicPluginInformation[] = [];
 
 			let currentPluginsFound: IBasicPluginInformation[] = [];
-			let page = 0;
+			let page = 1;
 
 			do {
 				currentPluginsFound = this.getPluginsFromNpmjs(this._keywords, page++).wait();


### PR DESCRIPTION
When we get the plugins from http://npmjs.org we need to start from page 1 not from page 0 because page 1 and page 0 are the same.