### PR TITLE
Use rimraf to remove tns-core-modules

### DIFF
--- a/definitions/rimraf.d.ts
+++ b/definitions/rimraf.d.ts
@@ -1,5 +1,9 @@
 declare module "rimraf" {
-	function rmdir(path: string, callback: (error: Error) => void): void;
-	function sync(path: string): void;
-	export = rmdir;
+	function rimraf(path: string, callback: (error: Error) => void): void;
+	namespace rimraf {
+		export function sync(path: string): void;
+		export var EMFILE_MAX: number;
+		export var BUSYTRIES_MAX: number;
+	}
+	export = rimraf;
 }


### PR DESCRIPTION
When we migrate TS project and we remove the tns-core-modules we use the shelljs to remove the directory but there is some bug when using it - it fails to delete some of the subdirecotries. Thet's why we will use rimraf instead of shelljs.

Related to: https://github.com/Icenium/icenium-cli/pull/1553