### PR TITLE
Kill the process for iOS Simulator logs on SIGINT

### DIFF
--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -2,6 +2,7 @@ import {ApplicationManagerBase} from "../../application-manager-base";
 import Future = require("fibers/future");
 import * as path from "path";
 import * as temp from "temp";
+import { ChildProcess } from "child_process";
 
 export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 	constructor(private iosSim: any,
@@ -9,6 +10,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		private $options: ICommonOptions,
 		private $fs: IFileSystem,
 		private $bplistParser: IBinaryPlistParser,
+		private $processService: IProcessService,
 		$logger: ILogger) {
 		super($logger);
 	}
@@ -41,7 +43,8 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		return (() => {
 			let launchResult = this.iosSim.startApplication(this.identifier, appIdentifier).wait();
 			if (!this.$options.justlaunch) {
-				this.iosSim.printDeviceLog(this.identifier, launchResult);
+				let childProcess: ChildProcess = this.iosSim.printDeviceLog(this.identifier, launchResult);
+				this.$processService.attachToProcessExitSignals(this, childProcess.kill);
 			}
 
 		}).future<void>()();

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gaze": "1.0.0",
     "iconv-lite": "0.4.3",
     "inquirer": "0.8.2",
-    "ios-sim-portable": "~1.1.4",
+    "ios-sim-portable": "~1.4.0",
     "lodash": "4.13.1",
     "log4js": "0.6.9",
     "marked": "0.3.3",


### PR DESCRIPTION
On some Mac OS machines, the process for reading iOS Simulator logs does not die when Ctrl + C is used. So CLI's process cannot die as well and Ctrl + Z should be used. However the processes for reading logs remain alive and zombies.
Make sure to kill the process on SIGINT, SIGTERM, etc. This way CLI's process should die as well.

Use new version of ios-sim-portable, where the child process is returned to the CLI, so we can kill it later.