### PR TITLE
Keep the current indentation of json files

### DIFF
--- a/services/user-settings-service.ts
+++ b/services/user-settings-service.ts
@@ -41,7 +41,7 @@ export class UserSettingsServiceBase implements IUserSettingsService {
 					this.userSettingsData[propertyName] = data[propertyName];
 				});
 
-			this.$fs.writeJson(this.userSettingsFilePath, this.userSettingsData, "\t").wait();
+			this.$fs.writeJson(this.userSettingsFilePath, this.userSettingsData).wait();
 		}).future<void>()();
 	}
 

--- a/test/unit-tests/mobile/android-device-file-system.ts
+++ b/test/unit-tests/mobile/android-device-file-system.ts
@@ -146,6 +146,7 @@ describe("Android device file system tests", () => {
 				isDirectory: () => false,
 				isFile: () => true
 			});
+			fs.readText = () => Future.fromResult("");
 
 			let androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
 			androidDeviceFileSystem.transferFile = (localPath: string, devicePath: string) => {
@@ -173,6 +174,7 @@ describe("Android device file system tests", () => {
 				isDirectory: () => false,
 				isFile: () => true
 			});
+			fs.readText = () => Future.fromResult("");
 
 			let androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
 			let transferedFilesOnDevice: string[] = [];
@@ -206,6 +208,7 @@ describe("Android device file system tests", () => {
 				isDirectory: () => false,
 				isFile: () => true
 			});
+			fs.readText = () => Future.fromResult("");
 
 			let androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
 			androidDeviceFileSystem.transferFile = (localPath: string, devicePath: string) => {
@@ -233,6 +236,7 @@ describe("Android device file system tests", () => {
 				isDirectory: () => false,
 				isFile: () => true
 			});
+			fs.readText = () => Future.fromResult("");
 
 			let androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
 			androidDeviceFileSystem.transferFile = (localPath: string, devicePath: string) => {


### PR DESCRIPTION
Since our other clients use 2 spaces for indentation in json files we should use 2 spaces too. Since some users are using only the CLI we should not change their current indentation.