### PR TITLE
Transpile TS files on file change in livesync

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -433,6 +433,13 @@ interface ITypeScriptService {
 	 * @return {IFuture<boolean>} true when the project contains .ts files and false otherwise.
 	 */
 	isTypeScriptProject(projectDir: string): IFuture<boolean>;
+
+	/**
+	 * Checks if the file is TypeScript file.
+	 * @param {string} file The file name.
+	 * @return {boolean} true when the file is TypeScript file.
+	 */
+	isTypeScriptFile(file: string): boolean;
 }
 
 interface IDynamicHelpService {

--- a/services/livesync-service-base.ts
+++ b/services/livesync-service-base.ts
@@ -60,7 +60,6 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 				fiberBootstrap.run(() => {
 					that.$dispatcher.dispatch(() => (() => {
 						try {
-
 							if (filePath.indexOf(constants.APP_RESOURCES_FOLDER_NAME) !== -1) {
 								that.$logger.warn(`Skipping livesync for changed file ${filePath}. This change requires a full build to update your application. `.yellow.bold);
 								return;

--- a/services/livesync/sync-batch.ts
+++ b/services/livesync/sync-batch.ts
@@ -4,12 +4,16 @@ import * as fiberBootstrap from "../../fiber-bootstrap";
 export const SYNC_WAIT_THRESHOLD = 250; //milliseconds
 
 export class SyncBatch {
+	private _isTypeScriptProject: boolean;
+	private hasCheckedProjectType: boolean;
 	private timer: NodeJS.Timer = null;
 	private syncQueue: string[] = [];
 	private syncInProgress: boolean = false;
 
 	constructor(private $logger: ILogger,
 		private $projectFilesManager: IProjectFilesManager,
+		private $project: Project.IProjectBase,
+		private $typeScriptService: ITypeScriptService,
 		private done: () => IFuture<void>) { }
 
 	private get filesToSync(): string[] {
@@ -23,6 +27,16 @@ export class SyncBatch {
 
 	public syncFiles(syncAction: (filesToSync: string[]) => IFuture<void>): IFuture<void> {
 		return (() => {
+			if (this.isTypeScriptProject().wait()) {
+				// We need to remove the TypeScript files from the sync queue because if we don't remove them we will run the transpilation twice.
+				let typeScriptFiles = _.remove(this.syncQueue, this.$typeScriptService.isTypeScriptFile);
+
+				// Check if there are any TypeScript files because if the array is empty the transpile method will transpile the whole project.
+				if (typeScriptFiles.length) {
+					this.$typeScriptService.transpile(this.$project.projectDir, typeScriptFiles).wait();
+				}
+			}
+
 			if (this.filesToSync.length > 0) {
 				syncAction(this.filesToSync).wait();
 				this.reset();
@@ -58,5 +72,16 @@ export class SyncBatch {
 
 	private reset(): void {
 		this.syncQueue = [];
+	}
+
+	private isTypeScriptProject(): IFuture<boolean> {
+		return ((): boolean => {
+			if (!this.hasCheckedProjectType) {
+				this.hasCheckedProjectType = true;
+				this._isTypeScriptProject = this.$typeScriptService.isTypeScriptProject(this.$project.projectDir).wait();
+			}
+
+			return this._isTypeScriptProject;
+		}).future<boolean>()();
 	}
 }


### PR DESCRIPTION
When we run the livesync command with the --watch flag the .ts files are not transpiled and there are no new .js files to sync to the device. We should transpile the .ts files before we get the files to sync and remove the .ts files from the sync queue to avoid transpiling twice.

Fixes: http://teampulse.telerik.com/view#item/322155