### PR TITLE
Respect npm settings - proxy and registry

### DIFF
--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -3,17 +3,20 @@ import * as os from "os";
 import * as constants from "../../constants";
 import { fromWindowsRelativePathToUnix } from "../../helpers";
 import { exportedPromise } from "../../decorators";
+import * as url from "url";
 
 export class NpmService implements INpmService {
 	private static NPM_MODULE_NAME = "npm";
 	private static TYPES_DIRECTORY = "@types/";
 	private static TNS_CORE_MODULES_DEFINITION_FILE_NAME = `${constants.TNS_CORE_MODULES}${constants.FileExtensions.TYPESCRIPT_DEFINITION_FILE}`;
-	private static NPM_REGISTRY_URL = "https://registry.npmjs.org";
+	private static NPM_REGISTRY_URL = "http://registry.npmjs.org";
 	private static SCOPED_DEPENDENCY_REGEXP = /^(@.+?)(?:@(.+?))?$/;
 	private static DEPENDENCY_REGEXP = /^(.+?)(?:@(.+?))?$/;
 
 	private _npmExecutableName: string;
 	private _npmBinary: string;
+	private _proxySettings: IProxySettings;
+	private _hasCheckedNpmProxy = false;
 
 	constructor(private $childProcess: IChildProcess,
 		private $errors: IErrors,
@@ -170,7 +173,7 @@ export class NpmService implements INpmService {
 			try {
 				let url = this.buildNpmRegistryUrl(packageName, version);
 				// This call will return error with message '{}' in case there's no such package.
-				let result = this.$httpClient.httpRequest(url).wait().body;
+				let result = this.$httpClient.httpRequest(url, this.getNpmProxySettings().wait()).wait().body;
 				packageJsonContent = JSON.parse(result);
 			} catch (err) {
 				this.$logger.trace("Error caught while checking the NPM Registry for plugin with id: %s", packageName);
@@ -319,6 +322,32 @@ export class NpmService implements INpmService {
 
 	private executeNpmCommandCore(projectDir: string, npmArguments: string[]): IFuture<ISpawnResult> {
 		return this.$childProcess.spawnFromEvent(this.npmExecutableName, npmArguments, "close", { cwd: projectDir });
+	}
+
+	private getNpmProxySettings(): IFuture<IProxySettings> {
+		return ((): IProxySettings => {
+			if (!this._hasCheckedNpmProxy) {
+				try {
+					let npmProxy = (this.$childProcess.exec("npm config get proxy").wait() || "").toString();
+
+					if (npmProxy) {
+						let uri = url.parse(npmProxy);
+						this._proxySettings = {
+							hostname: uri.hostname,
+							port: uri.port
+						};
+					}
+				} catch (err) {
+					this.$logger.trace(`Unable to get npm proxy configuration. Error is: ${err.message}.`);
+				}
+
+				this.$logger.trace("Npm proxy is: hostname: " + this._proxySettings.hostname + " port: " + this._proxySettings.port);
+
+				this._hasCheckedNpmProxy = true;
+			}
+
+			return this._proxySettings;
+		}).future<IProxySettings>()();
 	}
 }
 $injector.register("npmService", NpmService);

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -113,7 +113,7 @@ declare module Server {
 
 	interface IHttpClient {
 		httpRequest(url: string): IFuture<IResponse>;
-		httpRequest(options: any): IFuture<IResponse>;
+		httpRequest(options: any, proxySettings?: IProxySettings): IFuture<IResponse>;
 	}
 
 	interface IRequestResponseData {
@@ -1346,4 +1346,19 @@ interface ITypeScriptTranspileOptions {
 	 * Use the typescript compiler which is installed localy for the project.
 	 */
 	useLocalTypeScriptCompiler?: boolean;
+}
+
+/**
+ * Proxy settings required for http request.
+ */
+interface IProxySettings {
+	/**
+	 * Hostname of the machine used for proxy.
+	 */
+	hostname: string;
+
+	/**
+	 * Port of the machine used for proxy that allows connections.
+	 */
+	port: string;
 }

--- a/http-client.ts
+++ b/http-client.ts
@@ -13,7 +13,7 @@ export class HttpClient implements Server.IHttpClient {
 		private $staticConfig: Config.IStaticConfig,
 		private $config: Config.IConfig) {}
 
-	httpRequest(options: any): IFuture<Server.IResponse> {
+	httpRequest(options: any, proxySettings?: IProxySettings): IFuture<Server.IResponse> {
 		return (() => {
 			if (_.isString(options)) {
 				options = {
@@ -48,11 +48,11 @@ export class HttpClient implements Server.IHttpClient {
 			options.headers = options.headers || {};
 			let headers = options.headers;
 
-			if(this.$config.USE_PROXY) {
+			if(proxySettings || this.$config.USE_PROXY) {
 				options.path = requestProto + "://" + options.host + options.path;
 				headers.Host = options.host;
-				options.host = this.$config.PROXY_HOSTNAME;
-				options.port = this.$config.PROXY_PORT;
+				options.host = proxySettings.hostname || this.$config.PROXY_HOSTNAME;
+				options.port = proxySettings.port || this.$config.PROXY_PORT;
 				this.$logger.trace("Using proxy with host: %s, port: %d, path is: %s", options.host, options.port, options.path);
 			}
 


### PR DESCRIPTION
Use npm proxy for connections to registry.npmjs.org. This way in case the user has set a proxy, we'll use it.

CLI makes calls to registry.npmjs.org. But the users can configure different registry (`npm config set registry <...>`), so CLI should respect it instead of calls to `registry.npmjs.org`.