### PR TITLE
Do not use proxy when npm config returns null

### DIFF
--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -358,7 +358,8 @@ export class NpmService implements INpmService {
 				try {
 					let npmProxy = (this.$childProcess.exec("npm config get proxy").wait() || "").toString().trim();
 
-					if (npmProxy) {
+					// npm will return null as string in case there's no proxy set.
+					if (npmProxy && npmProxy !== "null") {
 						let uri = url.parse(npmProxy);
 						this._proxySettings = {
 							hostname: uri.hostname,
@@ -369,7 +370,7 @@ export class NpmService implements INpmService {
 					this.$logger.trace(`Unable to get npm proxy configuration. Error is: ${err.message}.`);
 				}
 
-				this.$logger.trace("Npm proxy is: hostname: " + this._proxySettings.hostname + " port: " + this._proxySettings.port);
+				this.$logger.trace("Npm proxy is: ", this._proxySettings);
 
 				this._hasCheckedNpmProxy = true;
 			}

--- a/http-client.ts
+++ b/http-client.ts
@@ -51,8 +51,8 @@ export class HttpClient implements Server.IHttpClient {
 			if(proxySettings || this.$config.USE_PROXY) {
 				options.path = requestProto + "://" + options.host + options.path;
 				headers.Host = options.host;
-				options.host = proxySettings.hostname || this.$config.PROXY_HOSTNAME;
-				options.port = proxySettings.port || this.$config.PROXY_PORT;
+				options.host = (proxySettings && proxySettings.hostname) || this.$config.PROXY_HOSTNAME;
+				options.port = (proxySettings && proxySettings.port) || this.$config.PROXY_PORT;
 				this.$logger.trace("Using proxy with host: %s, port: %d, path is: %s", options.host, options.port, options.path);
 			}
 


### PR DESCRIPTION
In case there's no npm proxy, `npm config get proxy` returns string "null" and we think this is the proxy.
This leads to incorrect calls to registry.npmjs.org.