### PR TITLE
Add timeout to http request and use it for calls to npm registry

### DIFF
--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -169,12 +169,15 @@ export class NpmService implements INpmService {
 
 	public getPackageJsonFromNpmRegistry(packageName: string, version?: string): IFuture<any> {
 		return (() => {
+			const timeout = 6000;
 			let packageJsonContent: any;
 			version = version || "latest";
 			try {
-				let url = this.buildNpmRegistryUrl(packageName, version).wait();
+				let url = this.buildNpmRegistryUrl(packageName, version).wait(),
+					proxySettings = this.getNpmProxySettings().wait();
+
 				// This call will return error with message '{}' in case there's no such package.
-				let result = this.$httpClient.httpRequest(url, this.getNpmProxySettings().wait()).wait().body;
+				let result = this.$httpClient.httpRequest({ url, timeout }, proxySettings).wait().body;
 				packageJsonContent = JSON.parse(result);
 			} catch (err) {
 				this.$logger.trace("Error caught while checking the NPM Registry for plugin with id: %s", packageName);


### PR DESCRIPTION
Add timeout option to http request which defines the time that we'll wait for response.
In case there's no response, the call will throw error.
Set timeout of 6000 for calls to registry.npmjs.org.