### PR TITLE
Fix getting ios simulator device logs

### DIFF
--- a/appbuilder/device-log-provider.ts
+++ b/appbuilder/device-log-provider.ts
@@ -7,7 +7,7 @@ export class DeviceLogProvider extends DeviceLogProviderBase {
 	}
 
 	public logData(line: string, platform: string, deviceIdentifier: string): void {
-		let logLevel = this.setLogLevelForDevice(deviceIdentifier);
+		let logLevel = this.setDefaultLogLevelForDevice(deviceIdentifier);
 
 		let applicationPid = this.getApplicationPidForDevice(deviceIdentifier),
 			data = this.$logFilter.filterData(platform, line, applicationPid, logLevel);
@@ -19,12 +19,11 @@ export class DeviceLogProvider extends DeviceLogProviderBase {
 
 	public setLogLevel(logLevel: string, deviceIdentifier?: string): void {
 		if (deviceIdentifier) {
-			this.devicesLogOptions[deviceIdentifier] = this.devicesLogOptions[deviceIdentifier] || <Mobile.IDeviceLogOptions> { };
-			this.devicesLogOptions[deviceIdentifier].logLevel = logLevel.toUpperCase();
+			this.setDeviceLogOptionsProperty(deviceIdentifier, (deviceLogOptions: Mobile.IDeviceLogOptions) => deviceLogOptions.logLevel, logLevel.toUpperCase());
 		} else {
 			this.$logFilter.loggingLevel = logLevel.toUpperCase();
 
-			_.each(this.devicesLogOptions, (deviceLogLevel: string, deviceId: string) => {
+			_.keys(this.devicesLogOptions).forEach(deviceId => {
 				this.devicesLogOptions[deviceId] = this.devicesLogOptions[deviceId] || <Mobile.IDeviceLogOptions> { };
 				this.devicesLogOptions[deviceId].logLevel = this.$logFilter.loggingLevel;
 			});

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -82,6 +82,7 @@ $injector.require("adb", "./mobile/android/android-debug-bridge");
 $injector.require("androidDebugBridgeResultHandler", "./mobile/android/android-debug-bridge-result-handler");
 $injector.require("logcatHelper", "./mobile/android/logcat-helper");
 $injector.require("iOSSimResolver", "./mobile/ios/simulator/ios-sim-resolver");
+$injector.require("iOSSimulatorLogProvider", "./mobile/ios/simulator/ios-simulator-log-provider");
 
 $injector.require("localToDevicePathDataFactory", "./mobile/local-to-device-path-data-factory");
 $injector.require("deviceAppDataFactory", "./mobile/device-app-data/device-app-data-factory");

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -170,7 +170,7 @@ declare module Mobile {
 	/**
 	 * Describes different options for filtering device logs.
 	 */
-	interface IDeviceLogOptions {
+	interface IDeviceLogOptions extends IStringDictionary {
 		/**
 		 * Process id of the application on the device.
 		 */

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -139,9 +139,58 @@ declare module Mobile {
 		start(deviceIdentifier: string): void;
 	}
 
+	/**
+	 * Describes methods for providing device logs to a specific consumer.
+	 */
 	interface IDeviceLogProvider {
+		/**
+		 * Logs data in the specific way for the consumer.
+		 * @param {string} line String from the device logs.
+		 * @param {string} platform The platform of the device (for example iOS or Android).
+		 * @param {string} deviceIdentifier The unique identifier of the device.
+		 * @returns {void}
+		 */
 		logData(line: string, platform: string, deviceIdentifier: string): void;
+
+		/**
+		 * Sets the level of logging that will be used.
+		 * @param {string} level The level of logs - could be INFO or FULL.
+		 * @param {string} deviceIdentifier @optional The unique identifier of the device. When it is passed, only it's logging level is changed.
+		 */
 		setLogLevel(level: string, deviceIdentifier?: string): void;
+
+		/**
+		 * Sets the PID of the application on the specified device.
+		 * @param {string} deviceIdentifier The unique identifier of the device.
+		 * @param {string} pid The Process ID of the currently running application for which we need the logs.
+		 */
+		setApplictionPidForDevice(deviceIdentifier: string, pid: string): void;
+	}
+
+	/**
+	 * Describes different options for filtering device logs.
+	 */
+	interface IDeviceLogOptions {
+		/**
+		 * Process id of the application on the device.
+		 */
+		applicationPid: string;
+
+		/**
+		 * Selected log level for the current device. It can be INFO or FULL.
+		 */
+		logLevel: string;
+	}
+
+	/**
+	 * Describes required methods for getting iOS Simulator's logs.
+	 */
+	interface IiOSSimulatorLogProvider {
+		/**
+		 * Starts the process for getting simulator logs and sends collected data to deviceLogProvider, which should decide how to show it to the user.
+		 * @param {string} deviceIdentifier The unique identifier of the device.
+		 */
+		startLogProcess(deviceIdentifier: string): void;
 	}
 
 	/**
@@ -158,10 +207,11 @@ declare module Mobile {
 		 * Filters data for specified platform.
 		 * @param {string} platform The platform for which is the device log.
 		 * @param {string} data The input data for filtering.
+		 * @param {string} pid @optional The application PID for this device.
 		 * @param {string} logLevel @optional The logging level based on which input data will be filtered.
 		 * @return {string} The filtered result based on the input or null when the input data shouldn't be shown.
 		 */
-		filterData(platform: string, data: string, logLevel?: string): string;
+		filterData(platform: string, data: string, pid?: string, logLevel?: string): string;
 	}
 
 	/**
@@ -172,9 +222,10 @@ declare module Mobile {
 		 * Filters passed string data based on the passed logging level.
 		 * @param {string} data The string data that will be checked based on the logging level.
 		 * @param {string} logLevel Selected logging level.
+		 * @param {string} pid The Process ID of the currently running application for which we need the logs.
 		 * @return {string} The filtered result based on the input or null when the input data shouldn't be shown.
 		 */
-		filterData(data: string, logLevel: string): string;
+		filterData(data: string, logLevel: string, pid: string): string;
 	}
 
 	interface ILoggingLevels {

--- a/helpers.ts
+++ b/helpers.ts
@@ -5,6 +5,17 @@ let Table = require("cli-table");
 import Future = require("fibers/future");
 import { platform } from "os";
 
+export function getPropertyName(func: Function): string {
+	if (func) {
+		let match = func.toString().match(/(?:return\s+?.*\.(.+);)|(?:=>\s*?.*\.(.+)\b)/);
+		if(match) {
+			return (match[1] || match[2]).trim();
+		}
+	}
+
+	return null;
+}
+
 function bashQuote(s: string): string {
 	if (s[0] === "'" && s[s.length - 1] === "'") {
 		return s;

--- a/mobile/device-log-provider-base.ts
+++ b/mobile/device-log-provider-base.ts
@@ -1,0 +1,34 @@
+import { EventEmitter } from "events";
+
+export abstract class DeviceLogProviderBase extends EventEmitter implements Mobile.IDeviceLogProvider {
+	protected devicesLogOptions: IDictionary<Mobile.IDeviceLogOptions> = {};
+
+	constructor(protected $logFilter: Mobile.ILogFilter,
+		protected $logger: ILogger) {
+		super();
+	}
+
+	public abstract logData(lineText: string, platform: string, deviceIdentifier: string): void;
+
+	public abstract setLogLevel(logLevel: string, deviceIdentifier?: string): void;
+
+	public setApplictionPidForDevice(deviceIdentifier: string, pid: string): void {
+		this.devicesLogOptions[deviceIdentifier] = this.devicesLogOptions[deviceIdentifier] || <Mobile.IDeviceLogOptions>{};
+		this.devicesLogOptions[deviceIdentifier].applicationPid = pid;
+	}
+
+	protected setLogLevelForDevice(deviceIdentifier: string, logLevel?: string): string {
+		logLevel = logLevel || this.$logFilter.loggingLevel;
+
+		if (deviceIdentifier) {
+			logLevel = (this.devicesLogOptions[deviceIdentifier] && this.devicesLogOptions[deviceIdentifier].logLevel) || this.$logFilter.loggingLevel;
+			this.setLogLevel(logLevel, deviceIdentifier);
+		}
+
+		return logLevel;
+	}
+
+	protected getApplicationPidForDevice(deviceIdentifier: string): string {
+		return this.devicesLogOptions[deviceIdentifier] && this.devicesLogOptions[deviceIdentifier].applicationPid;
+	}
+}

--- a/mobile/device-log-provider-base.ts
+++ b/mobile/device-log-provider-base.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import { getPropertyName } from "../helpers";
 
 export abstract class DeviceLogProviderBase extends EventEmitter implements Mobile.IDeviceLogProvider {
 	protected devicesLogOptions: IDictionary<Mobile.IDeviceLogOptions> = {};
@@ -13,22 +14,26 @@ export abstract class DeviceLogProviderBase extends EventEmitter implements Mobi
 	public abstract setLogLevel(logLevel: string, deviceIdentifier?: string): void;
 
 	public setApplictionPidForDevice(deviceIdentifier: string, pid: string): void {
-		this.devicesLogOptions[deviceIdentifier] = this.devicesLogOptions[deviceIdentifier] || <Mobile.IDeviceLogOptions>{};
-		this.devicesLogOptions[deviceIdentifier].applicationPid = pid;
+		this.setDeviceLogOptionsProperty(deviceIdentifier, (deviceLogOptions: Mobile.IDeviceLogOptions) => deviceLogOptions.applicationPid, pid);
 	}
 
-	protected setLogLevelForDevice(deviceIdentifier: string, logLevel?: string): string {
-		logLevel = logLevel || this.$logFilter.loggingLevel;
-
-		if (deviceIdentifier) {
-			logLevel = (this.devicesLogOptions[deviceIdentifier] && this.devicesLogOptions[deviceIdentifier].logLevel) || this.$logFilter.loggingLevel;
-			this.setLogLevel(logLevel, deviceIdentifier);
-		}
+	protected setDefaultLogLevelForDevice(deviceIdentifier: string): string {
+		let logLevel = (this.devicesLogOptions[deviceIdentifier] && this.devicesLogOptions[deviceIdentifier].logLevel) || this.$logFilter.loggingLevel;
+		this.setLogLevel(logLevel, deviceIdentifier);
 
 		return logLevel;
 	}
 
 	protected getApplicationPidForDevice(deviceIdentifier: string): string {
 		return this.devicesLogOptions[deviceIdentifier] && this.devicesLogOptions[deviceIdentifier].applicationPid;
+	}
+
+	protected setDeviceLogOptionsProperty(deviceIdentifier: string, propNameFunction: Function, propertyValue: string): void {
+		let propertyName = getPropertyName(propNameFunction);
+
+		if (propertyName) {
+			this.devicesLogOptions[deviceIdentifier] = this.devicesLogOptions[deviceIdentifier] || <Mobile.IDeviceLogOptions>{};
+			this.devicesLogOptions[deviceIdentifier][propertyName] = propertyValue;
+		}
 	}
 }

--- a/mobile/device-log-provider.ts
+++ b/mobile/device-log-provider.ts
@@ -1,10 +1,16 @@
-export class DeviceLogProvider implements Mobile.IDeviceLogProvider {
-	constructor(private $logFilter: Mobile.ILogFilter,
-		private $logger: ILogger) { }
+import { DeviceLogProviderBase } from "./device-log-provider-base";
+
+export class DeviceLogProvider extends DeviceLogProviderBase {
+	constructor(protected $logFilter: Mobile.ILogFilter,
+		protected $logger: ILogger) {
+		super($logFilter, $logger);
+	}
 
 	public logData(lineText: string, platform: string, deviceIdentifier: string): void {
-		let data = this.$logFilter.filterData(platform, lineText);
-		if(data) {
+		let applicationPid = this.getApplicationPidForDevice(deviceIdentifier);
+
+		let data = this.$logFilter.filterData(platform, lineText, applicationPid);
+		if (data) {
 			this.$logger.out(data);
 		}
 	}

--- a/mobile/ios/ios-log-filter.ts
+++ b/mobile/ios/ios-log-filter.ts
@@ -1,12 +1,16 @@
 export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 	private static INFO_FILTER_REGEX = /^.*?(AppBuilder|Cordova|NativeScript).*?(<Notice>:.*?(CONSOLE LOG|JS ERROR).*?|<Warning>:.*?|<Error>:.*?)$/im;
 
-	constructor(private $loggingLevels: Mobile.ILoggingLevels) {}
+	constructor(private $loggingLevels: Mobile.ILoggingLevels) { }
 
-	public filterData(data: string, logLevel: string): string {
+	public filterData(data: string, logLevel: string, pid?: string): string {
 		let specifiedLogLevel = (logLevel || '').toUpperCase();
 
-		if(specifiedLogLevel === this.$loggingLevels.info) {
+		if (specifiedLogLevel === this.$loggingLevels.info) {
+			if (pid) {
+				return data && data.indexOf(`[${pid}]`) !== -1 ? data.trim() : null;
+			}
+
 			let matchingInfoMessage = data.match(IOSLogFilter.INFO_FILTER_REGEX);
 			return matchingInfoMessage ? matchingInfoMessage[2] : null;
 		}

--- a/mobile/ios/simulator/ios-simulator-device.ts
+++ b/mobile/ios/simulator/ios-simulator-device.ts
@@ -9,7 +9,8 @@ export class IOSSimulator implements Mobile.IiOSSimulator {
 	constructor(private simulator: Mobile.IiSimDevice,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $injector: IInjector,
-		private $iOSSimResolver: Mobile.IiOSSimResolver) { }
+		private $iOSSimResolver: Mobile.IiOSSimResolver,
+		private $iOSSimulatorLogProvider: Mobile.IiOSSimulatorLogProvider) { }
 
 	public get deviceInfo(): Mobile.IDeviceInfo {
 		return {
@@ -51,6 +52,6 @@ export class IOSSimulator implements Mobile.IiOSSimulator {
 	}
 
 	public openDeviceLogStream(): void {
-		return this.$iOSSimResolver.iOSSim.printDeviceLog(this.deviceInfo.identifier);
+		this.$iOSSimulatorLogProvider.startLogProcess(this.simulator.id);
 	}
 }

--- a/mobile/ios/simulator/ios-simulator-log-provider.ts
+++ b/mobile/ios/simulator/ios-simulator-log-provider.ts
@@ -1,0 +1,31 @@
+import { ChildProcess } from "child_process";
+
+export class IOSSimulatorLogProvider implements Mobile.IiOSSimulatorLogProvider {
+	private isStarted: boolean;
+
+	constructor(private $iOSSimResolver: Mobile.IiOSSimResolver,
+		private $deviceLogProvider: Mobile.IDeviceLogProvider,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $processService: IProcessService) { }
+
+	public startLogProcess(deviceIdentifier: string): void {
+		if (!this.isStarted) {
+			let deviceLogChildProcess: ChildProcess = this.$iOSSimResolver.iOSSim.getDeviceLogProcess(deviceIdentifier);
+
+			let action = (data: NodeBuffer | string) => this.$deviceLogProvider.logData(data.toString(), this.$devicePlatformsConstants.iOS, deviceIdentifier);
+
+			if (deviceLogChildProcess.stdout) {
+				deviceLogChildProcess.stdout.on("data", action);
+			}
+
+			if (deviceLogChildProcess.stderr) {
+				deviceLogChildProcess.stderr.on("data", action);
+			}
+
+			this.$processService.attachToProcessExitSignals(this, deviceLogChildProcess.kill);
+
+			this.isStarted = true;
+		}
+	}
+}
+$injector.register("iOSSimulatorLogProvider", IOSSimulatorLogProvider);

--- a/mobile/log-filter.ts
+++ b/mobile/log-filter.ts
@@ -3,22 +3,22 @@ export class LogFilter implements Mobile.ILogFilter {
 
 	constructor(private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $injector: IInjector,
-		private $loggingLevels: Mobile.ILoggingLevels) {}
+		private $loggingLevels: Mobile.ILoggingLevels) { }
 
 	public get loggingLevel(): string {
 		return this._loggingLevel;
 	}
 
 	public set loggingLevel(logLevel: string) {
-		if(this.verifyLogLevel(logLevel)) {
+		if (this.verifyLogLevel(logLevel)) {
 			this._loggingLevel = logLevel;
 		}
 	}
 
-	public filterData(platform: string, data: string, logLevel?: string): string {
+	public filterData(platform: string, data: string, pid?: string, logLevel?: string): string {
 		let deviceLogFilter = this.getDeviceLogFilterInstance(platform);
-		if(deviceLogFilter) {
-			return deviceLogFilter.filterData(data, logLevel || this.loggingLevel);
+		if (deviceLogFilter) {
+			return deviceLogFilter.filterData(data, logLevel || this.loggingLevel, pid);
 		}
 
 		// In case the platform is not valid, just return the data without filtering.
@@ -26,13 +26,14 @@ export class LogFilter implements Mobile.ILogFilter {
 	}
 
 	private getDeviceLogFilterInstance(platform: string): Mobile.IPlatformLogFilter {
-		if(platform) {
-			if(platform.toLowerCase() === this.$devicePlatformsConstants.iOS.toLowerCase()) {
+		if (platform) {
+			if (platform.toLowerCase() === this.$devicePlatformsConstants.iOS.toLowerCase()) {
 				return this.$injector.resolve("iOSLogFilter");
-			} else if(platform.toLowerCase() ===  this.$devicePlatformsConstants.Android.toLowerCase()) {
+			} else if (platform.toLowerCase() === this.$devicePlatformsConstants.Android.toLowerCase()) {
 				return this.$injector.resolve("androidLogFilter");
 			}
 		}
+
 		return null;
 	}
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gaze": "1.0.0",
     "iconv-lite": "0.4.3",
     "inquirer": "0.8.2",
-    "ios-sim-portable": "~1.4.0",
+    "ios-sim-portable": "~1.5.0",
     "lodash": "4.13.1",
     "log4js": "0.6.9",
     "marked": "0.3.3",

--- a/test/unit-tests/appbuilder/device-log-provider.ts
+++ b/test/unit-tests/appbuilder/device-log-provider.ts
@@ -1,15 +1,18 @@
 import { Yok } from "../../../yok";
 import * as assert from "assert";
 import { DeviceLogProvider } from "../../../appbuilder/device-log-provider";
+import { CommonLoggerStub } from "../stubs";
 
 function createTestInjector(loggingLevel: string, emptyFilteredData?: boolean) {
 	let testInjector = new Yok();
 	testInjector.register("logFilter", {
 		loggingLevel: loggingLevel,
-		filterData: (platform: string, data: string, logLevel?: string) => {
+		filterData: (platform: string, data: string, pid?: string, logLevel?: string) => {
 			return emptyFilteredData ? null : `${logLevel} ${data}`;
 		}
 	});
+
+	testInjector.register("logger", CommonLoggerStub);
 
 	return testInjector;
 };

--- a/test/unit-tests/helpers.ts
+++ b/test/unit-tests/helpers.ts
@@ -1,0 +1,152 @@
+import * as helpers from "../../helpers";
+import {assert} from "chai";
+
+interface ITestData {
+	input: any;
+	expectedResult: string;
+}
+
+describe("helpers", () => {
+	describe("getPropertyName", () => {
+		let ES5Functions: ITestData[] = [
+			{
+				input: `function (a) {
+					return a.test;
+				}`,
+				expectedResult: "test"
+			},
+			{
+				input: `function(a) {return a.test;}`,
+				expectedResult: "test"
+			},
+			{
+				input: null,
+				expectedResult: null
+			},
+			{
+				input: "",
+				expectedResult: null
+			},
+			{
+				// Not supported scenario.
+				// Argument of the function must be object and the function must return one of its properties.
+				input: "function(a){ return a; }",
+				expectedResult: null
+			},
+			{
+				input: `function(a) {return a.b.test;}`,
+				expectedResult: "test"
+			},
+			{
+				input: `function(a) {return a.b.c.d.["test1"].e.f.test;}`,
+				expectedResult: "test"
+			},
+			{
+				input: `function(a) {return ;}`,
+				expectedResult: null
+			},
+			{
+				input: `function(a) {return undefined;}`,
+				expectedResult: null
+			},
+			{
+				input: `function(a) {return null;}`,
+				expectedResult: null
+			},
+			{
+				input: `function(a) {return "test";}`,
+				expectedResult: null
+			}
+		];
+
+		let ES6Functions: ITestData[] = [
+			{
+				input: `(a) => {
+					return a.test;
+				}`,
+				expectedResult: "test"
+			},
+			{
+				input: `(a)=>{return a.test;}`,
+				expectedResult: "test"
+			},
+			{
+				input: `a => a.test`,
+				expectedResult: "test"
+			},
+			{
+				input: `(a) => a.test`,
+				expectedResult: "test"
+			},
+			{
+				input: `(a)     =>    a.test      `,
+				expectedResult: "test"
+			},
+			{
+				input: `(a)=>a.test       `,
+				expectedResult: "test"
+			},
+			{
+				input: null,
+				expectedResult: null
+			},
+			{
+				input: "",
+				expectedResult: null
+			},
+			{
+				// Not supported scenario.
+				// Argument of the function must be object and the function must return one of its properties.
+				input: "a => a",
+				expectedResult: null
+			},
+			{
+				input: `(a) => a.b.test`,
+				expectedResult: "test"
+			},
+			{
+				input: `(a) => { return a.b.test; }`,
+				expectedResult: "test"
+			},
+			{
+				input: `a => a.b.c.d.["test1"].e.f.test`,
+				expectedResult: "test"
+			},
+			{
+				input: `(a) => {return ;}`,
+				expectedResult: null
+			},
+			{
+				input: `a => undefined `,
+				expectedResult: null
+			},
+			{
+				input: `a => null`,
+				expectedResult: null
+			},
+			{
+				input: `a => "test"`,
+				expectedResult: null
+			},
+			{
+				input: (a: any) => a.test,
+				expectedResult: "test"
+			}
+		];
+
+		let assertTestData = (testData: ITestData) => {
+			// getPropertyName accepts function as argument.
+			// The tests will use strings in order to skip transpilation of lambdas to functions.
+			let actualResult = helpers.getPropertyName(testData.input);
+			assert.deepEqual(actualResult, testData.expectedResult, `For input ${testData.input}, the expected result is: ${testData.expectedResult}, but actual result is: ${actualResult}.`);
+		};
+
+		it("returns correct property name for ES5 functions", () => {
+			_.each(ES5Functions, assertTestData);
+		});
+
+		it("returns correct property name for ES6 functions", () => {
+			_.each(ES6Functions, assertTestData);
+		});
+	});
+});

--- a/test/unit-tests/ios-log-filter.ts
+++ b/test/unit-tests/ios-log-filter.ts
@@ -4,63 +4,166 @@ import { Yok } from "../../yok";
 import * as assert from "assert";
 
 let iosTestData = [
-	{ input: 'Dec 29 08:46:04 Dragons-iPhone iaptransportd[65] <Warning>: CIapPortAppleIDBus: Auth timer timeout completed on pAIDBPort:0x135d09410, portID:01 downstream port', output: null },
-	{ input: 'Dec 29 08:46:06 Dragons-iPhone kernel[0] <Notice>: AppleARMPMUCharger: AppleUSBCableDetect 1', output: null },
-	{ input: 'Dec 29 08:47:24 Dragons-iPhone bird[131] <Error>: unable to determine evictable space: Error Domain=LibrarianErrorDomain Code=10 "The operation couldn’t be completed. (LibrarianErrorDomain error 10 - Unable to configure the collection.)" UserInfo=0x137528190 {NSDescription=Unable to configure the collection.}', output: null },
-	{ input: 'Dec 29 08:47:43 Dragons-iPhone syslog_relay[179] <Notice>: syslog_relay found the ASL prompt. Starting...', output: null },
-	{ input: 'Dec 29 08:48:47 Dragons-iPhone com.apple.xpc.launchd[1] (com.apple.WebKit.Networking.08B3A589-3D68-492A-BA8D-A812EC55FDEB[13306]) <Warning>: Service exited with abnormal code: 1', output: null },
-	{ input: 'Dec 29 08:48:47 Dragons-iPhone ReportCrash[13308] <Notice>: Saved report to /var/mobile/Library/Logs/CrashReporter/Cordova370_2015-12-29-084847_Dragons-iPhone.ips', output: null },
-	{ input: 'Dec 29 08:48:47 Dragons-iPhone com.apple.WebKit.Networking[13306] <Error>: Failed to obtain sandbox extension for path=/private/var/mobile/Containers/Data/Application/047BB8F2-B8C8-405F-A820-8719EE207E6F/Library/Caches/com.telerik.BlankJS. Errno:1', output: null },
-	{ input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: Apache Cordova native platform version 3.7.0 is starting.',
-		output: '<Warning>: Apache Cordova native platform version 3.7.0 is starting.' },
-	{ input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Notice>: Multi-tasking -> Device: YES, App: YES', output: null },
-	{ input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: Unlimited access to network resources',
-		output: '<Warning>: Unlimited access to network resources' },
-	{ input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: Finished load of: file:///var/mobile/Containers/Data/Application/0746156D-3C83-402E-8B4E-2B3063F42F76/Documents/index.html',
-		output: '<Warning>: Finished load of: file:///var/mobile/Containers/Data/Application/0746156D-3C83-402E-8B4E-2B3063F42F76/Documents/index.html' },
-	{ input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: ---------------------------------- LOG FROM MY APP',
-		output: '<Warning>: ---------------------------------- LOG FROM MY APP' },
-	{ input: 'Dec 29 08:50:31 Dragons-iPhone NativeScript143[13314] <Error>: assertion failed: 12F70: libxpc.dylib + 71768 [B870B51D-AA85-3686-A7D9-ACD48C5FE153]: 0x7d',
-		output: '<Error>: assertion failed: 12F70: libxpc.dylib + 71768 [B870B51D-AA85-3686-A7D9-ACD48C5FE153]: 0x7d' },
-	{ input: 'Dec 29 08:50:31 Dragons-iPhone Unknown[13314] <Error>:', output: null },
-	{ input: 'Dec 29 08:50:31 Dragons-iPhone locationd[57] <Notice>: Gesture EnabledForTopCLient: 0, EnabledInDaemonSettings: 0', output: null },
-	{ input: 'Dec 29 08:55:24 Dragons-iPhone NativeScript143[13323] <Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41',
-		output: '<Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41'},
-	{ input: 'Dec 29 08:55:24 Dragons-iPhone NativeScript143[13323] <Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41\n',
-		output: '<Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41'}
+	{
+		input: 'Dec 29 08:46:04 Dragons-iPhone iaptransportd[65] <Warning>: CIapPortAppleIDBus: Auth timer timeout completed on pAIDBPort:0x135d09410, portID:01 downstream port',
+		output: null,
+		pid13309Output: null
+	},
+	{
+		input: 'Dec 29 08:46:06 Dragons-iPhone kernel[0] <Notice>: AppleARMPMUCharger: AppleUSBCableDetect 1',
+		output: null,
+		pid13309Output: null
+	},
+	{
+		input: 'Dec 29 08:47:24 Dragons-iPhone bird[131] <Error>: unable to determine evictable space: Error Domain=LibrarianErrorDomain Code=10 "The operation couldn’t be completed. (LibrarianErrorDomain error 10 - Unable to configure the collection.)" UserInfo=0x137528190 {NSDescription=Unable to configure the collection.}',
+		output: null,
+		pid13309Output: null
+	},
+	{
+		input: 'Dec 29 08:47:43 Dragons-iPhone syslog_relay[179] <Notice>: syslog_relay found the ASL prompt. Starting...',
+		output: null,
+		pid13309Output: null
+	},
+	{
+		input: 'Dec 29 08:48:47 Dragons-iPhone com.apple.xpc.launchd[1] (com.apple.WebKit.Networking.08B3A589-3D68-492A-BA8D-A812EC55FDEB[13306]) <Warning>: Service exited with abnormal code: 1',
+		output: null,
+		pid13309Output: null
+	},
+	{
+		input: 'Dec 29 08:48:47 Dragons-iPhone ReportCrash[13308] <Notice>: Saved report to /var/mobile/Library/Logs/CrashReporter/Cordova370_2015-12-29-084847_Dragons-iPhone.ips',
+		output: null,
+		pid13309Output: null
+	},
+	{
+		input: 'Dec 29 08:48:47 Dragons-iPhone com.apple.WebKit.Networking[13306] <Error>: Faild to obtain sandbox extension for path=/private/var/mobile/Containers/Data/Application/047BB8F2-B8C8-405F-A820-8719EE207E6F/Library/Caches/com.telerik.BlankJS. Errno:1',
+		output: null,
+		pid13309Output: null
+	},
+	{
+		input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: Apache Cordova native platform version 3.7.0 is starting.',
+		output: '<Warning>: Apache Cordova native platform version 3.7.0 is starting.',
+		pid13309Output: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: Apache Cordova native platform version 3.7.0 is starting.'
+	},
+	{
+		input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Notice>: Multi-tasking -> Device: YES, App: YES',
+		output: null,
+		pid13309Output: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Notice>: Multi-tasking -> Device: YES, App: YES'
+	},
+	{
+		input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: Unlimited access to network resources',
+		output: '<Warning>: Unlimited access to network resources',
+		pid13309Output: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: Unlimited access to network resources'
+	},
+	{
+		input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: Finished load of: file:///var/mobile/Containers/Data/Application/0746156D-3C83-402E-8B4E-2B3063F42F76/Documents/index.html',
+		output: '<Warning>: Finished load of: file:///var/mobile/Containers/Data/Application/0746156D-3C83-402E-8B4E-2B3063F42F76/Documents/index.html',
+		pid13309Output: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: Finished load of: file:///var/mobile/Containers/Data/Application/0746156D-3C83-402E-8B4E-2B3063F42F76/Documents/index.html',
+	},
+	{
+		input: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: ---------------------------------- LOG FROM MY APP',
+		output: '<Warning>: ---------------------------------- LOG FROM MY APP',
+		pid13309Output: 'Dec 29 08:49:06 Dragons-iPhone Cordova370[13309] <Warning>: ---------------------------------- LOG FROM MY APP',
+	},
+	{
+		input: 'Dec 29 08:50:31 Dragons-iPhone NativeScript143[13314] <Error>: assertion failed: 12F70: libxpc.dylib + 71768 [B870B51D-AA85-3686-A7D9-ACD48C5FE153]: 0x7d',
+		output: '<Error>: assertion failed: 12F70: libxpc.dylib + 71768 [B870B51D-AA85-3686-A7D9-ACD48C5FE153]: 0x7d',
+		pid13309Output: null
+	},
+	{
+		input: 'Dec 29 08:50:31 Dragons-iPhone Unknown[13314] <Error>:',
+		output: null,
+		pid13309Output: null
+	},
+	{
+		input: 'Dec 29 08:50:31 Dragons-iPhone locationd[57] <Notice>: Gesture EnabledForTopCLient: 0, EnabledInDaemonSettings: 0',
+		output: null,
+		pid13309Output: null
+	},
+	{
+		input: 'Dec 29 08:55:24 Dragons-iPhone NativeScript143[13309] <Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41',
+		output: '<Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41',
+		pid13309Output: 'Dec 29 08:55:24 Dragons-iPhone NativeScript143[13309] <Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41'
+
+	},
+	{
+		input: 'Dec 29 08:55:24 Dragons-iPhone NativeScript143[13309] <Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41\n',
+		output: '<Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41',
+		pid13309Output: 'Dec 29 08:55:24 Dragons-iPhone NativeScript143[13309] <Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41',
+	},
+	{
+		input: 'Dec 29 08:55:24 Dragons-iPhone NativeScript143[13309]: <Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41\n',
+		output: '<Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41',
+		pid13309Output: 'Dec 29 08:55:24 Dragons-iPhone NativeScript143[13309]: <Notice>: file:///app/main-view-model.js:11:14: CONSOLE LOG COUNTER: 41'
+	},
+	{
+		input: 'Oct  4 08:53:46 bd-airtestmac com.apple.CoreSimulator.SimDevice.3616FC55-9CAB-47D4-8C58-5E5F0BE99C8E.launchd_sim[30337] (UIKitApplication:org.nativescript.ap1[0x76c5][13309]): Service exited due to signal: Terminated: 15',
+		output: null,
+		pid13309Output: 'Oct  4 08:53:46 bd-airtestmac com.apple.CoreSimulator.SimDevice.3616FC55-9CAB-47D4-8C58-5E5F0BE99C8E.launchd_sim[30337] (UIKitApplication:org.nativescript.ap1[0x76c5][13309]): Service exited due to signal: Terminated: 15'
+	},
+	{
+		input: 'Oct  4 08:52:44 bd-airtestmac assertiond[13309]: assertion failed: 15G31 13A344: assertiond + 12188 [93893311-6962-33A7-A734-E36F946D8EBA]: 0x1',
+		output: null,
+		pid13309Output: 'Oct  4 08:52:44 bd-airtestmac assertiond[13309]: assertion failed: 15G31 13A344: assertiond + 12188 [93893311-6962-33A7-A734-E36F946D8EBA]: 0x1'
+	}
 ];
 
 describe("iOSLogFilter", () => {
 
-	let assertFiltering = (inputData: string, expectedOutput: string, logLevel?: string) => {
+	let assertFiltering = (inputData: string, expectedOutput: string, logLevel?: string, pid?: string) => {
 		let testInjector = new Yok();
 		testInjector.register("loggingLevels", LoggingLevels);
-		let androidLogFilter = testInjector.resolve(IOSLogFilter);
-		let filteredData = androidLogFilter.filterData(inputData, logLevel);
+		let iOSLogFilter = testInjector.resolve(IOSLogFilter);
+		let filteredData = iOSLogFilter.filterData(inputData, logLevel, pid);
 		assert.deepEqual(filteredData, expectedOutput, `The actual result '${filteredData}' did NOT match expected output '${expectedOutput}'.`);
 	};
 
-	let logLevel = "INFO";
+	let logLevel = "INFO",
+		pid = "13309";
 
 	describe("filterData", () => {
-		it("when log level is full returns full data", () => {
-			logLevel = "FULL";
-			_.each(iosTestData, testData => {
-				assertFiltering(testData.input, testData.input, logLevel);
+		describe("when PID is not provided", () => {
+			it("when log level is full returns full data", () => {
+				logLevel = "FULL";
+				_.each(iosTestData, testData => {
+					assertFiltering(testData.input, testData.input, logLevel);
+				});
+			});
+
+			it("when log level is INFO filters data", () => {
+				logLevel = "INFO";
+				_.each(iosTestData, testData => {
+					assertFiltering(testData.input, testData.output, logLevel);
+				});
+			});
+
+			it("when log level is not specified returns full data", () => {
+				logLevel = null;
+				_.each(iosTestData, testData => {
+					assertFiltering(testData.input, testData.input);
+				});
 			});
 		});
 
-		it("when log level is INFO filters data", () => {
-			logLevel = "INFO";
-			_.each(iosTestData, testData => {
-				assertFiltering(testData.input, testData.output, logLevel);
+		describe("when PID is provided", () => {
+			it("when log level is full returns full data", () => {
+				logLevel = "FULL";
+				_.each(iosTestData, testData => {
+					assertFiltering(testData.input, testData.input, logLevel, pid);
+				});
 			});
-		});
 
-		it("when log level is not specified returns full data", () => {
-			logLevel = null;
-			_.each(iosTestData, testData => {
-				assertFiltering(testData.input, testData.input);
+			it("when log level is INFO filters data", () => {
+				logLevel = "INFO";
+				_.each(iosTestData, testData => {
+					assertFiltering(testData.input, testData.pid13309Output, logLevel, pid);
+				});
+			});
+
+			it("when log level is not specified returns full data", () => {
+				logLevel = null;
+				_.each(iosTestData, testData => {
+					assertFiltering(testData.input, testData.input, logLevel, pid);
+				});
 			});
 		});
 	});

--- a/test/unit-tests/log-filter.ts
+++ b/test/unit-tests/log-filter.ts
@@ -11,13 +11,13 @@ function createTestInjector(): IInjector {
 	testInjector.register("loggingLevels", LoggingLevels);
 	testInjector.register("logFilter", LogFilter);
 	testInjector.register("iOSLogFilter", {
-		filterData: (data: string, logLevel: string) => {
+		filterData: (data: string, logLevel: string, pid?: string) => {
 			return `ios: ${data} ${logLevel}`;
 		}
 	});
 
 	testInjector.register("androidLogFilter", {
-		filterData: (data: string, logLevel: string) => {
+		filterData: (data: string, logLevel: string, pid?: string) => {
 			return `android: ${data} ${logLevel}`;
 		}
 	});
@@ -110,17 +110,17 @@ describe("logFilter", () => {
 			beforeEach(() => logLevel = infoLogLevel);
 
 			it("returns same data when platform is not correct", () => {
-				let actualData = logFilter.filterData("invalidPlatform", testData, logLevel);
+				let actualData = logFilter.filterData("invalidPlatform", testData, null, logLevel);
 				assert.deepEqual(actualData, testData, logLevel);
 			});
 
 			it("returns correct data when platform is android", () => {
-				let actualData = logFilter.filterData("android", testData, logLevel);
+				let actualData = logFilter.filterData("android", testData, null, logLevel);
 				assert.deepEqual(actualData, androidInfoTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				let actualData = logFilter.filterData("ios", testData, logLevel);
+				let actualData = logFilter.filterData("ios", testData, null, logLevel);
 				assert.deepEqual(actualData, iosInfoTestData);
 			});
 		});
@@ -129,17 +129,17 @@ describe("logFilter", () => {
 			beforeEach(() => logLevel = fullLogLevel);
 
 			it("returns same data when platform is not correct", () => {
-				let actualData = logFilter.filterData("invalidPlatform", testData, logLevel);
+				let actualData = logFilter.filterData("invalidPlatform", testData, null, logLevel);
 				assert.deepEqual(actualData, testData, logLevel);
 			});
 
 			it("returns correct data when platform is android", () => {
-				let actualData = logFilter.filterData("android", testData, logLevel);
+				let actualData = logFilter.filterData("android", testData, null, logLevel);
 				assert.deepEqual(actualData, androidFullTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				let actualData = logFilter.filterData("ios", testData, logLevel);
+				let actualData = logFilter.filterData("ios", testData, null, logLevel);
 				assert.deepEqual(actualData, iosFullTestData);
 			});
 		});

--- a/test/unit-tests/mobile/ios-simulator-discovery.ts
+++ b/test/unit-tests/mobile/ios-simulator-discovery.ts
@@ -22,6 +22,9 @@ function createTestInjector(): IInjector {
 	injector.register("devicePlatformsConstants", DevicePlatformsConstants);
 
 	injector.register("iOSSimulatorDiscovery", IOSSimulatorDiscovery);
+
+	injector.register("iOSSimulatorLogProvider", {});
+
 	return injector;
 }
 


### PR DESCRIPTION
iOS Simulator device logs are printed directly to process.stdout from the ios-sim-portable. However this makes it really difficult to filter the logs and provide them to different callers (for example AppBuilder CLI, NativeScript CLI, Proton).
In order to fix this, use the ios-sim-portable just to start the process of getting device logs. Filter them in the CLI itself.
Also change the logic in ios-log-filter to use process pid in case it's passed. For iOS Simulator we have filtered logs based on the PID of the application. With these changes, simulator logs are passed to ios-log-filter, so that's why we need process' PID there.
When application is restarted (during livesync for example), we set the PID again and the filter will use the new PID.

Merge AFTER https://github.com/telerik/ios-sim-portable/pull/79