### PR TITLE
Show helpful information when Sync over WIFI error is detected

### DIFF
--- a/mobile/ios/device/ios-device.ts
+++ b/mobile/ios/device/ios-device.ts
@@ -123,7 +123,7 @@ export class IOSDevice implements Mobile.IiOSDevice {
 
 	private validateResult(result: number, error: string) {
 		if (result !== 0) {
-			this.$errors.fail(util.format("%s. Result code is: %s", error, result));
+			this.$errors.fail({ formatStr: `${error}. Result code is: ${result}`, errorCode: result });
 		} else {
 			this.deviceInfo.status = constants.CONNECTED_STATUS;
 		}


### PR DESCRIPTION
iTunes has an option to sync changes over wifi for each iOS device. However, for some devices, when trying to start the installation_proxy service and `Sync over Wi-Fi` option is enabled, the connection fails.
Catch such cases and show helpful message describing the problem and how to resolve it.

Should help for issues like: https://github.com/NativeScript/nativescript-cli/issues/1398