### PR TITLE
Fix livesync --watch for NativeScript CLI

### DIFF
--- a/services/livesync/sync-batch.ts
+++ b/services/livesync/sync-batch.ts
@@ -4,8 +4,6 @@ import * as fiberBootstrap from "../../fiber-bootstrap";
 export const SYNC_WAIT_THRESHOLD = 250; //milliseconds
 
 export class SyncBatch {
-	private _isTypeScriptProject: boolean;
-	private hasCheckedProjectType: boolean;
 	private timer: NodeJS.Timer = null;
 	private syncQueue: string[] = [];
 	private syncInProgress: boolean = false;


### PR DESCRIPTION
Fix `livesync <platform> --watch` for NS CLI by removing AppBuilder specific code from SyncBatch.
Also start tsc with `--watch` option when `--watch` is passed.
In SyncBatch remove the files that are will not be synced from the syncQueue.