### PR TITLE
Do not try to resolve hookArgs

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -397,6 +397,7 @@ interface IAutoCompletionService {
 }
 
 interface IHooksService {
+	hookArgsName: string;
 	executeBeforeHooks(commandName: string, hookArguments?: IDictionary<any>): IFuture<void>;
 	executeAfterHooks(commandName: string, hookArguments?: IDictionary<any>): IFuture<void>;
 }

--- a/services/hooks-service.ts
+++ b/services/hooks-service.ts
@@ -25,6 +25,10 @@ export class HooksService implements IHooksService {
 		private $projectHelper: IProjectHelper,
 		private $options: ICommonOptions) { }
 
+	public get hookArgsName(): string {
+		return "hookArgs";
+	}
+
 	private initialize(): void {
 		this.cachedHooks = {};
 
@@ -250,7 +254,9 @@ export class HooksService implements IHooksService {
 
 		_.each(hookConstructor.$inject.args, (argument: string) => {
 			try {
-				this.$injector.resolve(argument);
+				if (argument !== this.hookArgsName) {
+					this.$injector.resolve(argument);
+				}
 			} catch (err) {
 				this.$logger.trace(`Cannot resolve ${argument}, reason: ${err}`);
 				invalidArguments.push(argument);


### PR DESCRIPTION
When we validate the hook arguments we try to resolve all of them but there is one argument which is not registered in the injector - hookArgs. If some hook wants to use it we will try to resolve it and fail. The solution is to skip the validation for the hookArgs argument.