### PR TITLE
Fix validation of -- options

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -114,7 +114,7 @@ export function isInteractive(): boolean {
 }
 
 export function toBoolean(str: any) {
-	return str && str.toString().toLowerCase() === "true";
+	return !!(str && str.toString().toLowerCase() === "true");
 }
 
 export function block(operation: () => void): void {
@@ -135,12 +135,12 @@ export function fromWindowsRelativePathToUnix(windowsRelativePath: string): stri
 	return windowsRelativePath.replace(/\\/g, "/");
 }
 
-export function isNullOrWhitespace(input: string): boolean {
-	if (!input) {
+export function isNullOrWhitespace(input: any): boolean {
+	if (!input && input !== false) {
 		return true;
 	}
 
-	return input.replace(/\s/gi, "").length < 1;
+	return _.isString(input) && input.replace(/\s/gi, "").length < 1;
 }
 
 export function getCurrentEpochTime(): number {
@@ -186,8 +186,7 @@ export function trimSymbol(str: string, symbol: string) {
 	return str;
 }
 
-// TODO: Use generic for predicatе predicate: (element: T|T[]) when TypeScript support this.
-export function getFuturesResults<T>(futures: IFuture<T | T[]>[], predicate: (element: any) => boolean): T[] {
+export function getFuturesResults<T>(futures: IFuture<T | T[]>[], predicate: (element: T|T[]) => boolean): T[] {
 	Future.wait(futures);
 	return _(futures)
 		.map(f => f.get())

--- a/helpers.ts
+++ b/helpers.ts
@@ -113,8 +113,8 @@ export function isInteractive(): boolean {
 	return process.stdout.isTTY && process.stdin.isTTY;
 }
 
-export function toBoolean(str: any) {
-	return !!(str && str.toString().toLowerCase() === "true");
+export function toBoolean(str: any): boolean {
+	return !!(str && str.toString && str.toString().toLowerCase() === "true");
 }
 
 export function block(operation: () => void): void {
@@ -186,7 +186,8 @@ export function trimSymbol(str: string, symbol: string) {
 	return str;
 }
 
-export function getFuturesResults<T>(futures: IFuture<T | T[]>[], predicate: (element: T|T[]) => boolean): T[] {
+// TODO: Use generic for predicatе predicate: (element: T|T[]) when TypeScript support this.
+export function getFuturesResults<T>(futures: IFuture<T | T[]>[], predicate: (element: any) => boolean): T[] {
 	Future.wait(futures);
 	return _(futures)
 		.map(f => f.get())

--- a/options.ts
+++ b/options.ts
@@ -1,4 +1,3 @@
-import * as util from "util";
 import * as helpers from "./helpers";
 import * as yargs from "yargs";
 
@@ -11,9 +10,12 @@ export class OptionType {
 }
 
 export class OptionsBase {
+	private static DASHED_OPTION_REGEX = /(.+?)([A-Z])(.*)/;
+	private static NONDASHED_OPTION_REGEX = /(.+?)[-]([a-zA-Z])(.*)/;
+
 	private optionsWhiteList = ["ui", "recursive", "reporter", "require", "timeout", "_", "$0"]; // These options shouldn't be validated
 	public argv: IYargArgv;
-	private GLOBAL_OPTIONS: IDictionary<IDashedOption> = {
+	private globalOptions: IDictionary<IDashedOption> = {
 		log: { type: OptionType.String },
 		verbose: { type: OptionType.Boolean, alias: "v" },
 		version: { type: OptionType.Boolean },
@@ -30,7 +32,7 @@ export class OptionsBase {
 		private $errors: IErrors,
 		private $staticConfig: Config.IStaticConfig) {
 
-		_.extend(this.options, this.commonOptions, this.GLOBAL_OPTIONS);
+		_.extend(this.options, this.commonOptions, this.globalOptions);
 		this.setArgv();
 	}
 
@@ -89,7 +91,7 @@ export class OptionsBase {
 
 	public validateOptions(commandSpecificDashedOptions?: IDictionary<IDashedOption>): void {
 		if (commandSpecificDashedOptions) {
-			this.options = this.GLOBAL_OPTIONS;
+			this.options = this.globalOptions;
 			_.extend(this.options, commandSpecificDashedOptions);
 			this.setArgv();
 		}
@@ -106,14 +108,16 @@ export class OptionsBase {
 				return;
 			}
 
-			let optionName = this.getNonDashedOptionName(originalOptionName);
+			let optionName = this.getCorrectOptionName(originalOptionName);
 
 			if (!_.includes(this.optionsWhiteList, optionName)) {
 				if (!this.isOptionSupported(optionName)) {
 					this.$errors.failWithoutHelp(`The option '${originalOptionName}' is not supported. To see command's options, use '$ ${this.$staticConfig.CLIENT_NAME.toLowerCase()} help ${process.argv[2]}'. To see all commands use '$ ${this.$staticConfig.CLIENT_NAME.toLowerCase()} help'.`);
 				}
-				let optionType = this.getOptionType(optionName);
-				let optionValue = parsed[optionName];
+
+				let optionType = this.getOptionType(optionName),
+					optionValue = parsed[optionName];
+
 				if (_.isArray(optionValue) && optionType !== OptionType.Array) {
 					this.$errors.fail("You have set the %s option multiple times. Check the correct command syntax below and try again.", originalOptionName);
 				} else if (optionType === OptionType.String && helpers.isNullOrWhitespace(optionValue)) {
@@ -155,11 +159,11 @@ export class OptionsBase {
 	// IMPORTANT: In your code, it is better to use the value without dashes (profileDir in the example).
 	// This way your code will work in case "$ <cli name> emulate android --profile-dir" or "$ <cli name> emulate android --profileDir" is used by user.
 	private getNonDashedOptionName(optionName: string): string {
-		let matchUpperCaseLetters = optionName.match(/(.+?)([-])([a-zA-Z])(.*)/);
+		let matchUpperCaseLetters = optionName.match(OptionsBase.NONDASHED_OPTION_REGEX);
 		if (matchUpperCaseLetters) {
 			// get here if option with upperCase letter is specified, for example profileDir
 			// check if in knownOptions we have its kebabCase presentation
-			let secondaryOptionName = util.format("%s%s%s", matchUpperCaseLetters[1], matchUpperCaseLetters[3].toUpperCase(), matchUpperCaseLetters[4] || '');
+			let secondaryOptionName = matchUpperCaseLetters[1] + matchUpperCaseLetters[2].toUpperCase() + matchUpperCaseLetters[3] || '';
 			return this.getNonDashedOptionName(secondaryOptionName);
 		}
 
@@ -167,9 +171,9 @@ export class OptionsBase {
 	}
 
 	private getDashedOptionName(optionName: string): string {
-		let matchUpperCaseLetters = optionName.match(/(.+?)([A-Z])(.*)/);
+		let matchUpperCaseLetters = optionName.match(OptionsBase.DASHED_OPTION_REGEX);
 		if (matchUpperCaseLetters) {
-			let secondaryOptionName = util.format("%s-%s%s", matchUpperCaseLetters[1], matchUpperCaseLetters[2].toLowerCase(), matchUpperCaseLetters[3] || '');
+			let secondaryOptionName = `${matchUpperCaseLetters[1]}-${matchUpperCaseLetters[2].toLowerCase()}${matchUpperCaseLetters[3] || ''}`;
 			return this.getDashedOptionName(secondaryOptionName);
 		}
 
@@ -187,16 +191,16 @@ export class OptionsBase {
 	}
 
 	private adjustDashedOptions(): void {
-			_.each(this.optionNames, optionName => {
-				Object.defineProperty(OptionsBase.prototype, optionName, {
-					configurable: true,
-					get: function () {
-						return this.getOptionValue(optionName);
-					},
-					set: function (value: any) {
-						this.argv[optionName] = value;
-					}
-				});
+		_.each(this.optionNames, optionName => {
+			Object.defineProperty(OptionsBase.prototype, optionName, {
+				configurable: true,
+				get: function () {
+					return this.getOptionValue(optionName);
+				},
+				set: function (value: any) {
+					this.argv[optionName] = value;
+				}
 			});
+		});
 	}
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "validator": "3.2.1",
     "winreg": "0.0.12",
     "xmlhttprequest": "https://github.com/telerik/node-XMLHttpRequest/tarball/master",
-    "yargs": "4.7.1",
+    "yargs": "6.0.0",
     "zipstream": "https://github.com/Icenium/node-zipstream/tarball/master"
   },
   "analyze": true,

--- a/test/unit-tests/common-options.ts
+++ b/test/unit-tests/common-options.ts
@@ -64,8 +64,26 @@ describe("common options", () => {
 			process.argv.push('--path1');
 			// If you do not pass value to an option, it's automatically set as true.
 			let options = createOptions(testInjector);
-			options.validateOptions();
 			process.argv.pop();
+			options.validateOptions();
+			assert.isTrue(isExecutionStopped);
+		});
+
+		it("breaks execution when valid dashed option passed without dashes does not have value", () => {
+			process.argv.push('--someDashedValue');
+			// If you do not pass value to a string option, it's automatically set to "".
+			let options = createOptions(testInjector);
+			process.argv.pop();
+			options.validateOptions();
+			assert.isTrue(isExecutionStopped);
+		});
+
+		it("breaks execution when valid dashed option does not have value", () => {
+			process.argv.push('--some-dashed-value');
+			// If you do not pass value to an option, it's automatically set as true.
+			let options = createOptions(testInjector);
+			process.argv.pop();
+			options.validateOptions();
 			assert.isTrue(isExecutionStopped);
 		});
 

--- a/test/unit-tests/helpers.ts
+++ b/test/unit-tests/helpers.ts
@@ -3,10 +3,16 @@ import {assert} from "chai";
 
 interface ITestData {
 	input: any;
-	expectedResult: string;
+	expectedResult: any;
 }
 
 describe("helpers", () => {
+
+	let assertTestData = (testData: ITestData, method: Function) => {
+		let actualResult = method(testData.input);
+		assert.deepEqual(actualResult, testData.expectedResult, `For input ${testData.input}, the expected result is: ${testData.expectedResult}, but actual result is: ${actualResult}.`);
+	};
+
 	describe("getPropertyName", () => {
 		let ES5Functions: ITestData[] = [
 			{
@@ -134,19 +140,125 @@ describe("helpers", () => {
 			}
 		];
 
-		let assertTestData = (testData: ITestData) => {
-			// getPropertyName accepts function as argument.
-			// The tests will use strings in order to skip transpilation of lambdas to functions.
-			let actualResult = helpers.getPropertyName(testData.input);
-			assert.deepEqual(actualResult, testData.expectedResult, `For input ${testData.input}, the expected result is: ${testData.expectedResult}, but actual result is: ${actualResult}.`);
-		};
-
+		// getPropertyName accepts function as argument.
+		// The tests will use strings in order to skip transpilation of lambdas to functions.
 		it("returns correct property name for ES5 functions", () => {
-			_.each(ES5Functions, assertTestData);
+			_.each(ES5Functions, testData => assertTestData(testData, helpers.getPropertyName));
 		});
 
 		it("returns correct property name for ES6 functions", () => {
-			_.each(ES6Functions, assertTestData);
+			_.each(ES6Functions, testData => assertTestData(testData, helpers.getPropertyName));
+		});
+	});
+
+	describe("toBoolean", () => {
+		let toBooleanTestData: ITestData[] = [
+			{
+				input: true,
+				expectedResult: true
+			},
+			{
+				input: false,
+				expectedResult: false
+			},
+			{
+				input: "true",
+				expectedResult: true
+			},
+			{
+				input: "false",
+				expectedResult: false
+			},
+			{
+				input: "",
+				expectedResult: false
+			},
+			{
+				input: null,
+				expectedResult: false
+			},
+			{
+				input: undefined,
+				expectedResult: false
+			},
+			{
+				input: "",
+				expectedResult: false
+			},
+			{
+				input: "some random text",
+				expectedResult: false
+			},
+			{
+				input: { "true": true },
+				expectedResult: false
+			},
+			{
+				input: {},
+				expectedResult: false
+			},
+			{
+				input: { "a": { "b": 1 } },
+				expectedResult: false
+			}
+		];
+
+		it("returns expected result", () => {
+			_.each(toBooleanTestData, testData => assertTestData(testData, helpers.toBoolean));
+		});
+	});
+
+	describe("isNullOrWhitespace", () => {
+		let isNullOrWhitespaceTestData: ITestData[] = [
+			{
+				input: "",
+				expectedResult: true
+			},
+			{
+				input: "     ",
+				expectedResult: true
+			},
+			{
+				input: null,
+				expectedResult: true
+			},
+			{
+				input: undefined,
+				expectedResult: true
+			},
+			{
+				input: [],
+				expectedResult: false
+			},
+			{
+				input: ["test1", "test2"],
+				expectedResult: false
+			},
+			{
+				input: {},
+				expectedResult: false
+			},
+			{
+				input: { a: 1, b: 2 },
+				expectedResult: false
+			},
+			{
+				input: true,
+				expectedResult: false
+			},
+			{
+				input: false,
+				expectedResult: false
+			}
+		];
+
+		it("returns expected result", () => {
+			_.each(isNullOrWhitespaceTestData, t => assertTestData(t, helpers.isNullOrWhitespace));
+		});
+
+		it("returns false when Object.create(null) is passed", () => {
+			let actualResult = helpers.isNullOrWhitespace(Object.create(null));
+			assert.deepEqual(actualResult, false);
 		});
 	});
 });

--- a/test/unit-tests/helpers.ts
+++ b/test/unit-tests/helpers.ts
@@ -182,7 +182,19 @@ describe("helpers", () => {
 				expectedResult: false
 			},
 			{
-				input: "",
+				input: '\n',
+				expectedResult: false
+			},
+			{
+				input: '\r\n',
+				expectedResult: false
+			},
+			{
+				input: '\t',
+				expectedResult: false
+			},
+			{
+				input: '\t\t\t\t\t\t\n\t\t\t\t\r\n\r\n\n\n   \t\t\t\r\n',
 				expectedResult: false
 			},
 			{
@@ -205,6 +217,11 @@ describe("helpers", () => {
 
 		it("returns expected result", () => {
 			_.each(toBooleanTestData, testData => assertTestData(testData, helpers.toBoolean));
+		});
+
+		it("returns false when Object.create(null) is passed", () => {
+			let actualResult = helpers.toBoolean(Object.create(null));
+			assert.deepEqual(actualResult, false);
 		});
 	});
 
@@ -249,6 +266,22 @@ describe("helpers", () => {
 			{
 				input: false,
 				expectedResult: false
+			},
+			{
+				input: '\n',
+				expectedResult: true
+			},
+			{
+				input: '\r\n',
+				expectedResult: true
+			},
+			{
+				input: '\t',
+				expectedResult: true
+			},
+			{
+				input: '\t\t\t\t\t\t\r\n\t\t\t\t\t\n\t\t\t     \t\t\t\t\t\n\r\n   ',
+				expectedResult: true
 			}
 		];
 


### PR DESCRIPTION
The validation of -- options passed on the command line depends on yargs module. Update it to latest versions as the previously used one didn't set correct values of options marked as strings.
Also in our code we pass object of valid options to yargs. Options which have `-` in the name are treated in a special manner in yargs. However instead of passing them with `-`, we pass their secondary representation (remove the `-` and capitalize the next letter).
This way, when the user passes option with `-`, yargs treat it with it's default behavior and does not respect our options for it (as we have not defined that we have option with `-`).
Example:
```JavaScript
var yargs = require("yargs");
var opts = {
  "profile-dir": { type: "string" }
};
console.log(yargs(process.argv).options(opts).argv);

var opts1 = {
  "profileDir": { type: "string" }
};
console.log(yargs(process.argv).options(opts1).argv);
```

When called with:
```
node testYargs.js --profile-dir
```
The result is:
```
{
  'profile-dir': '',
  profileDir: '',
  '$0': 'testYargs.js'
}

{
  'profile-dir': true,
  profileDir: true,
  '$0': 'testYargs.js'
}
```

As you can see, passing "profileDir" and defining it as string does not work. But when we use "profile-dir" in our opts, everything works as expected and yargs sets the value to empty string.

In order to resolve the problem, make sure we pass options with dashes to yargs.

### Fix isNullOrWhitespace method
When boolean value is passed to isNullOrWhitespace helper method, it fails as true.replace is not available function.

### Add unit tests
Add unit tests for:
 - options issue - assert correct behavior when dashed option is passed on the terminal
 - helpers isNullOrWhitespace method
 - helpers isBoolean method