### PR TITLE
if there is no app folder just return an empty array of files

### DIFF
--- a/file-system.ts
+++ b/file-system.ts
@@ -453,6 +453,13 @@ export class FileSystem implements IFileSystem {
 			filterCallback?: (_file: string, _stat: IFsStats) => boolean,
 			opts?: { enumerateDirectories?: boolean, includeEmptyDirectories?: boolean }, foundFiles?: string[]): string[] {
 		foundFiles = foundFiles || [];
+
+		if(!this.exists(directoryPath).wait()) {
+			let $logger = this.$injector.resolve("logger");
+			$logger.warn('Could not find folder: ' + directoryPath);
+			return foundFiles;
+		}
+
 		let contents = this.readDirectory(directoryPath).wait();
 		for (let i = 0; i < contents.length; ++i) {
 			let file = path.join(directoryPath, contents[i]);


### PR DESCRIPTION
currently if there is no given folder the line:
```typescript
let contents = this.readDirectory(directoryPath).wait();
```
blows up because there is no directory. Currently if directory present, the function will return an empty array.

ping: @rosen-vladimirov 

