### PR TITLE
Fixed: getRunningSimulator is slow, so we should call it only when th…

### DIFF
--- a/test/unit-tests/mobile/ios-simulator-discovery.ts
+++ b/test/unit-tests/mobile/ios-simulator-discovery.ts
@@ -4,11 +4,14 @@ import Future = require("fibers/future");
 import { assert } from "chai";
 import { DevicePlatformsConstants } from "../../../mobile/device-platforms-constants";
 
-let currentlyRunningSimulator: any;
+let currentlyRunningSimulator: any,
+	isCurrentlyRunning: boolean;
 
 function createTestInjector(): IInjector {
 	let injector = new Yok();
-	injector.register("childProcess", { /* No implementation required. */ });
+	injector.register("childProcess", {
+		exec: (command: string) => Future.fromResult(isCurrentlyRunning ? 'launchd_sim' : '')
+ 	});
 	injector.register("injector", injector);
 	injector.register("iOSSimResolver", {
 		iOSSim: {
@@ -36,6 +39,7 @@ describe("ios-simulator-discovery", () => {
 
 	let detectNewSimulatorAttached = (runningSimulator: any): Mobile.IiOSSimulator => {
 		let future = new Future<any>();
+		isCurrentlyRunning = true;
 		currentlyRunningSimulator = _.cloneDeep(runningSimulator);
 		iOSSimulatorDiscovery.once("deviceFound", (device: Mobile.IDevice) => {
 			future.return(device);
@@ -45,6 +49,7 @@ describe("ios-simulator-discovery", () => {
 	};
 
 	let detectSimulatorDetached = (): Mobile.IiOSSimulator => {
+		isCurrentlyRunning = false;
 		currentlyRunningSimulator = null;
 		let lostDeviceFuture = new Future<Mobile.IDevice>();
 		iOSSimulatorDiscovery.once("deviceLost", (device: Mobile.IDevice) => {
@@ -75,6 +80,7 @@ describe("ios-simulator-discovery", () => {
 	};
 
 	beforeEach(() => {
+		isCurrentlyRunning = false;
 		currentlyRunningSimulator = null;
 		testInjector = createTestInjector();
 		iOSSimulatorDiscovery = testInjector.resolve("iOSSimulatorDiscovery");
@@ -148,6 +154,7 @@ describe("ios-simulator-discovery", () => {
 				throw new Error("Cannot find iOS Devices.");
 			}).future<any>()();
 		};
+		isCurrentlyRunning = true;
 		iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
 			throw new Error("Device found should not be raised when getting running iOS Simulator fails.");
 		});
@@ -156,6 +163,7 @@ describe("ios-simulator-discovery", () => {
 
 	it("does not detect iOS Simulator when not running on OS X", () => {
 		testInjector.resolve("hostInfo").isDarwin = false;
+		isCurrentlyRunning = true;
 		iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
 			throw new Error("Device found should not be raised when OS is not OS X.");
 		});
@@ -164,6 +172,7 @@ describe("ios-simulator-discovery", () => {
 
 	it("checkForDevices return future", () => {
 		testInjector.resolve("hostInfo").isDarwin = false;
+		isCurrentlyRunning = true;
 		iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
 			throw new Error("Device found should not be raised when OS is not OS X.");
 		});


### PR DESCRIPTION
Fixed: getRunningSimulator is slow and causes LiveSync to wait for about 10 seconds, so we should call it only when there is a simulator process running

ping @rosen-vladimirov , @TsvetanMilanov 