### PR TITLE
Added install hook.

### DIFF
--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -1,7 +1,8 @@
-import {EOL} from "os";
-import {ApplicationManagerBase} from "../application-manager-base";
+import { EOL } from "os";
+import { ApplicationManagerBase } from "../application-manager-base";
 import { LiveSyncConstants, TARGET_FRAMEWORK_IDENTIFIERS } from "../../constants";
 import Future = require("fibers/future");
+import { hook } from "../../helpers";
 
 export class AndroidApplicationManager extends ApplicationManagerBase {
 
@@ -12,8 +13,9 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		private $logcatHelper: Mobile.ILogcatHelper,
 		private $androidProcessService: Mobile.IAndroidProcessService,
 		private $httpClient: Server.IHttpClient,
-		$logger: ILogger) {
-		super($logger);
+		$logger: ILogger,
+		$hooksService: IHooksService) {
+		super($logger, $hooksService);
 	}
 
 	public getInstalledApplications(): IFuture<string[]> {
@@ -30,6 +32,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		}).future<string[]>()();
 	}
 
+	@hook('install')
 	public installApplication(packageFilePath: string): IFuture<void> {
 		return this.adb.executeCommand(["install", "-r", `${packageFilePath}`]);
 	}

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -1,12 +1,13 @@
 import { EventEmitter } from "events";
-import {TARGET_FRAMEWORK_IDENTIFIERS} from "../constants";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../constants";
 
 export abstract class ApplicationManagerBase extends EventEmitter implements Mobile.IDeviceApplicationManager {
 	private lastInstalledAppIdentifiers: string[];
 	private lastAvailableDebuggableApps: Mobile.IDeviceApplicationInformation[];
 	private lastAvailableDebuggableAppViews: IDictionary<Mobile.IDebugWebViewInfo[]> = {};
 
-	constructor(protected $logger: ILogger) {
+	constructor(protected $logger: ILogger,
+		protected $hooksService: IHooksService) {
 		super();
 	}
 

--- a/mobile/ios/device/ios-application-manager.ts
+++ b/mobile/ios/device/ios-application-manager.ts
@@ -2,8 +2,9 @@ import * as net from "net";
 import * as ref from "ref";
 import * as os from "os";
 import * as iOSProxyServices from "./ios-proxy-services";
-import {ApplicationManagerBase} from "../../application-manager-base";
-import {CoreTypes, GDBServer} from "./ios-core";
+import { hook } from "../../../helpers";
+import { ApplicationManagerBase } from "../../application-manager-base";
+import { CoreTypes, GDBServer } from "./ios-core";
 import Future = require("fibers/future");
 
 export class IOSApplicationManager extends ApplicationManagerBase {
@@ -12,6 +13,7 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 	private applicationsLiveSyncInfos: Mobile.ILiveSyncApplicationInfo[];
 
 	constructor(protected $logger: ILogger,
+		protected $hooksService: IHooksService,
 		private device: Mobile.IiOSDevice,
 		private devicePointer: NodeBuffer,
 		private $childProcess: IChildProcess,
@@ -24,7 +26,7 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $processService: IProcessService,
 		private $options: ICommonOptions) {
-		super($logger);
+		super($logger, $hooksService);
 		this.uninstallApplicationCallbackPtr = CoreTypes.am_device_mount_image_callback.toPointer(IOSApplicationManager.uninstallCallback);
 	}
 
@@ -43,6 +45,7 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 		}).future<string[]>()();
 	}
 
+	@hook('install')
 	public installApplication(packageFilePath: string): IFuture<void> {
 		return (() => {
 			let installationProxy = this.getInstallationProxy();
@@ -74,8 +77,8 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 						"ApplicationType": "User",
 						"ReturnAttributes": [
 							"CFBundleIdentifier",
-								"IceniumLiveSyncEnabled",
-								"configuration"
+							"IceniumLiveSyncEnabled",
+							"configuration"
 						]
 					}
 				}).wait();
@@ -158,7 +161,7 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 						isLiveSyncSupported: app.IceniumLiveSyncEnabled,
 						configuration: app.configuration,
 						deviceIdentifier: this.device.deviceInfo.identifier
-					 }));
+					}));
 					this.applicationsLiveSyncInfos = this.applicationsLiveSyncInfos.concat(currentList);
 				});
 

--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -2,6 +2,7 @@ import {ApplicationManagerBase} from "../../application-manager-base";
 import Future = require("fibers/future");
 import * as path from "path";
 import * as temp from "temp";
+import { hook } from "../../../helpers";
 
 export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 	constructor(private iosSim: any,
@@ -11,14 +12,16 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		private $bplistParser: IBinaryPlistParser,
 		private $iOSSimulatorLogProvider: Mobile.IiOSSimulatorLogProvider,
 		private $deviceLogProvider: Mobile.IDeviceLogProvider,
-		$logger: ILogger) {
-		super($logger);
+		$logger: ILogger,
+		$hooksService: IHooksService) {
+		super($logger, $hooksService);
 	}
 
 	public getInstalledApplications(): IFuture<string[]> {
 		return Future.fromResult(this.iosSim.getInstalledApplications(this.identifier));
 	}
 
+	@hook('install')
 	public installApplication(packageFilePath: string): IFuture<void> {
 		return (() => {
 			if (this.$fs.exists(packageFilePath).wait() && path.extname(packageFilePath) === ".zip") {

--- a/test/unit-tests/mobile/application-manager-base.ts
+++ b/test/unit-tests/mobile/application-manager-base.ts
@@ -1,6 +1,6 @@
-import {Yok} from "../../../yok";
-import {assert} from "chai";
-import { CommonLoggerStub } from "../stubs";
+import { Yok } from "../../../yok";
+import { assert } from "chai";
+import { CommonLoggerStub, HooksServiceStub } from "../stubs";
 import { ApplicationManagerBase } from "../../../mobile/application-manager-base";
 import Future = require("fibers/future");
 
@@ -9,8 +9,8 @@ let currentlyAvailableAppsForDebugging: Mobile.IDeviceApplicationInformation[],
 	currentlyAvailableAppWebViewsForDebugging: IDictionary<Mobile.IDebugWebViewInfo[]>;
 
 class ApplicationManager extends ApplicationManagerBase {
-	constructor($logger: ILogger) {
-		super($logger);
+	constructor($logger: ILogger, $hooksService: IHooksService) {
+		super($logger, $hooksService);
 	}
 
 	public isLiveSyncSupported(appIdentifier: string): IFuture<boolean> {
@@ -57,6 +57,7 @@ class ApplicationManager extends ApplicationManagerBase {
 function createTestInjector(): IInjector {
 	let testInjector = new Yok();
 	testInjector.register("logger", CommonLoggerStub);
+	testInjector.register("hooksService", HooksServiceStub);
 	testInjector.register("applicationManager", ApplicationManager);
 	return testInjector;
 }

--- a/test/unit-tests/stubs.ts
+++ b/test/unit-tests/stubs.ts
@@ -1,6 +1,7 @@
 /* tslint:disable:no-empty */
 
 import * as util from "util";
+import Future = require("fibers/future");
 
 export class CommonLoggerStub implements ILogger {
 	setLevel(level: string): void { }
@@ -63,4 +64,15 @@ export class ErrorsStub implements IErrors {
 	}
 
 	verifyHeap(message: string): void { }
+}
+
+export class HooksServiceStub implements IHooksService {
+	executeBeforeHooks(commandName: string): IFuture<void> {
+		return Future.fromResult();
+	}
+	executeAfterHooks(commandName: string): IFuture<void> {
+		return Future.fromResult();
+	}
+
+	hookArgsName = "hookArgs";
 }


### PR DESCRIPTION
Can be useful for some scenarios like granting permissions for application via adb (automating testing process). Granting permissions require app to be deployed on device in order to work, so after-prepare hook cannot be used.