### PR TITLE
Break CLI process when Node is not supported

### DIFF
--- a/verify-node-version.ts
+++ b/verify-node-version.ts
@@ -1,29 +1,32 @@
 
 // This function must be separate to avoid dependencies on C++ modules - it must execute precisely when other functions cannot
 
-import {EOL} from "os";
-import * as semver from "semver";
+// Use only ES5 code here - pure JavaScript can be executed with any Node.js version (even 0.10, 0.12).
+/* tslint:disable:no-var-keyword no-var-requires */
+var os = require("os"),
+	semver = require("semver"),
+	util = require("util");
 
 // These versions cannot be used with CLI due to bugs in the node itself.
 // We are absolutely sure we cannot work with them, so inform the user if he is trying to use any of them and exit the process.
-let versionsCausingFailure = ["0.10.34", "4.0.0", "4.2.0", "5.0.0"];
+var versionsCausingFailure = ["0.10.34", "4.0.0", "4.2.0", "5.0.0"];
+var minimumRequiredVersion = "4.2.1";
 
-export function verifyNodeVersion(supportedVersionsRange: string, cliName: string, deprecationVersion: string): void {
+export function verifyNodeVersion(supportedVersionsRange: string, cliName: string): void {
 	// The colors module should not be assigned to variable because the lint task will fail for not used variable.
 	require("colors");
-	let nodeVer = process.version.substr(1);
 
-	if (versionsCausingFailure.indexOf(nodeVer) !== -1) {
-		console.error(`${EOL}Node.js '${nodeVer}' is not supported. To be able to work with ${cliName} CLI, install any Node.js version in the following range: ${supportedVersionsRange}.${EOL}`.red.bold);
+	var nodeVer = process.version.substr(1);
+
+	if (versionsCausingFailure.indexOf(nodeVer) !== -1 || !semver.valid(nodeVer) || semver.lt(nodeVer, minimumRequiredVersion)) {
+		console.error(util.format("%sNode.js '%s' is not supported. To be able to work with %s CLI, install any Node.js version in the following range: %s.%s",
+				os.EOL, nodeVer, cliName, supportedVersionsRange, os.EOL).red.bold);
 		process.exit(1);
 	}
 
-	if (semver.satisfies(nodeVer, "~0.12.0")) {
-		console.warn(`${EOL}Support for Node.js 0.12.x is deprecated and will be removed in the ${cliName} ${deprecationVersion} release. Please, upgrade to the latest Node.js LTS version.${EOL}`.yellow.bold);
-	} else {
-		let checkSatisfied = semver.satisfies(nodeVer, supportedVersionsRange);
-		if (!checkSatisfied) {
-			console.log(`${EOL}Support for Node.js ${nodeVer} is not verified. This CLI might not install or run properly.${EOL}`.yellow.bold);
-		}
+	var checkSatisfied = semver.satisfies(nodeVer, supportedVersionsRange);
+	if (!checkSatisfied) {
+		console.log(util.format("%sSupport for Node.js %s is not verified. This CLI might not install or run properly.%s", os.EOL, nodeVer, os.EOL).yellow.bold);
 	}
 }
+/* tslint:enable */


### PR DESCRIPTION
As old versions of Node.js cannot be used anymore (after transpiling to ES6), we should break the process when such case happens.
Use only var instead of let, const, as only var keyword is supported in Node.js 0.10.x