### PR TITLE
Fix $injector to resolve lambdas

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -362,7 +362,7 @@ export function connectEventuallyUntilTimeout(factory: () => net.Socket, timeout
 
 const CLASS_NAME = /class\s+([A-Z].+?)(?:\s+.*?)?\{/;
 const CONSTRUCTOR_ARGS = /constructor\s*([^\(]*)\(\s*([^\)]*)\)/m;
-const FN_NAME_AND_ARGS = /^(?:function)?\s*([^\(]*)\(\s*([^\)]*)\)\s*\{/m;
+const FN_NAME_AND_ARGS = /^(?:function)?\s*([^\(]*)\(\s*([^\)]*)\)\s*(=>)?\s*\{/m;
 const FN_ARG_SPLIT = /,/;
 const FN_ARG = /^\s*(_?)(\S+?)\1\s*$/;
 const STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;

--- a/test/unit-tests/yok.ts
+++ b/test/unit-tests/yok.ts
@@ -63,6 +63,43 @@ describe("yok", () => {
 			assert.strictEqual(obj, result.foo);
 		});
 
+		it("injects directly into passed constructor, ES6 lambda", () => {
+			let injector = new Yok();
+			let obj = {};
+			let resultFoo: any = null;
+
+			injector.register("foo", obj);
+
+			let Test = (foo:any) => {
+				resultFoo = foo;
+			};
+
+			injector.resolve(Test);
+
+			assert.strictEqual(obj, resultFoo);
+		});
+
+		it("injects directly into passed constructor, ES6 lambda, constructor args", () => {
+			const injector = new Yok();
+			const obj = {};
+			const expectedBar = {};
+
+			let resultFoo: any = null,
+				resultBar: any = null;
+
+			injector.register("foo", obj);
+
+			let Test = (foo:any, bar: any) => {
+				resultFoo = foo;
+				resultBar = bar;
+			};
+
+			injector.resolve(Test, { bar: expectedBar });
+
+			assert.strictEqual(obj, resultFoo);
+			assert.strictEqual(expectedBar, resultBar);
+		});
+
 		it("inject dependency into registered constructor", () => {
 			let injector = new Yok();
 			let obj = {};
@@ -77,6 +114,47 @@ describe("yok", () => {
 			let result = injector.resolve("test");
 
 			assert.strictEqual(obj, result.foo);
+		});
+
+		it("inject dependency into registered constructor, ES6 lambda", () => {
+			let injector = new Yok();
+			let obj = {};
+			let resultFoo: any = null;
+
+			injector.register("foo", obj);
+
+			let Test = (foo:any) => {
+				resultFoo = foo;
+			};
+
+			injector.register("test", Test);
+
+			injector.resolve("test");
+
+			assert.strictEqual(obj, resultFoo);
+		});
+
+		it("inject dependency into registered constructor, ES6 lambda, constructor args", () => {
+			const injector = new Yok();
+			const obj = {};
+			const expectedBar = {};
+
+			let resultFoo: any = null,
+				resultBar: any = null;
+
+			injector.register("foo", obj);
+
+			let Test = (foo: any, bar: any) => {
+				resultFoo = foo;
+				resultBar = bar;
+			};
+
+			injector.register("test", Test);
+
+			injector.resolve("test", { bar: expectedBar });
+
+			assert.strictEqual(obj, resultFoo);
+			assert.strictEqual(expectedBar, resultBar);
 		});
 
 		it("inject dependency with $ prefix", () => {
@@ -202,6 +280,29 @@ describe("yok", () => {
 			assert.strictEqual(obj, result.foo);
 		});
 
+		it("injects directly into passed constructor, constructor args", () => {
+			const injector = new Yok();
+			const obj = {};
+			const expectedBar = {};
+
+			injector.register("foo", obj);
+
+			class Test {
+				private foo: any;
+				private bar: any;
+
+				constructor(foo: any, bar: any) {
+					this.foo = foo;
+					this.bar = bar;
+				}
+			};
+
+			let result = injector.resolve(Test, { bar: expectedBar });
+
+			assert.strictEqual(obj, result.foo);
+			assert.strictEqual(expectedBar, result.bar);
+		});
+
 		it("inject dependency into registered constructor", () => {
 			let injector = new Yok();
 			let obj = {};
@@ -220,6 +321,31 @@ describe("yok", () => {
 			let result = injector.resolve("test");
 
 			assert.strictEqual(obj, result.foo);
+		});
+
+		it("inject dependency into registered constructor, constructor args", () => {
+			const injector = new Yok();
+			const obj = {};
+			const expectedBar = {};
+
+			injector.register("foo", obj);
+
+			class Test {
+				private foo: any;
+				private bar: any;
+
+				constructor(foo: any, bar: any) {
+					this.foo = foo;
+					this.bar = bar;
+				}
+			};
+
+			injector.register("test", Test);
+
+			let result = injector.resolve("test", { bar: expectedBar });
+
+			assert.strictEqual(obj, result.foo);
+			assert.strictEqual(expectedBar, result.bar);
 		});
 
 		it("inject dependency with $ prefix", () => {


### PR DESCRIPTION
As the transpilation had been changed to ES6 instead of ES5, there is a problem, when $injector should resolve lambdas.
When they are transpiled to ES5, they are converted to functions. However in ES6 they are still lambdas and current `annotate` method does not work correctly.
Fix the regex that's used for the parsing and add unit tests for the failing cases.