### PR TITLE
Set stdio inherit to npm install

### DIFF
--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -365,7 +365,7 @@ export class NpmService implements INpmService {
 	}
 
 	private executeNpmCommandCore(projectDir: string, npmArguments: string[]): IFuture<ISpawnResult> {
-		return this.$childProcess.spawnFromEvent(this.npmExecutableName, npmArguments, "close", { cwd: projectDir });
+		return this.$childProcess.spawnFromEvent(this.npmExecutableName, npmArguments, "close", { cwd: projectDir, stdio: "inherit" });
 	}
 
 	private getNpmProxySettings(): IFuture<IProxySettings> {


### PR DESCRIPTION
We need to set the stdio when installing node modules because nativescript-telerik-ui asks for email in its post-install script and does not check if the terminal is interactive or not. If it is not interactive it will ask for email and out npm install will hang.