### PR TITLE
Implemented get/put file functionality in device file systems

### DIFF
--- a/commands/device/get-file.ts
+++ b/commands/device/get-file.ts
@@ -9,7 +9,7 @@ export class GetFileCommand implements ICommand {
 		return (() => {
 			this.$devicesService.initialize({ deviceId: this.$options.device, skipInferPlatform: true }).wait();
 
-			let action = (device: Mobile.IDevice) =>  { return (() => device.fileSystem.getFile(args[0]).wait()).future<void>()(); };
+			let action = (device: Mobile.IDevice) =>  { return (() => device.fileSystem.getFile(args[0], this.$options.file).wait()).future<void>()(); };
 			this.$devicesService.execute(action).wait();
 		}).future<void>()();
 	}

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -286,7 +286,7 @@ declare module Mobile {
 
 	interface IDeviceFileSystem {
 		listFiles(devicePath: string, appIdentifier?: string): IFuture<any>;
-		getFile(deviceFilePath: string): IFuture<void>;
+		getFile(deviceFilePath: string, outputFilePath?: string): IFuture<void>;
 		putFile(localFilePath: string, deviceFilePath: string): IFuture<void>;
 		deleteFile?(deviceFilePath: string, appIdentifier: string): void;
 		transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<void>;

--- a/mobile/ios/device/ios-proxy-services.ts
+++ b/mobile/ios/device/ios-proxy-services.ts
@@ -78,15 +78,10 @@ export class AfcFile extends AfcBase implements Mobile.IAfcFile {
 	public read(len: number): any {
 		let readLengthRef = ref.alloc(iOSCore.CoreTypes.uintType, len);
 		let data = new Buffer(len * iOSCore.CoreTypes.pointerSize);
-		let result = this.tryExecuteAfcAction(() => {
-			data = new Buffer(len * iOSCore.CoreTypes.pointerSize);
-			this.$mobileDevice.afcFileRefRead(this.afcConnection, this.afcFile, data, readLengthRef);
-		});
-
-		if(result !== 0) {
+		let result = this.tryExecuteAfcAction(() =>	this.$mobileDevice.afcFileRefRead(this.afcConnection, this.afcFile, data, readLengthRef));
+		if (result !== 0) {
 			this.$errors.fail("Unable to read data from file '%s'. Result is: '%s'", this.afcFile, result);
 		}
-
 		let readLength = readLengthRef.deref();
 		return data.slice(0, readLength);
 	}

--- a/mobile/ios/simulator/ios-simulator-file-system.ts
+++ b/mobile/ios/simulator/ios-simulator-file-system.ts
@@ -12,12 +12,18 @@ export class IOSSimulatorFileSystem implements Mobile.IDeviceFileSystem {
 		return this.iosSim.listFiles(devicePath);
 	}
 
-	public getFile(deviceFilePath: string): IFuture<void> {
-		return this.iosSim.getFile(deviceFilePath);
+	public getFile(deviceFilePath: string, outputFilePath?: string): IFuture<void> {
+		return (() => {
+			if (outputFilePath) {
+				shelljs.cp("-f", deviceFilePath, outputFilePath);
+			}
+		}).future<void>()();
 	}
 
 	public putFile(localFilePath: string, deviceFilePath: string): IFuture<void> {
-		return this.iosSim.putFile(localFilePath, deviceFilePath);
+		return (() => {
+			shelljs.cp("-f", localFilePath, deviceFilePath);
+		}).future<void>()();
 	}
 
 	public deleteFile(deviceFilePath: string, appIdentifier: string): void {

--- a/options.ts
+++ b/options.ts
@@ -32,7 +32,7 @@ export class OptionsBase {
 		private $errors: IErrors,
 		private $staticConfig: Config.IStaticConfig) {
 
-		_.extend(this.options, this.commonOptions, this.globalOptions);
+		this.options = _.extend({}, this.commonOptions, this.options, this.globalOptions);
 		this.setArgv();
 	}
 


### PR DESCRIPTION
This functionality was necessary in order to implement predictable livesync as described here:

https://github.com/NativeScript/nativescript-cli/issues/2153
https://github.com/NativeScript/nativescript-cli/issues/2330

* Removed the watch option from options list. This option is specific for {N} CLI.