### PR TITLE
Update TypeScript to 2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,14 +78,14 @@
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-watch": "1.0.0",
     "grunt-shell": "1.3.0",
-    "grunt-ts": "6.0.0-beta.3",
+    "grunt-ts": "6.0.0-beta.6",
     "grunt-tslint": "3.3.0",
     "istanbul": "0.4.5",
     "mocha": "2.5.3",
     "mocha-fibers": "1.1.1",
     "spec-xunit-file": "0.0.1-3",
     "tslint": "3.15.1",
-    "typescript": "2.0.7"
+    "typescript": "2.1.4"
   },
   "bundledDependencies": [],
   "license": "Apache-2.0",

--- a/test/unit-tests/appbuilder/device-emitter.ts
+++ b/test/unit-tests/appbuilder/device-emitter.ts
@@ -134,17 +134,17 @@ describe("deviceEmitter", () => {
 					});
 				};
 
-				it("is raised when working with android device", (done) => {
+				it("is raised when working with android device", (done: mocha.Done) => {
 					attachDeviceEventVerificationHandler(androidDevice.deviceInfo, done);
 					androidDeviceDiscovery.emit(deviceEvent, androidDevice);
 				});
 
-				it("is raised when working with iOS device", (done) => {
+				it("is raised when working with iOS device", (done: mocha.Done) => {
 					attachDeviceEventVerificationHandler(iOSDevice.deviceInfo, done);
 					iOSDeviceDiscovery.emit(deviceEvent, iOSDevice);
 				});
 
-				it("is raised when working with iOS simulator", (done) => {
+				it("is raised when working with iOS simulator", (done: mocha.Done) => {
 					attachDeviceEventVerificationHandler(iOSSimulator.deviceInfo, done);
 					iOSSimulatorDiscovery.emit(deviceEvent, iOSSimulator);
 				});
@@ -165,17 +165,17 @@ describe("deviceEmitter", () => {
 				});
 			};
 
-			it("is called when working with android device", (done) => {
+			it("is called when working with android device", (done: mocha.Done) => {
 				attachDeviceEventVerificationHandler(androidDevice.deviceInfo, done);
 				androidDeviceDiscovery.emit("deviceFound", androidDevice);
 			});
 
-			it("is called when working with iOS device", (done) => {
+			it("is called when working with iOS device", (done: mocha.Done) => {
 				attachDeviceEventVerificationHandler(iOSDevice.deviceInfo, done);
 				iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
 			});
 
-			it("is called when working with iOS simulator", (done) => {
+			it("is called when working with iOS simulator", (done: mocha.Done) => {
 				attachDeviceEventVerificationHandler(iOSSimulator.deviceInfo, done);
 				iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
 			});
@@ -201,19 +201,19 @@ describe("deviceEmitter", () => {
 					});
 				};
 
-				it("is called when android device reports data", (done) => {
+				it("is called when android device reports data", (done: mocha.Done) => {
 					attachDeviceLogDataVerificationHandler(androidDevice.deviceInfo.identifier, done);
 					androidDeviceDiscovery.emit("deviceFound", androidDevice);
 					deviceLogProvider.emit("data", androidDevice.deviceInfo.identifier, expectedDeviceLogData);
 				});
 
-				it("is called when iOS device reports data", (done) => {
+				it("is called when iOS device reports data", (done: mocha.Done) => {
 					attachDeviceLogDataVerificationHandler(iOSDevice.deviceInfo.identifier, done);
 					iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
 					deviceLogProvider.emit("data", iOSDevice.deviceInfo.identifier, expectedDeviceLogData);
 				});
 
-				it("is called when iOS simulator reports data", (done) => {
+				it("is called when iOS simulator reports data", (done: mocha.Done) => {
 					attachDeviceLogDataVerificationHandler(iOSSimulator.deviceInfo.identifier, done);
 					iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
 					deviceLogProvider.emit("data", iOSSimulator.deviceInfo.identifier, expectedDeviceLogData);
@@ -236,19 +236,19 @@ describe("deviceEmitter", () => {
 					});
 				};
 
-				it("is raised when working with android device", (done) => {
+				it("is raised when working with android device", (done: mocha.Done) => {
 					attachApplicationEventVerificationHandler(androidDevice.deviceInfo.identifier, done);
 					androidDeviceDiscovery.emit("deviceFound", androidDevice);
 					androidDevice.applicationManager.emit(applicationEvent, expectedApplicationIdentifier);
 				});
 
-				it("is raised when working with iOS device", (done) => {
+				it("is raised when working with iOS device", (done: mocha.Done) => {
 					attachApplicationEventVerificationHandler(iOSDevice.deviceInfo.identifier, done);
 					iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
 					iOSDevice.applicationManager.emit(applicationEvent, expectedApplicationIdentifier);
 				});
 
-				it("is raised when working with iOS simulator", (done) => {
+				it("is raised when working with iOS simulator", (done: mocha.Done) => {
 					attachApplicationEventVerificationHandler(iOSSimulator.deviceInfo.identifier, done);
 					iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
 					iOSSimulator.applicationManager.emit(applicationEvent, expectedApplicationIdentifier);
@@ -268,7 +268,7 @@ describe("deviceEmitter", () => {
 					});
 				};
 
-				it("is raised when working with android device", (done) => {
+				it("is raised when working with android device", (done: mocha.Done) => {
 					let debuggableAppInfo: Mobile.IDeviceApplicationInformation = {
 						appIdentifier: "app identifier",
 						deviceIdentifier: androidDevice.deviceInfo.identifier,
@@ -280,7 +280,7 @@ describe("deviceEmitter", () => {
 					androidDevice.applicationManager.emit(applicationEvent, debuggableAppInfo);
 				});
 
-				it("is raised when working with iOS device", (done) => {
+				it("is raised when working with iOS device", (done: mocha.Done) => {
 					let debuggableAppInfo: Mobile.IDeviceApplicationInformation = {
 						appIdentifier: "app identifier",
 						deviceIdentifier: iOSDevice.deviceInfo.identifier,
@@ -292,7 +292,7 @@ describe("deviceEmitter", () => {
 					iOSDevice.applicationManager.emit(applicationEvent, debuggableAppInfo);
 				});
 
-				it("is raised when working with iOS simulator", (done) => {
+				it("is raised when working with iOS simulator", (done: mocha.Done) => {
 					let debuggableAppInfo: Mobile.IDeviceApplicationInformation = {
 						appIdentifier: "app identifier",
 						deviceIdentifier: iOSSimulator.deviceInfo.identifier,
@@ -336,7 +336,7 @@ describe("deviceEmitter", () => {
 					});
 				};
 
-				it("is raised when working with android device", (done) => {
+				it("is raised when working with android device", (done: mocha.Done) => {
 					let expectedDebuggableViewInfo: Mobile.IDebugWebViewInfo = createDebuggableWebView("test1");
 
 					attachDebuggableEventVerificationHandler(androidDevice.deviceInfo.identifier, appId, expectedDebuggableViewInfo, done);
@@ -344,7 +344,7 @@ describe("deviceEmitter", () => {
 					androidDevice.applicationManager.emit(applicationEvent, appId, expectedDebuggableViewInfo);
 				});
 
-				it("is raised when working with iOS device", (done) => {
+				it("is raised when working with iOS device", (done: mocha.Done) => {
 					let expectedDebuggableViewInfo: Mobile.IDebugWebViewInfo = createDebuggableWebView("test1");
 
 					attachDebuggableEventVerificationHandler(iOSDevice.deviceInfo.identifier, appId, expectedDebuggableViewInfo, done);
@@ -352,7 +352,7 @@ describe("deviceEmitter", () => {
 					iOSDevice.applicationManager.emit(applicationEvent, appId, expectedDebuggableViewInfo);
 				});
 
-				it("is raised when working with iOS simulator", (done) => {
+				it("is raised when working with iOS simulator", (done: mocha.Done) => {
 					let expectedDebuggableViewInfo: Mobile.IDebugWebViewInfo = createDebuggableWebView("test1");
 
 					attachDebuggableEventVerificationHandler(iOSSimulator.deviceInfo.identifier, appId, expectedDebuggableViewInfo, done);
@@ -376,7 +376,7 @@ describe("deviceEmitter", () => {
 							});
 						};
 
-						it("when working with android device", (done) => {
+						it("when working with android device", (done: mocha.Done) => {
 							attachCompanionEventVerificationHandler(androidDevice.deviceInfo.identifier, done);
 							androidDeviceDiscovery.emit("deviceFound", androidDevice);
 							androidDevice.applicationManager.emit("applicationInstalled", companionAppIdentifersForPlatform["android"]);
@@ -385,7 +385,7 @@ describe("deviceEmitter", () => {
 							}
 						});
 
-						it("when working with iOS device", (done) => {
+						it("when working with iOS device", (done: mocha.Done) => {
 							attachCompanionEventVerificationHandler(iOSDevice.deviceInfo.identifier, done);
 							iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
 							iOSDevice.applicationManager.emit("applicationInstalled", companionAppIdentifersForPlatform["ios"]);
@@ -394,7 +394,7 @@ describe("deviceEmitter", () => {
 							}
 						});
 
-						it("when working with iOS simulator", (done) => {
+						it("when working with iOS simulator", (done: mocha.Done) => {
 							attachCompanionEventVerificationHandler(iOSSimulator.deviceInfo.identifier, done);
 							iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
 							iOSSimulator.applicationManager.emit("applicationInstalled", companionAppIdentifersForPlatform["ios"]);

--- a/test/unit-tests/decorators.ts
+++ b/test/unit-tests/decorators.ts
@@ -1,6 +1,6 @@
 import * as decoratorsLib from "../../decorators";
 import { Yok } from "../../yok";
-import {assert} from "chai";
+import { assert } from "chai";
 import Future = require("fibers/future");
 
 describe("decorators", () => {
@@ -39,7 +39,7 @@ describe("decorators", () => {
 			assert.deepEqual(typeof ($injector.publicApi.__modules__[moduleName][propertyName]), "function");
 		});
 
-		it("returns Promise", (done) => {
+		it("returns Promise", (done: mocha.Done) => {
 			let expectedResult = "result";
 			$injector.register(moduleName, { propertyName: () => expectedResult });
 			generatePublicApiFromExportedPromiseDecorator();
@@ -51,7 +51,7 @@ describe("decorators", () => {
 			}).then(done).catch(done);
 		});
 
-		it("returns Promise, which is resolved to correct value (function without arguments)", (done) => {
+		it("returns Promise, which is resolved to correct value (function without arguments)", (done: mocha.Done) => {
 			let expectedResult = "result";
 			$injector.register(moduleName, { propertyName: () => expectedResult });
 			generatePublicApiFromExportedPromiseDecorator();
@@ -62,7 +62,7 @@ describe("decorators", () => {
 			}).then(done).catch(done);
 		});
 
-		it("returns Promise, which is resolved to correct value (function with arguments)", (done) => {
+		it("returns Promise, which is resolved to correct value (function with arguments)", (done: mocha.Done) => {
 			let expectedArgs = ["result", "result1", "result2"];
 			$injector.register(moduleName, { propertyName: (functionArgs: string[]) => functionArgs });
 			generatePublicApiFromExportedPromiseDecorator();
@@ -73,7 +73,7 @@ describe("decorators", () => {
 			}).then(done).catch(done);
 		});
 
-		it("returns Promise, which is resolved to correct value (function returning IFuture without arguments)", (done) => {
+		it("returns Promise, which is resolved to correct value (function returning IFuture without arguments)", (done: mocha.Done) => {
 			let expectedResult = "result";
 			$injector.register(moduleName, { propertyName: () => Future.fromResult(expectedResult) });
 			generatePublicApiFromExportedPromiseDecorator();
@@ -84,7 +84,7 @@ describe("decorators", () => {
 			}).then(done).catch(done);
 		});
 
-		it("returns Promise, which is resolved to correct value (function returning IFuture with arguments)", (done) => {
+		it("returns Promise, which is resolved to correct value (function returning IFuture with arguments)", (done: mocha.Done) => {
 			let expectedArgs = ["result", "result1", "result2"];
 			$injector.register(moduleName, { propertyName: (args: string[]) => Future.fromResult(args) });
 			generatePublicApiFromExportedPromiseDecorator();
@@ -95,7 +95,7 @@ describe("decorators", () => {
 			}).then(done).catch(done);
 		});
 
-		it("rejects Promise, which is resolved to correct error (function without arguments throws)", (done) => {
+		it("rejects Promise, which is resolved to correct error (function without arguments throws)", (done: mocha.Done) => {
 			let expectedError = new Error("Test msg");
 			$injector.register(moduleName, { propertyName: () => { throw expectedError; } });
 			generatePublicApiFromExportedPromiseDecorator();
@@ -108,7 +108,7 @@ describe("decorators", () => {
 			}).then(done).catch(done);
 		});
 
-		it("rejects Promise, which is resolved to correct error (function returning IFuture without arguments throws)", (done) => {
+		it("rejects Promise, which is resolved to correct error (function returning IFuture without arguments throws)", (done: mocha.Done) => {
 			let expectedError = new Error("Test msg");
 			$injector.register(moduleName, { propertyName: () => { return (() => { throw expectedError; }).future<void>()(); } });
 			generatePublicApiFromExportedPromiseDecorator();
@@ -122,7 +122,7 @@ describe("decorators", () => {
 			}).then(done).catch(done);
 		});
 
-		it("returns Promises, which are resolved to correct value (function returning IFuture<T>[] without arguments)", (done) => {
+		it("returns Promises, which are resolved to correct value (function returning IFuture<T>[] without arguments)", (done: mocha.Done) => {
 			let expectedResults = ["result1", "result2", "result3"];
 			$injector.register(moduleName, { propertyName: () => _.map(expectedResults, expectedResult => Future.fromResult(expectedResult)) });
 			generatePublicApiFromExportedPromiseDecorator();
@@ -134,11 +134,11 @@ describe("decorators", () => {
 						assert.deepEqual(val, expectedResults[index]);
 					});
 				})
-				.then(done)
+				.then(() => done())
 				.catch(done);
 		});
 
-		it("rejects Promises, which are resolved to correct error (function returning IFuture<T>[] without arguments throws)", (done) => {
+		it("rejects Promises, which are resolved to correct error (function returning IFuture<T>[] without arguments throws)", (done: mocha.Done) => {
 			let expectedErrors = [new Error("result1"), new Error("result2"), new Error("result3")];
 			$injector.register(moduleName, { propertyName: () => _.map(expectedErrors, expectedError => { return (() => { throw expectedError; }).future<void>()(); }) });
 			generatePublicApiFromExportedPromiseDecorator();
@@ -160,7 +160,7 @@ describe("decorators", () => {
 			}).then(done).catch(done);
 		});
 
-		it("rejects only Promises which throw, resolves the others correctly (function returning IFuture<T>[] without arguments)", (done) => {
+		it("rejects only Promises which throw, resolves the others correctly (function returning IFuture<T>[] without arguments)", (done: mocha.Done) => {
 			let expectedResults: any[] = ["result1", new Error("result2")];
 			$injector.register(moduleName, { propertyName: () => _.map(expectedResults, expectedResult => Future.fromResult(expectedResult)) });
 			generatePublicApiFromExportedPromiseDecorator();
@@ -210,7 +210,7 @@ describe("decorators", () => {
 				isActionExecuted = false;
 			});
 
-			it("executes postAction after all promises are resolved (function returning IFuture<T>)", (done) => {
+			it("executes postAction after all promises are resolved (function returning IFuture<T>)", (done: mocha.Done) => {
 				expectedResults = "result";
 
 				$injector.register(moduleName, {
@@ -229,7 +229,7 @@ describe("decorators", () => {
 					.catch(done);
 			});
 
-			it("executes postAction after all promises are resolved (function returning IFuture<T>[])", (done) => {
+			it("executes postAction after all promises are resolved (function returning IFuture<T>[])", (done: mocha.Done) => {
 				expectedResults = ["result1", "result2", "result3"];
 
 				$injector.register(moduleName, {
@@ -245,11 +245,11 @@ describe("decorators", () => {
 
 				Promise.all(getPromisesWithPostAction())
 					.then(assertResults)
-					.then(done)
+					.then(() => done())
 					.catch(done);
 			});
 
-			it("executes postAction after a promise is rejected (function returning IFuture<T> that throws)", (done) => {
+			it("executes postAction after a promise is rejected (function returning IFuture<T> that throws)", (done: mocha.Done) => {
 				expectedResults = "result";
 				let errorMessage = "This future throws";
 
@@ -276,7 +276,7 @@ describe("decorators", () => {
 					.catch(done);
 			});
 
-			it("executes postAction after all promises are rejected (function returning IFuture<T>[] that throws)", (done) => {
+			it("executes postAction after all promises are rejected (function returning IFuture<T>[] that throws)", (done: mocha.Done) => {
 				expectedResults = ["result1", "result2", "result3"];
 				let errorMessage = "This future throws.";
 
@@ -316,7 +316,7 @@ describe("decorators", () => {
 					.catch(done);
 			});
 
-			it("executes postAction after all some promises are rejected and others are resolved (function returning IFuture<T>[] where some of the future throw)", (done) => {
+			it("executes postAction after all some promises are rejected and others are resolved (function returning IFuture<T>[] where some of the future throw)", (done: mocha.Done) => {
 				let calledActionsCount = 0;
 				expectedResults = ["result1", "result2", "result3", "result4"];
 				let errorMessage = "This future throws.";

--- a/test/unit-tests/helpers.ts
+++ b/test/unit-tests/helpers.ts
@@ -333,18 +333,19 @@ describe("helpers", () => {
 		];
 
 		_.each(settlePromisesTestData, (testData, inputNumber) => {
-			it(`returns correct data, test case ${inputNumber}`, (done) => {
+			it(`returns correct data, test case ${inputNumber}`, (done: mocha.Done) => {
+				const invokeDoneCallback = () => done();
 				helpers.settlePromises<any>(testData.input)
 					.then(res => {
 						assert.deepEqual(res, testData.expectedResult);
 					}, err => {
 						assert.deepEqual(err.message, testData.expectedError);
 					})
-					.then(done, done);
+					.then(invokeDoneCallback, invokeDoneCallback);
 			});
 		});
 
-		it("executes all promises even when some of them are rejected", (done) => {
+		it("executes all promises even when some of them are rejected", (done: mocha.Done) => {
 			let isPromiseSettled = false;
 
 			const testData: ITestData = {

--- a/test/unit-tests/mobile/application-manager-base.ts
+++ b/test/unit-tests/mobile/application-manager-base.ts
@@ -104,7 +104,7 @@ describe("ApplicationManagerBase", () => {
 
 	describe("checkForApplicationUpdates", () => {
 		describe("debuggableApps", () => {
-			it("emits debuggableAppFound when new application is available for debugging", (done) => {
+			it("emits debuggableAppFound when new application is available for debugging", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
 				let foundAppsForDebug: Mobile.IDeviceApplicationInformation[] = [];
 
@@ -121,7 +121,7 @@ describe("ApplicationManagerBase", () => {
 				applicationManager.checkForApplicationUpdates().wait();
 			});
 
-			it("emits debuggableAppFound when new application is available for debugging (several calls)", (done) => {
+			it("emits debuggableAppFound when new application is available for debugging (several calls)", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(1);
 				let foundAppsForDebug: Mobile.IDeviceApplicationInformation[] = [],
 					isFinalCheck = false;
@@ -147,7 +147,7 @@ describe("ApplicationManagerBase", () => {
 				applicationManager.checkForApplicationUpdates().wait();
 			});
 
-			it("emits debuggableAppLost when application cannot be debugged anymore", (done) => {
+			it("emits debuggableAppLost when application cannot be debugged anymore", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
 				let expectedAppsToBeLost = currentlyAvailableAppsForDebugging,
 					lostAppsForDebug: Mobile.IDeviceApplicationInformation[] = [];
@@ -171,7 +171,7 @@ describe("ApplicationManagerBase", () => {
 				applicationManager.checkForApplicationUpdates().wait();
 			});
 
-			it("emits debuggableAppLost when application cannot be debugged anymore (several calls)", (done) => {
+			it("emits debuggableAppLost when application cannot be debugged anymore (several calls)", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(4);
 				let lostAppsForDebug: Mobile.IDeviceApplicationInformation[] = [],
 					isFinalCheck = false,
@@ -234,7 +234,7 @@ describe("ApplicationManagerBase", () => {
 				Future.wait(futures);
 			});
 
-			it("emits debuggableViewFound when new views are available for debug", (done) => {
+			it("emits debuggableViewFound when new views are available for debug", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
 				let numberOfViewsPerApp = 2;
 				currentlyAvailableAppWebViewsForDebugging = createDebuggableWebViews(currentlyAvailableAppsForDebugging, numberOfViewsPerApp);
@@ -259,7 +259,7 @@ describe("ApplicationManagerBase", () => {
 				applicationManager.checkForApplicationUpdates().wait();
 			});
 
-			it("emits debuggableViewLost when views for debug are removed", (done) => {
+			it("emits debuggableViewLost when views for debug are removed", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
 				let numberOfViewsPerApp = 2;
 				currentlyAvailableAppWebViewsForDebugging = createDebuggableWebViews(currentlyAvailableAppsForDebugging, numberOfViewsPerApp);
@@ -290,7 +290,7 @@ describe("ApplicationManagerBase", () => {
 				applicationManager.checkForApplicationUpdates().wait();
 			});
 
-			it("emits debuggableViewFound when new views are available for debug", (done) => {
+			it("emits debuggableViewFound when new views are available for debug", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
 				let numberOfViewsPerApp = 2;
 				currentlyAvailableAppWebViewsForDebugging = createDebuggableWebViews(currentlyAvailableAppsForDebugging, numberOfViewsPerApp);
@@ -325,7 +325,7 @@ describe("ApplicationManagerBase", () => {
 				applicationManager.checkForApplicationUpdates().wait();
 			});
 
-			it("emits debuggableViewLost when views for debug are not available anymore", (done) => {
+			it("emits debuggableViewLost when views for debug are not available anymore", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
 				let numberOfViewsPerApp = 2;
 				currentlyAvailableAppWebViewsForDebugging = createDebuggableWebViews(currentlyAvailableAppsForDebugging, numberOfViewsPerApp);
@@ -357,7 +357,7 @@ describe("ApplicationManagerBase", () => {
 				applicationManager.checkForApplicationUpdates().wait();
 			});
 
-			it("emits debuggableViewChanged when view's property is modified (each one except id)", (done) => {
+			it("emits debuggableViewChanged when view's property is modified (each one except id)", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(1);
 				currentlyAvailableAppWebViewsForDebugging = createDebuggableWebViews(currentlyAvailableAppsForDebugging, 2);
 				let viewToChange = currentlyAvailableAppWebViewsForDebugging[currentlyAvailableAppsForDebugging[0].appIdentifier][0];
@@ -374,7 +374,7 @@ describe("ApplicationManagerBase", () => {
 				applicationManager.checkForApplicationUpdates().wait();
 			});
 
-			it("does not emit debuggableViewChanged when id is modified", (done) => {
+			it("does not emit debuggableViewChanged when id is modified", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(1);
 				currentlyAvailableAppWebViewsForDebugging = createDebuggableWebViews(currentlyAvailableAppsForDebugging, 2);
 				let viewToChange = currentlyAvailableAppWebViewsForDebugging[currentlyAvailableAppsForDebugging[0].appIdentifier][0];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
 		"declaration": false,
 		"removeComments": false,
 		"noImplicitAny": true,
-		"experimentalDecorators": true
+		"experimentalDecorators": true,
+		"alwaysStrict": true
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
TypeScript 2.0 does not add "use strict"; in files which just declare class and does not export it. This breaks Node 4 because of the class keyword.