### PR TITLE
Fix cache decorator

### DIFF
--- a/decorators.ts
+++ b/decorators.ts
@@ -3,15 +3,15 @@ import { isPromise } from "./helpers";
 
 export function cache(): any {
 	return (target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>): TypedPropertyDescriptor<any> => {
-		let isCalled = false;
 		let result: any;
 		let propName: string = descriptor.value ? "value" : "get";
 
 		const originalValue = (<any>descriptor)[propName];
 
 		(<any>descriptor)[propName] = function (...args: any[]) {
-			if (!isCalled) {
-				isCalled = true;
+			let propertyName = `__isCalled_${propertyKey}__`;
+			if (this && !this[propertyName]) {
+				this[propertyName] = true;
 				result = originalValue.apply(this, args);
 			}
 

--- a/mobile/android/android-device.ts
+++ b/mobile/android/android-device.ts
@@ -2,7 +2,7 @@ import { DeviceAndroidDebugBridge } from "./device-android-debug-bridge";
 import * as applicationManagerPath from "./android-application-manager";
 import * as fileSystemPath from "./android-device-file-system";
 import * as constants from "../../constants";
-import { invokeInit } from "../../decorators";
+import { cache, invokeInit } from "../../decorators";
 
 interface IAndroidDeviceDetails {
 	model: string;
@@ -54,6 +54,7 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 		private $logcatHelper: Mobile.ILogcatHelper,
 		private $injector: IInjector) { }
 
+	@cache()
 	public async init(): Promise<void> {
 		this.adb = this.$injector.resolve(DeviceAndroidDebugBridge, { identifier: this.identifier });
 		this.applicationManager = this.$injector.resolve(applicationManagerPath.AndroidApplicationManager, { adb: this.adb, identifier: this.identifier });

--- a/services/hooks-service.ts
+++ b/services/hooks-service.ts
@@ -110,11 +110,8 @@ export class HooksService implements IHooksService {
 					return;
 				}
 
-				console.log(`--------------------------------------------------------------${hookName}-----------------------------------------------------------------`);
-				console.log(`--------------------------------------------------------------${hook.fullPath}-----------------------------------------------------------------`);
 				let maybePromise = this.$injector.resolve(hookEntryPoint, hookArguments);
 				if (maybePromise) {
-					console.log("---------mbpr: ", maybePromise);
 					this.$logger.trace('Hook promises to signal completion');
 					await new Promise((resolve, reject) => {
 						maybePromise.then(
@@ -129,12 +126,9 @@ export class HooksService implements IHooksService {
 							});
 					});
 
-					console.log("-------------after await");
 				}
 				this.$logger.trace('Hook completed');
-				console.log("---------mbpr down: ", maybePromise);
 			} else {
-				console.log("------------------down down");
 				let environment = this.prepareEnvironment(hook.fullPath);
 				this.$logger.trace("Executing %s hook at location %s with environment ", hookName, hook.fullPath, environment);
 


### PR DESCRIPTION
We need to cache the result of the decorated methods for each instance not for all instances. Also we need to add the name of the cached member to the cache property becasue if we do not add it we can't cache other members.

Also we need to execute build and deploy on multiple devices synchronously because the build will fail if the actions are executed for each device in parallel.

There were forgotten console.logs from debugging which are removed.