### PR TITLE
Make isEmulator a get property

### DIFF
--- a/appbuilder/providers/device-app-data-provider.ts
+++ b/appbuilder/providers/device-app-data-provider.ts
@@ -101,7 +101,7 @@ export class IOSAppIdentifier extends AppBuilderDeviceAppDataBase implements ILi
 
 	@cache()
 	public async deviceProjectRootPath(): Promise<string> {
-		if (this.device.isEmulator()) {
+		if (this.device.isEmulator) {
 			let applicationPath = this.$iOSSimResolver.iOSSim.getApplicationPath(this.device.deviceInfo.identifier, this.appIdentifier);
 			return path.join(applicationPath, "www");
 		}
@@ -126,7 +126,7 @@ export class IOSNativeScriptAppIdentifier extends AppBuilderDeviceAppDataBase im
 
 	@cache()
 	public async deviceProjectRootPath(): Promise<string> {
-		if (this.device.isEmulator()) {
+		if (this.device.isEmulator) {
 			let applicationPath = this.$iOSSimResolver.iOSSim.getApplicationPath(this.device.deviceInfo.identifier, this.appIdentifier);
 			return applicationPath;
 		}

--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -21,7 +21,7 @@ export class IOSLiveSyncService implements IDeviceLiveSyncService {
 	}
 
 	public async refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void> {
-		if (this.device.isEmulator()) {
+		if (this.device.isEmulator) {
 			let simulatorLogFilePath = path.join(osenv.home(), `/Library/Developer/CoreSimulator/Devices/${this.device.deviceInfo.identifier}/data/Library/Logs/system.log`);
 			let simulatorLogFileContent = this.$fs.readText(simulatorLogFilePath) || "";
 

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -89,7 +89,7 @@ declare module Mobile {
 		deviceInfo: Mobile.IDeviceInfo;
 		applicationManager: Mobile.IDeviceApplicationManager;
 		fileSystem: Mobile.IDeviceFileSystem;
-		isEmulator(): Promise<boolean>;
+		isEmulator: boolean;
 		openDeviceLogStream(): Promise<void>;
 		getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo>;
 	}

--- a/mobile/android/android-device.ts
+++ b/mobile/android/android-device.ts
@@ -2,7 +2,7 @@ import { DeviceAndroidDebugBridge } from "./device-android-debug-bridge";
 import * as applicationManagerPath from "./android-application-manager";
 import * as fileSystemPath from "./android-device-file-system";
 import * as constants from "../../constants";
-import { cache, invokeInit } from "../../decorators";
+import { cache } from "../../decorators";
 
 interface IAndroidDeviceDetails {
 	model: string;
@@ -91,12 +91,10 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 		this.$logger.trace(this.deviceInfo);
 	}
 
-	@invokeInit()
-	public async isEmulator(): Promise<boolean> {
+	public get isEmulator(): boolean {
 		return this.deviceInfo.type === "Emulator";
 	}
 
-	@invokeInit()
 	public async getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo> {
 		let files = await this.fileSystem.listFiles(constants.LiveSyncConstants.ANDROID_FILES_PATH, applicationIdentifier),
 			androidFilesMatch = files.match(/(\S+)\.abproject/),
@@ -113,7 +111,6 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 		return result;
 	}
 
-	@invokeInit()
 	public async openDeviceLogStream(): Promise<void> {
 		if (this.deviceInfo.status === constants.CONNECTED_STATUS) {
 			await this.$logcatHelper.start(this.identifier);

--- a/mobile/ios/device/ios-device.ts
+++ b/mobile/ios/device/ios-device.ts
@@ -88,7 +88,7 @@ export class IOSDevice implements Mobile.IiOSDevice {
 		return activeArchitecture;
 	}
 
-	public async isEmulator(): Promise<boolean> {
+	public get isEmulator(): boolean {
 		return false;
 	}
 

--- a/mobile/ios/simulator/ios-simulator-device.ts
+++ b/mobile/ios/simulator/ios-simulator-device.ts
@@ -27,7 +27,7 @@ export class IOSSimulator implements Mobile.IiOSSimulator {
 		};
 	}
 
-	public async isEmulator(): Promise<boolean> {
+	public get isEmulator(): boolean {
 		return true;
 	}
 


### PR DESCRIPTION
Instead of a function - it doesn't perform any slow operations and can be a get property.
isEmulator was previously a property but was subsequently re-written as a function, however this is no longer necessary.

Ping @rosen-vladimirov @TsvetanMilanov 