### PR TITLE
Change the resolve constructor logic in yok

### DIFF
--- a/yok.ts
+++ b/yok.ts
@@ -361,8 +361,7 @@ export class Yok implements IInjector {
 			}
 		});
 
-		let name = ctor.$inject.name;
-		if (name && name[0] === name[0].toUpperCase()) {
+		if (ctor.constructor && ctor.prototype && ctor.prototype.constructor) {
 			return new (<any>ctor)(...resolvedArgs);
 		} else {
 			return ctor.apply(null, resolvedArgs);


### PR DESCRIPTION
Right now we can't resolve classes with names starting with small letter. With this change we keep the logic for resolving hooks and hierarchical commands.