### PR TITLE
Fix ENOENT when sync to iOS simulator

### DIFF
--- a/mobile/ios/simulator/ios-simulator-file-system.ts
+++ b/mobile/ios/simulator/ios-simulator-file-system.ts
@@ -48,6 +48,7 @@ export class IOSSimulatorFileSystem implements Mobile.IDeviceFileSystem {
 			if (this.$fs.getFsStats(localFilePath).isDirectory()) {
 				shelljs.mkdir(deviceFilePath);
 			} else {
+				this.$fs.ensureDirectoryExists(path.dirname(deviceFilePath));
 				shelljs.cp("-f", localFilePath, deviceFilePath);
 			}
 		}).future<void>()();


### PR DESCRIPTION
In some cases we are not able to sync files to iOS Simulator as chokidar does not raise correct events on macOS when directory is renamed immediately after it's being created.
After adding a file to this directory we throw ENOENT, as such dir does not exist in Simulator's dir. In order to fix this, ensure the directory exist in the simulator.