### PR TITLE
Fix check if package has `@types`

### DIFF
--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -175,7 +175,7 @@ export class NpmService implements INpmService {
 	}
 
 	private async hasTypesForDependency(packageName: string): Promise<boolean> {
-		return !(await this.getPackageJsonFromNpmRegistry(`${NpmService.TYPES_DIRECTORY}${packageName}`));
+		return !!(await this.getPackageJsonFromNpmRegistry(`${NpmService.TYPES_DIRECTORY}${packageName}`));
 	}
 
 	private async buildNpmRegistryUrl(packageName: string, version: string): Promise<string> {


### PR DESCRIPTION
During migration from fibers to promises, we've lost one `!` in the check if npm package has typings in `@types` repo.
This led to incorrect behavior:
 - typings of packages, which are available in `@types`, are not installed (for example `lodash`).
 - trying to install plugin, which does not have typing in `@types` leads to error (something like `Error while installing dependency: Command npm.cmd failed with exit code 4294963238.`).

Fix the check (add the missing `!`) which will fix the incorrect behavior.