### PR TITLE
Fix getting info from registry.npmjs.org for specific version

### DIFF
--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -184,7 +184,7 @@ export class NpmService implements INpmService {
 			registryUrl += "/";
 		}
 
-		return `${registryUrl}${packageName.replace("/", "%2F")}?version=${encodeURIComponent(version)}`;
+		return `${registryUrl}${packageName.replace("/", "%2F")}/${encodeURIComponent(version)}`;
 	}
 
 	private async getNpmRegistryUrl(): Promise<string> {


### PR DESCRIPTION
CLI tries to get information for specific version of a package by calling registry.npmjs.org.
It looks like recently the registry.npmjs.org has been modified and when passing version as query parameter, it just disregards it. Now the version is part of the URL itself.
Old: `http://registry.npmjs.org/rosen-test-npm-package?version=1.0.0`
New: `http://registry.npmjs.org/rosen-test-npm-package/1.0.0`

So fix CLI's code where we are generating the URL.