### PR TITLE
Fix getting package.json from npm registry (again)

### DIFF
--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -54,7 +54,7 @@ export class NpmService implements INpmService {
 				npmInstallResult.error = err;
 			}
 
-			if (dependencyToInstall.installTypes && await npmInstallResult.result.isInstalled && this.hasTypesForDependency(dependencyToInstall.name)) {
+			if (dependencyToInstall.installTypes && npmInstallResult.result.isInstalled && await this.hasTypesForDependency(dependencyToInstall.name)) {
 				try {
 					await this.installTypingsForDependency(projectDir, dependencyToInstall.name);
 					npmInstallResult.result.isTypesInstalled = true;
@@ -144,12 +144,25 @@ export class NpmService implements INpmService {
 		let packageJsonContent: any;
 		version = version || "latest";
 		try {
-			let url = await this.buildNpmRegistryUrl(packageName, version),
+			const url = await this.buildNpmRegistryUrl(packageName),
 				proxySettings = await this.getNpmProxySettings();
 
 			// This call will return error with message '{}' in case there's no such package.
-			let result = (await this.$httpClient.httpRequest({ url, timeout }, proxySettings)).body;
-			packageJsonContent = JSON.parse(result);
+			const result = (await this.$httpClient.httpRequest({ url, timeout }, proxySettings)).body;
+
+			const fullData = JSON.parse(result);
+			const distTags = fullData["dist-tags"];
+			const versions = fullData.versions;
+
+			// check if passed version is in fact tag (for example latest, next, etc.) In this case - get the real version.
+			_.each(distTags, (ver, tagName) => {
+				if (tagName === version) {
+					version = ver;
+					return false;
+				}
+			});
+
+			packageJsonContent = versions[version];
 		} catch (err) {
 			this.$logger.trace("Error caught while checking the NPM Registry for plugin with id: %s", packageName);
 			this.$logger.trace(err.message);
@@ -178,13 +191,13 @@ export class NpmService implements INpmService {
 		return !!(await this.getPackageJsonFromNpmRegistry(`${NpmService.TYPES_DIRECTORY}${packageName}`));
 	}
 
-	private async buildNpmRegistryUrl(packageName: string, version: string): Promise<string> {
+	private async buildNpmRegistryUrl(packageName: string): Promise<string> {
 		let registryUrl = await this.getNpmRegistryUrl();
 		if (!_.endsWith(registryUrl, "/")) {
 			registryUrl += "/";
 		}
 
-		return `${registryUrl}${packageName.replace("/", "%2F")}/${encodeURIComponent(version)}`;
+		return `${registryUrl}${packageName.replace("/", "%2F")}`;
 	}
 
 	private async getNpmRegistryUrl(): Promise<string> {


### PR DESCRIPTION
CLI needs information for specific versions of packages. However registry.npmjs.org have broken something and the URL we've been using (`http://registry.npmjs.org/<package_name>?version=<version>`) does not work anymore.
Instead it returns information for all versions.
We've tried calling `http://registry.npmjs.org/<package_name>/<version>`, which seemed to work fine, but it turned out it has a lot of issues with scoped dependencies.
Issues are describe [here](https://github.com/npm/registry/issues/130).
In order to fix CLI and allow installation of all plugins, get the full information from the registry and find only the info we need for the specified version.