### PR TITLE
Fix transpilation problems

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -606,9 +606,9 @@ interface ITypeScriptService {
 	 * @param {string[]} typeScriptFiles @optional The files that will be compiled.
 	 * @param {string[]} definitionFiles @optional The definition files used for compilation.
 	 * @param {ITypeScriptTranspileOptions} options @optional The transpilation options.
-	 * @return {Promise<string>} The result from the TypeScript transpilation.
+	 * @return {Promise<void>}
 	 */
-	transpile(projectDir: string, typeScriptFiles?: string[], definitionFiles?: string[], options?: ITypeScriptTranspileOptions): Promise<string>;
+	transpile(projectDir: string, typeScriptFiles?: string[], definitionFiles?: string[], options?: ITypeScriptTranspileOptions): Promise<void>;
 
 	/**
 	 * Returns new object, containing all TypeScript and all TypeScript definition files.


### PR DESCRIPTION
The first problem is when in the tsconfig.json file in the compilerOptions there is a property with array value. We need to pass the array values correctly to the tsc command.

The second problem is with TypeScript 2.1 output. When there is an error in the output while transpiling TS 2.1 will make the `error` word red. This means that the actual autput will look like this: `[91merror [0m TS2304`. We need to update our regular expressions to match the new output.

Fixes: http://teampulse.telerik.com/view#item/329315