### PR TITLE
Fix livesync issues

### DIFF
--- a/services/process-service.ts
+++ b/services/process-service.ts
@@ -26,7 +26,11 @@ export class ProcessService implements IProcessService {
 
 	private executeAllCallbacks(): void {
 		_.each(this._listeners, (listener: IListener) => {
-			listener.callback.apply(listener.context);
+			try {
+				listener.callback.apply(listener.context);
+			} catch (err) {
+				// ignore the error and let other handlers to be called.
+			}
 		});
 	}
 }

--- a/services/typescript-service.ts
+++ b/services/typescript-service.ts
@@ -187,7 +187,7 @@ export class TypeScriptService implements ITypeScriptService {
 		if (!this._watchProcess && this.$options.watch) {
 			params.push("--watch");
 			this._watchProcess = this.$childProcess.spawn(process.argv[0], params, { cwd: projectDir });
-			this.$processService.attachToProcessExitSignals(null, this._watchProcess.kill);
+			this.$processService.attachToProcessExitSignals(this, () => this._watchProcess.kill());
 		}
 	}
 


### PR DESCRIPTION
Fix several missing `await`s in LiveSyncServiceBase which caused unexpected behavior during livesync. For example livesync to ION leads to error when adding a file in some cases.
Fix gaze to skip `node_modules` and `platforms` directories - in the current state, when we are inside Angular project, the node_modules directory contains tens of thousands of files. Gaze starts painfully slow and utilizes 100% of the CPU.
So ignore these directories.
Fix killing of TypeScript process started with `--watch` option. It failed with error `Cannot read property '_handle' of null`. Fix this by passing correct `this`.
When we are inside TypeScript process, we attach to process's SIGINT signal in order to kill TypeScript Watcher. However Node.js decides that we have to handle all other currently living processes on our own. In this particular case, gaze process is also kept alive and pressing Ctrl + C does not kill the livesync process.
Fix this by killing gaze process on SIGINT.

In some cases, the handles that we are trying to execute on process exit are failing. Try-catch each execution, so even if one fails, we'll still execute all of the handles.

Fixes http://teampulse.telerik.com/view#item/329354