### PR TITLE
Get rid of $projectData dependency in services

### DIFF
--- a/child-process.ts
+++ b/child-process.ts
@@ -1,8 +1,11 @@
 import * as child_process from "child_process";
+import { EventEmitter } from "events";
 
-export class ChildProcess implements IChildProcess {
+export class ChildProcess extends EventEmitter implements IChildProcess {
 	constructor(private $logger: ILogger,
-		private $errors: IErrors) { }
+		private $errors: IErrors) {
+		super();
+	}
 
 	public async exec(command: string, options?: any, execOptions?: IExecOptions): Promise<any> {
 		return new Promise<any>((resolve, reject) => {
@@ -62,12 +65,20 @@ export class ChildProcess implements IChildProcess {
 
 			if (childProcess.stdout) {
 				childProcess.stdout.on("data", (data: string) => {
+					if (spawnFromEventOptions && spawnFromEventOptions.emitOptions && spawnFromEventOptions.emitOptions.eventName) {
+						this.emit(spawnFromEventOptions.emitOptions.eventName, { data, pipe: 'stdout' });
+					}
+
 					capturedOut += data;
 				});
 			}
 
 			if (childProcess.stderr) {
 				childProcess.stderr.on("data", (data: string) => {
+					if (spawnFromEventOptions && spawnFromEventOptions.emitOptions && spawnFromEventOptions.emitOptions.eventName) {
+						this.emit(spawnFromEventOptions.emitOptions.eventName, { data, pipe: 'stdout' });
+					}
+
 					capturedErr += data;
 				});
 			}

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -208,11 +208,12 @@ declare module Mobile {
 		 * Filters data for specified platform.
 		 * @param {string} platform The platform for which is the device log.
 		 * @param {string} data The input data for filtering.
+		 * @param {string} projectDir The project's root directory.
 		 * @param {string} pid @optional The application PID for this device.
 		 * @param {string} logLevel @optional The logging level based on which input data will be filtered.
 		 * @return {string} The filtered result based on the input or null when the input data shouldn't be shown.
 		 */
-		filterData(platform: string, data: string, pid?: string, logLevel?: string): string;
+		filterData(platform: string, data: string, projectDir: string, pid?: string, logLevel?: string): string;
 	}
 
 	/**
@@ -224,9 +225,10 @@ declare module Mobile {
 		 * @param {string} data The string data that will be checked based on the logging level.
 		 * @param {string} logLevel Selected logging level.
 		 * @param {string} pid The Process ID of the currently running application for which we need the logs.
+		 * @param {string} projectDir The root directory of the project.
 		 * @return {string} The filtered result based on the input or null when the input data shouldn't be shown.
 		 */
-		filterData(data: string, logLevel: string, pid: string): string;
+		filterData(data: string, logLevel: string, projectDir: string, pid: string): string;
 	}
 
 	interface ILoggingLevels {
@@ -327,6 +329,7 @@ declare module Mobile {
 
 	interface IDevicesServicesInitializationOptions {
 		platform?: string;
+		emulator?: boolean;
 		deviceId?: string;
 		skipInferPlatform?: boolean;
 	}

--- a/mobile/ios/ios-log-filter.ts
+++ b/mobile/ios/ios-log-filter.ts
@@ -3,7 +3,7 @@ export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 
 	constructor(private $loggingLevels: Mobile.ILoggingLevels) { }
 
-	public filterData(data: string, logLevel: string, pid?: string): string {
+	public filterData(data: string, logLevel: string, projectDir: string, pid?: string): string {
 		let specifiedLogLevel = (logLevel || '').toUpperCase();
 
 		if (specifiedLogLevel === this.$loggingLevels.info) {

--- a/mobile/log-filter.ts
+++ b/mobile/log-filter.ts
@@ -15,10 +15,10 @@ export class LogFilter implements Mobile.ILogFilter {
 		}
 	}
 
-	public filterData(platform: string, data: string, pid?: string, logLevel?: string): string {
+	public filterData(platform: string, data: string, projectDir: string, pid?: string, logLevel?: string): string {
 		let deviceLogFilter = this.getDeviceLogFilterInstance(platform);
 		if (deviceLogFilter) {
-			return deviceLogFilter.filterData(data, logLevel || this.loggingLevel, pid);
+			return deviceLogFilter.filterData(data, logLevel || this.loggingLevel, projectDir, pid);
 		}
 
 		// In case the platform is not valid, just return the data without filtering.

--- a/services/project-files-provider-base.ts
+++ b/services/project-files-provider-base.ts
@@ -4,7 +4,7 @@ import { Configurations } from "../constants";
 
 export abstract class ProjectFilesProviderBase implements IProjectFilesProvider {
 	abstract isFileExcluded(filePath: string): boolean;
-	abstract mapFilePath(filePath: string, platform: string): string;
+	abstract mapFilePath(filePath: string, platform: string, projectData: any): string;
 
 	constructor(private $mobileHelper: Mobile.IMobileHelper,
 		protected $options: ICommonOptions) { }

--- a/test/unit-tests/ios-log-filter.ts
+++ b/test/unit-tests/ios-log-filter.ts
@@ -113,7 +113,7 @@ describe("iOSLogFilter", () => {
 		let testInjector = new Yok();
 		testInjector.register("loggingLevels", LoggingLevels);
 		let iOSLogFilter = testInjector.resolve(IOSLogFilter);
-		let filteredData = iOSLogFilter.filterData(inputData, logLevel, pid);
+		let filteredData = iOSLogFilter.filterData(inputData, logLevel, "", pid);
 		assert.deepEqual(filteredData, expectedOutput, `The actual result '${filteredData}' did NOT match expected output '${expectedOutput}'.`);
 	};
 

--- a/test/unit-tests/log-filter.ts
+++ b/test/unit-tests/log-filter.ts
@@ -67,22 +67,22 @@ describe("logFilter", () => {
 	describe("filterData", () => {
 		describe("when logLevel is not specified and default log level is not changed", () => {
 			it("returns same data when platform is not correct", () => {
-				let actualData = logFilter.filterData("invalidPlatform", testData);
+				let actualData = logFilter.filterData("invalidPlatform", testData, "");
 				assert.deepEqual(actualData, testData);
 			});
 
 			it("returns same data when platform is not passed", () => {
-				let actualData = logFilter.filterData(null, testData);
+				let actualData = logFilter.filterData(null, testData, "");
 				assert.deepEqual(actualData, testData);
 			});
 
 			it("returns correct data when platform is android", () => {
-				let actualData = logFilter.filterData("android", testData);
+				let actualData = logFilter.filterData("android", testData, "");
 				assert.deepEqual(actualData, androidInfoTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				let actualData = logFilter.filterData("ios", testData);
+				let actualData = logFilter.filterData("ios", testData, "");
 				assert.deepEqual(actualData, iosInfoTestData);
 			});
 		});
@@ -91,17 +91,17 @@ describe("logFilter", () => {
 			beforeEach(() => logFilter.loggingLevel = fullLogLevel);
 
 			it("returns same data when platform is not correct", () => {
-				let actualData = logFilter.filterData("invalidPlatform", testData);
+				let actualData = logFilter.filterData("invalidPlatform", testData, "");
 				assert.deepEqual(actualData, testData);
 			});
 
 			it("returns correct data when platform is android", () => {
-				let actualData = logFilter.filterData("android", testData);
+				let actualData = logFilter.filterData("android", testData, "");
 				assert.deepEqual(actualData, androidFullTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				let actualData = logFilter.filterData("ios", testData);
+				let actualData = logFilter.filterData("ios", testData, "");
 				assert.deepEqual(actualData, iosFullTestData);
 			});
 		});
@@ -134,12 +134,12 @@ describe("logFilter", () => {
 			});
 
 			it("returns correct data when platform is android", () => {
-				let actualData = logFilter.filterData("android", testData, null, logLevel);
+				let actualData = logFilter.filterData("android", testData, null, null, logLevel);
 				assert.deepEqual(actualData, androidFullTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				let actualData = logFilter.filterData("ios", testData, null, logLevel);
+				let actualData = logFilter.filterData("ios", testData, null, null, logLevel);
 				assert.deepEqual(actualData, iosFullTestData);
 			});
 		});


### PR DESCRIPTION
That way services become stateless and can be used in long-running processes

Ping @rosen-vladimirov @TsvetanMilanov 