### PR TITLE
added forgotten await

### DIFF
--- a/mobile/ios/device/ios-core.ts
+++ b/mobile/ios/device/ios-core.ts
@@ -1182,7 +1182,7 @@ export class GDBServer implements Mobile.IGDBServer {
 
 	@cache()
 	public async init(argv: string[]): Promise<void> {
-		this.awaitResponse("QStartNoAckMode", "+ await ");
+		await this.awaitResponse("QStartNoAckMode", "+ await ");
 		this.sendCore("+");
 		await this.awaitResponse("QEnvironmentHexEncoded:");
 		await this.awaitResponse("QSetDisableASLR:1");


### PR DESCRIPTION
`awaitResponse` method is declared as `async` and there was a forgotten await in front of it.

Maybe this will be useless after [this PR](https://github.com/telerik/mobile-cli-lib/pull/889) is merged, so feel free to close it if it's useless.