### PR TITLE
emulator name was undefined because we missed an await

### DIFF
--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -190,7 +190,6 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 				return emulatorId;
 			}
 		}
-		this.$errors.failWithoutHelp("Couldn't find emulator id");
 	}
 
 	@invokeInit()

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -184,9 +184,13 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 
 		// if we get here, there's at least one running emulator
 		let getNameFunction = this.$options.geny ? this.getNameFromGenymotionEmulatorId : this.getNameFromSDKEmulatorId;
-		let emulatorId = await _(runningEmulators).find(async emulator => await getNameFunction.apply(this, [emulator]) === image);
-
-		return emulatorId;
+		for (let emulatorId of runningEmulators) {
+			const currentEmulatorName = await getNameFunction.apply(this, [emulatorId]);
+			if (currentEmulatorName === image) {
+				return emulatorId;
+			}
+		}
+		this.$errors.failWithoutHelp("Couldn't find emulator id");
 	}
 
 	@invokeInit()

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -184,7 +184,7 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 
 		// if we get here, there's at least one running emulator
 		let getNameFunction = this.$options.geny ? this.getNameFromGenymotionEmulatorId : this.getNameFromSDKEmulatorId;
-		let emulatorId = await _(runningEmulators).find(emulator => getNameFunction.apply(this, [emulator]) === image);
+		let emulatorId = await _(runningEmulators).find(async emulator => await getNameFunction.apply(this, [emulator]) === image);
 
 		return emulatorId;
 	}


### PR DESCRIPTION
See more info: https://github.com/NativeScript/nativescript-cli/issues/2576

_Problem_
When `tns run/debug android` is ran, with no running emulator, the emulator was started, the app was installed, but not launched. The problem is after the emulator was started we couldn't get the name of the emulator.

Related issue: https://github.com/NativeScript/nativescript-cli/issues/2486