### PR TITLE
Fix device log filter

### DIFF
--- a/appbuilder/device-log-provider.ts
+++ b/appbuilder/device-log-provider.ts
@@ -30,4 +30,5 @@ export class DeviceLogProvider extends DeviceLogProviderBase {
 		}
 	}
 }
+
 $injector.register("deviceLogProvider", DeviceLogProvider);

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -205,12 +205,11 @@ declare module Mobile {
 		 * Filters data for specified platform.
 		 * @param {string} platform The platform for which is the device log.
 		 * @param {string} data The input data for filtering.
-		 * @param {string} projectDir The project's root directory.
 		 * @param {string} pid @optional The application PID for this device.
 		 * @param {string} logLevel @optional The logging level based on which input data will be filtered.
 		 * @return {string} The filtered result based on the input or null when the input data shouldn't be shown.
 		 */
-		filterData(platform: string, data: string, projectDir: string, pid?: string, logLevel?: string): string;
+		filterData(platform: string, data: string, pid?: string, logLevel?: string): string;
 	}
 
 	/**
@@ -222,10 +221,9 @@ declare module Mobile {
 		 * @param {string} data The string data that will be checked based on the logging level.
 		 * @param {string} logLevel Selected logging level.
 		 * @param {string} pid The Process ID of the currently running application for which we need the logs.
-		 * @param {string} projectDir The root directory of the project.
 		 * @return {string} The filtered result based on the input or null when the input data shouldn't be shown.
 		 */
-		filterData(data: string, logLevel: string, projectDir: string, pid: string): string;
+		filterData(data: string, logLevel: string, pid: string): string;
 	}
 
 	interface ILoggingLevels {

--- a/mobile/ios/ios-log-filter.ts
+++ b/mobile/ios/ios-log-filter.ts
@@ -3,7 +3,7 @@ export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 
 	constructor(private $loggingLevels: Mobile.ILoggingLevels) { }
 
-	public filterData(data: string, logLevel: string, projectDir: string, pid?: string): string {
+	public filterData(data: string, logLevel: string, pid?: string): string {
 		let specifiedLogLevel = (logLevel || '').toUpperCase();
 
 		if (specifiedLogLevel === this.$loggingLevels.info) {

--- a/mobile/log-filter.ts
+++ b/mobile/log-filter.ts
@@ -15,10 +15,10 @@ export class LogFilter implements Mobile.ILogFilter {
 		}
 	}
 
-	public filterData(platform: string, data: string, projectDir: string, pid?: string, logLevel?: string): string {
+	public filterData(platform: string, data: string, pid?: string, logLevel?: string): string {
 		let deviceLogFilter = this.getDeviceLogFilterInstance(platform);
 		if (deviceLogFilter) {
-			return deviceLogFilter.filterData(data, logLevel || this.loggingLevel, projectDir, pid);
+			return deviceLogFilter.filterData(data, logLevel || this.loggingLevel, pid);
 		}
 
 		// In case the platform is not valid, just return the data without filtering.

--- a/test/unit-tests/ios-log-filter.ts
+++ b/test/unit-tests/ios-log-filter.ts
@@ -113,7 +113,7 @@ describe("iOSLogFilter", () => {
 		let testInjector = new Yok();
 		testInjector.register("loggingLevels", LoggingLevels);
 		let iOSLogFilter = testInjector.resolve(IOSLogFilter);
-		let filteredData = iOSLogFilter.filterData(inputData, logLevel, "", pid);
+		let filteredData = iOSLogFilter.filterData(inputData, logLevel, pid);
 		assert.deepEqual(filteredData, expectedOutput, `The actual result '${filteredData}' did NOT match expected output '${expectedOutput}'.`);
 	};
 

--- a/test/unit-tests/log-filter.ts
+++ b/test/unit-tests/log-filter.ts
@@ -134,12 +134,12 @@ describe("logFilter", () => {
 			});
 
 			it("returns correct data when platform is android", () => {
-				let actualData = logFilter.filterData("android", testData, null, null, logLevel);
+				let actualData = logFilter.filterData("android", testData,  null, logLevel);
 				assert.deepEqual(actualData, androidFullTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				let actualData = logFilter.filterData("ios", testData, null, null, logLevel);
+				let actualData = logFilter.filterData("ios", testData, null, logLevel);
 				assert.deepEqual(actualData, iosFullTestData);
 			});
 		});


### PR DESCRIPTION
We have added one parameter in the filter method which we do not need and we do not respect it when we call the method. The solution is to remove it.