### PR TITLE
Fix getting info for Android tools

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -852,8 +852,8 @@ interface ISysInfoData {
 	adbVer: string;
 	/** Whether iTunes is installed on the machine */
 	itunesInstalled: boolean;
-	/** Whether `android` executable can be run */
-	androidInstalled: boolean;
+	/** Whether `emulator` executable can be run */
+	emulatorInstalled: boolean;
 	/** mono version, relevant on Mac only **/
 	monoVer: string;
 	/** git version string, as returned by `git --version` **/
@@ -875,7 +875,7 @@ interface ISysInfo {
 	 * @param {any} androidToolsInfo Defines paths to adb and android executables.
 	 * @return {Promise<ISysInfoData>} Object containing information for current system.
 	 */
-	getSysInfo(pathToPackageJson: string, androidToolsInfo?: { pathToAdb: string, pathToAndroid: string }): Promise<ISysInfoData>;
+	getSysInfo(pathToPackageJson: string, androidToolsInfo?: { pathToAdb: string }): Promise<ISysInfoData>;
 
 	/** Returns Java version. **/
 	getJavaVersion(): Promise<string>;

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -491,6 +491,7 @@ declare module Mobile {
 
 	interface IAndroidEmulatorServices extends IEmulatorPlatformServices {
 		getAllRunningEmulators(): Promise<string[]>;
+		pathToEmulatorExecutable: string;
 	}
 
 	interface IiSimDevice {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -492,6 +492,8 @@ declare module Mobile {
 	interface IAndroidEmulatorServices extends IEmulatorPlatformServices {
 		getAllRunningEmulators(): Promise<string[]>;
 		pathToEmulatorExecutable: string;
+		getInfoFromAvd(avdName: string): Mobile.IAvdInfo;
+		getAvds(): string[];
 	}
 
 	interface IiSimDevice {

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -44,11 +44,25 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 		this.adbFilePath = await this.$staticConfig.getAdbFilePath();
 	}
 
-	private get pathToEmulatorExecutable(): string {
+	public get pathToEmulatorExecutable(): string {
 		if (!this._pathToEmulatorExecutable) {
-			let androidHome = process.env.ANDROID_HOME;
-			let emulatorExecutableName = "emulator";
-			this._pathToEmulatorExecutable = androidHome ? path.join(androidHome, "tools", emulatorExecutableName) : emulatorExecutableName;
+			const androidHome = process.env.ANDROID_HOME;
+			const emulatorExecutableName = "emulator";
+
+			this._pathToEmulatorExecutable = emulatorExecutableName;
+
+			if (androidHome) {
+				// Check https://developer.android.com/studio/releases/sdk-tools.html (25.3.0)
+				// Since this version of SDK tools, the emulator is a separate package.
+				// However the emulator executable still exists in the "tools" dir.
+				const pathToEmulatorFromAndroidStudio =  path.join(androidHome, emulatorExecutableName, emulatorExecutableName);
+
+				if (this.$fs.exists(pathToEmulatorFromAndroidStudio)) {
+					this._pathToEmulatorExecutable = pathToEmulatorFromAndroidStudio;
+				} else {
+					this._pathToEmulatorExecutable = path.join(androidHome, "tools", emulatorExecutableName);
+				}
+			}
 		}
 
 		return this._pathToEmulatorExecutable;

--- a/sys-info-base.ts
+++ b/sys-info-base.ts
@@ -213,16 +213,12 @@ export class SysInfoBase implements ISysInfo {
 	}
 
 	private async checkEmulator(): Promise<boolean> {
-		let result = false;
-		try {
-			// emulator -help exits with code 1 on Windows, so we should parse the output.
-			// First line of it should be:
-			// Android Emulator usage: emulator [options] [-qemu args]
-			const emulatorHelp = await this.$childProcess.spawnFromEvent(this.$androidEmulatorServices.pathToEmulatorExecutable, ["-help"], "close", {}, { throwError: false });
-			result = emulatorHelp.stdout.indexOf("usage: emulator") !== -1;
-		} catch (err) {
-			this.$logger.trace(`Error while checking is emulator installed. Error is: ${err.messge}`);
-		}
+		// emulator -help exits with code 1 on Windows, so we should parse the output.
+		// First line of it should be:
+		// Android Emulator usage: emulator [options] [-qemu args]
+		const emulatorHelp = await this.$childProcess.spawnFromEvent(this.$androidEmulatorServices.pathToEmulatorExecutable, ["-help"], "close", {}, { throwError: false });
+		const result = !!(emulatorHelp && emulatorHelp.stdout && emulatorHelp.stdout.indexOf("usage: emulator") !== -1);
+		this.$logger.trace(`The result of checking is Android Emulator installed is:${os.EOL}- stdout: ${emulatorHelp && emulatorHelp.stdout}${os.EOL}- stderr: ${emulatorHelp && emulatorHelp.stderr}`);
 
 		return result;
 	}

--- a/test/unit-tests/sys-info-base.ts
+++ b/test/unit-tests/sys-info-base.ts
@@ -24,7 +24,7 @@ interface IChildProcessResults {
 	nodeGypVersion: IChildProcessResultDescription;
 	xCodeVersion: IChildProcessResultDescription;
 	adbVersion: IChildProcessResultDescription;
-	androidInstalled: IChildProcessResultDescription;
+	emulatorInstalled: IChildProcessResultDescription;
 	monoVersion: IChildProcessResultDescription;
 	gradleVersion: IChildProcessResultDescription;
 	gitVersion: IChildProcessResultDescription;
@@ -50,7 +50,7 @@ function createChildProcessResults(childProcessResult: IChildProcessResults): ID
 		"pod --version": childProcessResult.podVersion,
 		'"adb" version': childProcessResult.adbVersion,
 		"'adb' version": childProcessResult.adbVersion, // for Mac and Linux
-		'android': childProcessResult.androidInstalled,
+		'emulator': childProcessResult.emulatorInstalled,
 		"mono --version": childProcessResult.monoVersion,
 		"git --version": childProcessResult.gitVersion,
 		"gradle -v": childProcessResult.gradleVersion
@@ -93,6 +93,10 @@ function createTestInjector(childProcessResult: IChildProcessResults, hostInfoDa
 
 	injector.register("sysInfoBase", SysInfoBase);
 
+	injector.register("androidEmulatorServices", {
+		pathToEmulatorExecutable: "emulator"
+	});
+
 	return injector;
 }
 
@@ -116,7 +120,7 @@ describe("sysInfoBase", () => {
 			nodeGypVersion: { result: "2.0.0" },
 			xCodeVersion: { result: "6.4.0" },
 			adbVersion: { result: "Android Debug Bridge version 1.0.32" },
-			androidInstalled: { result: { stdout: "android" } },
+			emulatorInstalled: { result: { stdout: "Android Emulator usage: emulator [options] [-qemu args]" } },
 			monoVersion: { result: "version 1.0.6 " },
 			gradleVersion: { result: "Gradle 2.8" },
 			gitVersion: { result: "git version 1.9.5" },
@@ -134,7 +138,7 @@ describe("sysInfoBase", () => {
 				assert.deepEqual(result.javacVersion, "1.8.0_60");
 				assert.deepEqual(result.nodeGypVer, childProcessResult.nodeGypVersion.result);
 				assert.deepEqual(result.adbVer, childProcessResult.adbVersion.result);
-				assert.deepEqual(result.androidInstalled, true);
+				assert.deepEqual(result.emulatorInstalled, true);
 				assert.deepEqual(result.monoVer, "1.0.6");
 				assert.deepEqual(result.gradleVer, "2.8");
 				assert.deepEqual(result.gitVer, "1.9.5");
@@ -212,7 +216,7 @@ describe("sysInfoBase", () => {
 					nodeGypVersion: { shouldThrowError: true },
 					xCodeVersion: { shouldThrowError: true },
 					adbVersion: { shouldThrowError: true },
-					androidInstalled: { shouldThrowError: true },
+					emulatorInstalled: { shouldThrowError: true },
 					monoVersion: { shouldThrowError: true },
 					gradleVersion: { shouldThrowError: true },
 					gitVersion: { shouldThrowError: true },
@@ -221,18 +225,18 @@ describe("sysInfoBase", () => {
 			});
 
 			describe("when android info is incorrect", () => {
-				it("pathToAdb and pathToAndroid are null", async () => {
+				it("pathToAdb is null", async () => {
 					childProcessResult.adbVersion = {
 						result: null
 					};
-					childProcessResult.androidInstalled = {
-						result: false
+					childProcessResult.emulatorInstalled = {
+						result: null
 					};
 					testInjector = createTestInjector(childProcessResult, { isWindows: false, isDarwin: false, dotNetVersion: "4.5.1" }, null);
 					sysInfoBase = testInjector.resolve("sysInfoBase");
-					let result = await sysInfoBase.getSysInfo(toolsPackageJson, { pathToAdb: null, pathToAndroid: null });
+					let result = await sysInfoBase.getSysInfo(toolsPackageJson, { pathToAdb: null });
 					assert.deepEqual(result.adbVer, null);
-					assert.deepEqual(result.androidInstalled, false);
+					assert.deepEqual(result.emulatorInstalled, false);
 				});
 			});
 
@@ -246,7 +250,7 @@ describe("sysInfoBase", () => {
 					assert.deepEqual(result.nodeGypVer, null);
 					assert.deepEqual(result.xcodeVer, null);
 					assert.deepEqual(result.adbVer, null);
-					assert.deepEqual(result.androidInstalled, false);
+					assert.deepEqual(result.emulatorInstalled, false);
 					assert.deepEqual(result.monoVer, null);
 					assert.deepEqual(result.gradleVer, null);
 					assert.deepEqual(result.gitVer, null);

--- a/test/unit-tests/sys-info-base.ts
+++ b/test/unit-tests/sys-info-base.ts
@@ -31,9 +31,17 @@ interface IChildProcessResults {
 	podVersion: IChildProcessResultDescription;
 }
 
-function getResultFromChildProcess(childProcessResultDescription: IChildProcessResultDescription): any {
+function getResultFromChildProcess(childProcessResultDescription: IChildProcessResultDescription, spawnFromEventOpts?: { throwError: boolean }): any {
 	if (childProcessResultDescription.shouldThrowError) {
-		throw new Error("This one throws error.");
+		if (spawnFromEventOpts && !spawnFromEventOpts.throwError) {
+			return {
+				stderr: "This one throws error.",
+				code: 1,
+				stdout: null
+			};
+		} else {
+			throw new Error("This one throws error.");
+		}
 	}
 
 	return childProcessResultDescription.result;
@@ -65,8 +73,8 @@ function createTestInjector(childProcessResult: IChildProcessResults, hostInfoDa
 			return getResultFromChildProcess(childProcessResultDictionary[command]);
 		},
 
-		spawnFromEvent: (command: string, args: string[], event: string) => {
-			return getResultFromChildProcess(childProcessResultDictionary[command]);
+		spawnFromEvent: (command: string, args: string[], event: string, opts: any, spawnFromEventOpts?: { throwError: boolean }) => {
+			return getResultFromChildProcess(childProcessResultDictionary[command], spawnFromEventOpts);
 		}
 	});
 


### PR DESCRIPTION
Due to changes in Android SDK, we have to update the checks in CLI. While gathering system information, we check the android executable, which is no longer returning correct results.
In order to fix this, we rely on the emulator executable, which is the real thing we need as it is the one that allows us to work with Android Emulators.
Fix sys-info checks and get correct path to emulator according to latest changes.