### PR TITLE
Do not check for application updates for Unreachable devices

### DIFF
--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -191,7 +191,8 @@ export class DevicesService implements Mobile.IDevicesService {
 					}
 
 					try {
-						await settlePromises(_.map(this._devices, device => device.applicationManager.checkForApplicationUpdates()));
+						const trustedDevices = _.filter(this._devices, device => device.deviceInfo.status === constants.CONNECTED_STATUS);
+						await settlePromises(_.map(trustedDevices, device => device.applicationManager.checkForApplicationUpdates()));
 					} catch (err) {
 						this.$logger.trace("Error checking for application updates on devices.", err);
 					}

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -190,7 +190,8 @@ describe("devicesService", () => {
 		iOSDevice = {
 			deviceInfo: {
 				identifier: "ios-device",
-				platform: "ios"
+				platform: "ios",
+				status: constants.CONNECTED_STATUS
 			},
 			applicationManager: {
 				getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2"]),
@@ -209,7 +210,8 @@ describe("devicesService", () => {
 		androidDevice = {
 			deviceInfo: {
 				identifier: "android-device",
-				platform: "android"
+				platform: "android",
+				status: constants.CONNECTED_STATUS
 			},
 			applicationManager: {
 				getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"]),
@@ -1259,6 +1261,14 @@ describe("devicesService", () => {
 				await devicesService.startDeviceDetectionInterval();
 
 				assert.isTrue(hasCheckedForAndroidAppUpdates);
+			});
+
+			it("should check for application updates only on devices with status Connected", async () => {
+				androidDevice.deviceInfo.status = constants.UNREACHABLE_STATUS;
+				await devicesService.startDeviceDetectionInterval();
+
+				assert.isFalse(hasCheckedForAndroidAppUpdates);
+				assert.isTrue(hasCheckedForIosAppUpdates);
 			});
 
 			it("should not throw if all checks for application updates on all devices throw exceptions.", () => {


### PR DESCRIPTION
When devices are not with status Connected, we should not check for application updates on these devices as the code will fail.
Fix this in the deviceDetectionInterval logic, so long living processes will work correctly.