### PR TITLE
Fix copy of MobileApp.app build file after creation

### DIFF
--- a/file-system.ts
+++ b/file-system.ts
@@ -211,7 +211,9 @@ export class FileSystem implements IFileSystem {
 
 		this.createDirectory(path.dirname(destinationFileName));
 
-		shelljs.cp("-f", sourceFileName, destinationFileName);
+		// MobileApplication.app is resolved as a directory on Mac,
+		// therefore we need to copy it recursively as it's not a single file.
+		shelljs.cp("-rf", sourceFileName, destinationFileName);
 
 		const err = shelljs.error();
 


### PR DESCRIPTION
When the --copy-to flag in the CLI is set, we use the CopyFile method from FileSystem to copy the built file - AppName.app to the destination. Mac OS resolves this file as a directory in the terminal and the cp command fails with "omitting directory" because it's missing the -R flag.