### PR TITLE
Throw correct error when unable to install app on iOS

### DIFF
--- a/mobile/ios/device/ios-application-manager.ts
+++ b/mobile/ios/device/ios-application-manager.ts
@@ -28,7 +28,7 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 	@hook('install')
 	public async installApplication(packageFilePath: string): Promise<void> {
 		await this.$iosDeviceOperations.install(packageFilePath, [this.device.deviceInfo.identifier], (err: IOSDeviceLib.IDeviceError) => {
-			this.$logger.warn(`Failed to install ${packageFilePath} on device with identifier ${err.deviceId}`);
+			this.$errors.failWithoutHelp(`Failed to install ${packageFilePath} on device with identifier ${err.deviceId}. Error is: ${err.message}`);
 		});
 	}
 


### PR DESCRIPTION
When we are unable to install app on iOS device, we show warning and we continue the execution. However we have to throw error in such cases.