### PR TITLE
Fix device detection interval deadlock

### DIFF
--- a/decorators.ts
+++ b/decorators.ts
@@ -72,7 +72,7 @@ export function invokeInit(): any {
 	return invokeBefore("init");
 }
 
-export function exportedPromise(moduleName: string, postAction?: () => void): any {
+export function exportedPromise(moduleName: string, postAction?: () => Promise<void>): any {
 	return (target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>): TypedPropertyDescriptor<any> => {
 		$injector.publicApi.__modules__[moduleName] = $injector.publicApi.__modules__[moduleName] || {};
 		$injector.publicApi.__modules__[moduleName][propertyKey] = (...args: any[]): Promise<any>[] | Promise<any> => {
@@ -115,10 +115,10 @@ export function exportedPromise(moduleName: string, postAction?: () => void): an
 	};
 }
 
-function getPromise(originalValue: any, config?: { postActionMethod: () => void, shouldExecutePostAction?: boolean }): Promise<any> {
-	let postAction = (data: any) => {
+function getPromise(originalValue: any, config?: { postActionMethod: () => Promise<void>, shouldExecutePostAction?: boolean }): Promise<any> {
+	let postAction = async (data: any) => {
 		if (config && config.postActionMethod && config.shouldExecutePostAction) {
-			config.postActionMethod();
+			await config.postActionMethod();
 		}
 
 		if (data instanceof Error) {

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -213,9 +213,9 @@ export class DevicesService implements Mobile.IDevicesService {
 	}
 
 	public async stopDeviceDetectionInterval(): Promise<void> {
+		await this.getDeviceDetectionIntervalPromise();
 		this.clearDeviceDetectionInterval();
 		this.deviceDetectionInterval = null;
-		await this.getDeviceDetectionIntervalFuture();
 	}
 
 	public getDeviceByIdentifier(identifier: string): Mobile.IDevice {
@@ -551,7 +551,7 @@ export class DevicesService implements Mobile.IDevicesService {
 		};
 	}
 
-	private async getDeviceDetectionIntervalFuture(): Promise<void> {
+	private async getDeviceDetectionIntervalPromise(): Promise<void> {
 		return this.deviceDetectionIntervalPromise || Promise.resolve();
 	}
 }

--- a/test/unit-tests/decorators.ts
+++ b/test/unit-tests/decorators.ts
@@ -186,7 +186,7 @@ describe("decorators", () => {
 			let isActionExecuted = false;
 			let expectedResults: any;
 
-			let postAction = () => {
+			let postAction = async (): Promise<void> => {
 				assert.isTrue(isActionExecuted, "Post Action MUST be executed AFTER all actions are executed.");
 				isPostActionExecuted = true;
 			};


### PR DESCRIPTION
The exportedDecorator promise may have postAction. In case the postAction returns a promise, we'll not wait for its execution and we'll return the result to the caller.
This leads to problem when there are two consecutive calls to deployOnDevices - after the first one finishes, we start the deviceDetectioninterval, but we do not wait for it to finish the first execution.
When the second deploy starts it sees there's a running interval, clears it and waits for the promise to be resolved. However we've never started the execution, so the promise is never started, so it is never resolved.
Fix this by:
 - clearing the interval after waiting for current promise to be resolved
 - fix the exportedPromise decorator to wait for the first execution of the startDeviceDetection interval to finish