### PR TITLE
Fix stop application on iOS simulator

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -239,7 +239,7 @@ declare module Mobile {
 		reinstallApplication(appIdentifier: string, packageFilePath: string): Promise<void>;
 		startApplication(appIdentifier: string): Promise<void>;
 		stopApplication(appIdentifier: string): Promise<void>;
-		restartApplication(appIdentifier: string): Promise<void>;
+		restartApplication(appIdentifier: string, appName?: string): Promise<void>;
 		canStartApplication(): boolean;
 		checkForApplicationUpdates(): Promise<void>;
 		isLiveSyncSupported(appIdentifier: string): Promise<boolean>;

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -16,8 +16,8 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 		await this.installApplication(packageFilePath);
 	}
 
-	public async restartApplication(appIdentifier: string): Promise<void> {
-		await this.stopApplication(appIdentifier);
+	public async restartApplication(appIdentifier: string, appName?: string): Promise<void> {
+		await this.stopApplication(appName || appIdentifier);
 		await this.startApplication(appIdentifier);
 	}
 

--- a/mobile/ios/device/ios-device-operations.ts
+++ b/mobile/ios/device/ios-device-operations.ts
@@ -126,7 +126,7 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 			this.$logger.trace(`Stopping application ${s.appId} on device with identifier: ${s.deviceId}.`);
 		});
 
-		return this.getMultipleResults<IOSDeviceLib.IDeviceResponse>(() => this.deviceLib.start(stopArray), errorHandler);
+		return this.getMultipleResults<IOSDeviceLib.IDeviceResponse>(() => this.deviceLib.stop(stopArray), errorHandler);
 	}
 
 	public dispose(signal?: string): void {


### PR DESCRIPTION
We need to pass the project name instead of the app identifier to kill the application on the simulator.