### PR TITLE
Stop stopping device detection interval

### DIFF
--- a/appbuilder/services/livesync/livesync-service.ts
+++ b/appbuilder/services/livesync/livesync-service.ts
@@ -1,4 +1,4 @@
-import { exportedPromise } from "../../../decorators";
+import { exported } from "../../../decorators";
 
 export class ProtonLiveSyncService implements IProtonLiveSyncService {
 	private excludedProjectDirsAndFiles = ["app_resources", "plugins", ".*.tmp", ".ab"];
@@ -14,16 +14,14 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 		private $logger: ILogger,
 		private $companionAppsService: ICompanionAppsService) { }
 
-	@exportedPromise("liveSyncService", async function () {
-		await this.$devicesService.startDeviceDetectionInterval();
-	})
+	@exported("liveSyncService")
 	public livesync(deviceDescriptors: IDeviceLiveSyncInfo[], projectDir: string, filePaths?: string[]): Promise<IDeviceLiveSyncResult>[] {
 		this.$project.projectDir = projectDir;
 		this.$logger.trace(`Called livesync for identifiers ${_.map(deviceDescriptors, d => d.deviceIdentifier)}. Project dir is ${projectDir}. Files are: ${filePaths}`);
 		return _.map(deviceDescriptors, deviceDescriptor => this.liveSyncOnDevice(deviceDescriptor, filePaths));
 	}
 
-	@exportedPromise("liveSyncService")
+	@exported("liveSyncService")
 	public deleteFiles(deviceDescriptors: IDeviceLiveSyncInfo[], projectDir: string, filePaths: string[]): Promise<IDeviceLiveSyncResult>[] {
 		this.$project.projectDir = projectDir;
 		this.$logger.trace(`Called deleteFiles for identifiers ${_.map(deviceDescriptors, d => d.deviceIdentifier)}. Project dir is ${projectDir}. Files are: ${filePaths}`);
@@ -33,7 +31,6 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 	private async liveSyncOnDevice(deviceDescriptor: IDeviceLiveSyncInfo, filePaths: string[], liveSyncOptions?: ILiveSyncDeletionOptions): Promise<IDeviceLiveSyncResult> {
 		let isForDeletedFiles = liveSyncOptions && liveSyncOptions.isForDeletedFiles;
 
-		await this.$devicesService.stopDeviceDetectionInterval();
 		let result: IDeviceLiveSyncResult = {
 			deviceIdentifier: deviceDescriptor.deviceIdentifier
 		};

--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as os from "os";
 import * as constants from "../../constants";
 import { fromWindowsRelativePathToUnix } from "../../helpers";
-import { exportedPromise } from "../../decorators";
+import { exported } from "../../decorators";
 import * as url from "url";
 
 export class NpmService implements INpmService {
@@ -37,7 +37,7 @@ export class NpmService implements INpmService {
 		return this._npmExecutableName;
 	}
 
-	@exportedPromise("npmService")
+	@exported("npmService")
 	public async install(projectDir: string, dependencyToInstall?: INpmDependency): Promise<INpmInstallResult> {
 		let npmInstallResult: INpmInstallResult = {};
 
@@ -76,7 +76,7 @@ export class NpmService implements INpmService {
 		return npmInstallResult;
 	}
 
-	@exportedPromise("npmService")
+	@exported("npmService")
 	public async uninstall(projectDir: string, dependency: string): Promise<void> {
 		let packageJsonContent = this.getPackageJsonContent(projectDir);
 

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -322,11 +322,30 @@ declare module Mobile {
 		ensureAdbServerStarted(): Promise<any>;
 	}
 
+	/**
+	 * Describes options that can be passed to devices service's initialization method.
+	 */
 	interface IDevicesServicesInitializationOptions {
+		/**
+		 * The platform for which to initialize. If passed will detect only devices belonging to said platform.
+		 */
 		platform?: string;
+		/**
+		 * Currently unused.
+		 */
 		emulator?: boolean;
+		/**
+		 * Specifies a device with which to work with.
+		 */
 		deviceId?: string;
+		/**
+		 * Specifies that platform should not be infered. That is to say that all devices will be detected regardless of platform and no errors will be thrown.
+		 */
 		skipInferPlatform?: boolean;
+		/**
+		 * If passed along with skipInferPlatform then the device detection interval will not be started but instead the currently attached devices will be detected.
+		 */
+		skipDeviceDetectionInterval?: boolean;
 	}
 
 	interface IDevicesService {
@@ -353,7 +372,6 @@ declare module Mobile {
 		setLogLevel(logLevel: string, deviceIdentifier?: string): void;
 		deployOnDevices(deviceIdentifiers: string[], packageFile: string, packageName: string, framework: string): Promise<void>[];
 		startDeviceDetectionInterval(): Promise<void>;
-		stopDeviceDetectionInterval(): Promise<void>;
 		getDeviceByIdentifier(identifier: string): Mobile.IDevice;
 		mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string, framework: string): Promise<string>;
 		detectCurrentlyAttachedDevices(): Promise<void>;

--- a/services/typescript-service.ts
+++ b/services/typescript-service.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as os from "os";
 import temp = require("temp");
-import { exportedPromise } from "../decorators";
+import { exported } from "../decorators";
 import { NODE_MODULES_DIR_NAME, FileExtensions } from "../constants";
 import { ChildProcess } from "child_process";
 temp.track();
@@ -35,7 +35,7 @@ export class TypeScriptService implements ITypeScriptService {
 		private $processService: IProcessService,
 		private $errors: IErrors) { }
 
-	@exportedPromise("typeScriptService")
+	@exported("typeScriptService")
 	public async transpile(projectDir: string, typeScriptFiles?: string[], definitionFiles?: string[], options?: ITypeScriptTranspileOptions): Promise<void> {
 		options = options || {};
 		let compilerOptions = this.getCompilerOptions(projectDir, options);

--- a/test/unit-tests/decorators.ts
+++ b/test/unit-tests/decorators.ts
@@ -7,12 +7,7 @@ import { isPromise } from "../../helpers";
 
 describe("decorators", () => {
 	let moduleName = "moduleName", // This is the name of the injected dependency that will be resolved, for example fs, devicesService, etc.
-		propertyName = "propertyName", // This is the name of the method/property from the resolved module
-		generatePublicApiFromExportedPromiseDecorator = () => {
-			assert.deepEqual($injector.publicApi.__modules__[moduleName], undefined);
-			let promisifiedResult: any = decoratorsLib.exportedPromise(moduleName);
-			/* actualResult is */ promisifiedResult({}, propertyName, {});
-		};
+		propertyName = "propertyName"; // This is the name of the method/property from the resolved module
 
 	beforeEach(() => {
 		$injector = new Yok();
@@ -21,341 +16,6 @@ describe("decorators", () => {
 	after(() => {
 		// Make sure global $injector is clean for next tests that will be executed.
 		$injector = new Yok();
-	});
-
-	describe("exportedPromise", () => {
-		it("returns function", () => {
-			let result: any = decoratorsLib.exportedPromise("test");
-			assert.equal(typeof (result), "function");
-		});
-
-		it("does not change original method", () => {
-			let promisifiedResult: any = decoratorsLib.exportedPromise(moduleName);
-			let expectedResult = { "originalObject": "originalValue" };
-			let actualResult = promisifiedResult({}, "myTest1", expectedResult);
-			assert.deepEqual(actualResult, expectedResult);
-		});
-
-		it("adds method to public api", () => {
-			generatePublicApiFromExportedPromiseDecorator();
-			assert.deepEqual(typeof ($injector.publicApi.__modules__[moduleName][propertyName]), "function");
-		});
-
-		it("returns Promise", (done: mocha.Done) => {
-			let expectedResult = "result";
-			$injector.register(moduleName, { propertyName: () => expectedResult });
-			generatePublicApiFromExportedPromiseDecorator();
-
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
-			assert.equal(typeof (promise.then), "function");
-			promise.then((val: string) => {
-				assert.deepEqual(val, expectedResult);
-			}).then(done).catch(done);
-		});
-
-		it("returns Promise, which is resolved to correct value (function without arguments)", (done: mocha.Done) => {
-			let expectedResult = "result";
-			$injector.register(moduleName, { propertyName: () => expectedResult });
-			generatePublicApiFromExportedPromiseDecorator();
-
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
-			promise.then((val: string) => {
-				assert.deepEqual(val, expectedResult);
-			}).then(done).catch(done);
-		});
-
-		it("returns Promise, which is resolved to correct value (function with arguments)", (done: mocha.Done) => {
-			let expectedArgs = ["result", "result1", "result2"];
-			$injector.register(moduleName, { propertyName: (functionArgs: string[]) => functionArgs });
-			generatePublicApiFromExportedPromiseDecorator();
-
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName](expectedArgs);
-			promise.then((val: string[]) => {
-				assert.deepEqual(val, expectedArgs);
-			}).then(done).catch(done);
-		});
-
-		it("returns Promise, which is resolved to correct value (function returning Promise without arguments)", (done: mocha.Done) => {
-			let expectedResult = "result";
-			$injector.register(moduleName, { propertyName: () => Promise.resolve(expectedResult) });
-			generatePublicApiFromExportedPromiseDecorator();
-
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
-			promise.then((val: string) => {
-				assert.deepEqual(val, expectedResult);
-			}).then(done).catch(done);
-		});
-
-		it("returns Promise, which is resolved to correct value (function returning Promise with arguments)", (done: mocha.Done) => {
-			let expectedArgs = ["result", "result1", "result2"];
-			$injector.register(moduleName, { propertyName: (args: string[]) => Promise.resolve(args) });
-			generatePublicApiFromExportedPromiseDecorator();
-
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName](expectedArgs);
-			promise.then((val: string[]) => {
-				assert.deepEqual(val, expectedArgs);
-			}).then(done).catch(done);
-		});
-
-		it("rejects Promise, which is resolved to correct error (function without arguments throws)", (done: mocha.Done) => {
-			let expectedError = new Error("Test msg");
-			$injector.register(moduleName, { propertyName: () => { throw expectedError; } });
-			generatePublicApiFromExportedPromiseDecorator();
-
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
-			promise.then((result: any) => {
-				throw new Error("Then method MUST not be called when promise is rejected!");
-			}, (err: Error) => {
-				assert.deepEqual(err, expectedError);
-			}).then(done).catch(done);
-		});
-
-		it("rejects Promise, which is resolved to correct error (function returning Promise without arguments throws)", (done: mocha.Done) => {
-			let expectedError = new Error("Test msg");
-			$injector.register(moduleName, { propertyName: async () => { throw expectedError; } });
-			generatePublicApiFromExportedPromiseDecorator();
-
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
-			promise.then((result: any) => {
-				throw new Error("Then method MUST not be called when promise is rejected!");
-			}, (err: Error) => {
-				assert.deepEqual(err.message, expectedError.message);
-			}).then(done).catch(done);
-		});
-
-		it("returns Promises, which are resolved to correct value (function returning Promise<T>[] without arguments)", (done: mocha.Done) => {
-			let expectedResults = ["result1", "result2", "result3"];
-			$injector.register(moduleName, { propertyName: () => _.map(expectedResults, expectedResult => Promise.resolve(expectedResult)) });
-			generatePublicApiFromExportedPromiseDecorator();
-
-			let promises: Promise<string>[] = $injector.publicApi.__modules__[moduleName][propertyName]();
-			Promise.all<string>(promises)
-				.then((promiseResults: string[]) => {
-					_.each(promiseResults, (val: string, index: number) => {
-						assert.deepEqual(val, expectedResults[index]);
-					});
-				})
-				.then(() => done())
-				.catch(done);
-		});
-
-		it("rejects Promises, which are resolved to correct error (function returning Promise<T>[] without arguments throws)", (done: mocha.Done) => {
-			let expectedErrors = [new Error("result1"), new Error("result2"), new Error("result3")];
-			$injector.register(moduleName, { propertyName: () => _.map(expectedErrors, async expectedError => { throw expectedError; }) });
-			generatePublicApiFromExportedPromiseDecorator();
-
-			new Promise((onFulfilled: Function, onRejected: Function) => {
-				let promises: Promise<string>[] = $injector.publicApi.__modules__[moduleName][propertyName]();
-				_.each(promises, (promise, index) => promise.then((result: any) => {
-					onRejected(new Error(`Then method MUST not be called when promise is rejected!. Result of promise is: ${result}`));
-				}, (err: Error) => {
-					if (err.message !== expectedErrors[index].message) {
-						onRejected(new Error(`Error message of rejected promise is not the expected one: expected: "${expectedErrors[index].message}", but was: "${err.message}".`));
-					}
-
-					if (index + 1 === expectedErrors.length) {
-						onFulfilled();
-					}
-				}));
-			}).then(done).catch(done);
-		});
-
-		it("rejects only Promises which throw, resolves the others correctly (function returning Promise<T>[] without arguments)", (done: mocha.Done) => {
-			let expectedResults: any[] = ["result1", new Error("result2")];
-			$injector.register(moduleName, { propertyName: () => _.map(expectedResults, expectedResult => Promise.resolve(expectedResult)) });
-			generatePublicApiFromExportedPromiseDecorator();
-
-			new Promise((onFulfilled: Function, onRejected: Function) => {
-				let promises: Promise<string>[] = $injector.publicApi.__modules__[moduleName][propertyName]();
-				_.each(promises, (promise, index) => promise.then((val: string) => {
-					assert.deepEqual(val, expectedResults[index]);
-					if (index + 1 === expectedResults.length) {
-						onFulfilled();
-					}
-				}, (err: Error) => {
-					assert.deepEqual(err.message, expectedResults[index].message);
-					if (index + 1 === expectedResults.length) {
-						onFulfilled();
-					}
-				}));
-			}).then(done).catch(done);
-		});
-
-		describe("postAction", () => {
-			let isPostActionExecuted = false;
-			let isActionExecuted = false;
-			let expectedResults: any;
-
-			let postAction = async (): Promise<void> => {
-				assert.isTrue(isActionExecuted, "Post Action MUST be executed AFTER all actions are executed.");
-				isPostActionExecuted = true;
-			};
-
-			let getPromisesWithPostAction = (): any => {
-				let promisifiedResultFunction: any = decoratorsLib.exportedPromise(moduleName, postAction);
-				// Call this line in order to generate publicApi and get the real Promise
-				promisifiedResultFunction({}, propertyName, {});
-				return $injector.publicApi.__modules__[moduleName][propertyName]();
-			};
-
-			let assertResults = (result: any): void => {
-				assert.deepEqual(result, expectedResults);
-				assert.isTrue(isPostActionExecuted, "Post action must be executed after all promises are resolved.");
-				assert.isTrue(isActionExecuted, "All actions must be executed after the promise is resolved.");
-			};
-
-			beforeEach(() => {
-				isPostActionExecuted = false;
-				isActionExecuted = false;
-			});
-
-			it("executes postAction after all promises are resolved (function returning Promise<T>)", (done: mocha.Done) => {
-				expectedResults = "result";
-
-				$injector.register(moduleName, {
-					propertyName: async () => {
-						assert.isFalse(isPostActionExecuted, "Post action MUST NOT be called before all actions are executed.");
-						isActionExecuted = true;
-						return expectedResults;
-					}
-				});
-
-				getPromisesWithPostAction()
-					.then(assertResults)
-					.then(done)
-					.catch(done);
-			});
-
-			it("executes postAction after all promises are resolved (function returning Promise<T>[])", (done: mocha.Done) => {
-				expectedResults = ["result1", "result2", "result3"];
-
-				$injector.register(moduleName, {
-					propertyName: () => _.map(expectedResults, async (expectedResult, index) => {
-						assert.isFalse(isPostActionExecuted, "Post action MUST NOT be called before all actions are executed.");
-
-						isActionExecuted = (index + 1) === expectedResults.length;
-						return expectedResult;
-					})
-				});
-
-				Promise.all(getPromisesWithPostAction())
-					.then(assertResults)
-					.then(() => done())
-					.catch(done);
-			});
-
-			it("executes postAction after a promise is rejected (function returning Promise<T> that throws)", (done: mocha.Done) => {
-				expectedResults = "result";
-				let errorMessage = "This future throws";
-
-				$injector.register(moduleName, {
-					propertyName: async (): Promise<void> => {
-						assert.isFalse(isPostActionExecuted, "Post action MUST NOT be called before all actions are executed.");
-
-						isActionExecuted = true;
-						throw new Error(errorMessage);
-					}
-				});
-
-				getPromisesWithPostAction()
-					.then((result: any) => {
-						throw new Error("Then method MUST not be called when promise is rejected!");
-					}, (err: Error) => {
-						assert.deepEqual(err.message, errorMessage, "Error message of rejection should be the specified one.");
-						assert.isTrue(isPostActionExecuted, "Post action must be executed after all promises are resolved.");
-						assert.isTrue(isActionExecuted, "All actions must be executed after the promise is resolved.");
-					})
-					.then(done)
-					.catch(done);
-			});
-
-			it("executes postAction after all promises are rejected (function returning Promise<T>[] that throws)", (done: mocha.Done) => {
-				expectedResults = ["result1", "result2", "result3"];
-				let errorMessage = "This future throws.";
-
-				$injector.register(moduleName, {
-					propertyName: () => _.map(expectedResults, async (expectedResult, index) => {
-						assert.isFalse(isPostActionExecuted, "Post action MUST NOT be called before all actions are executed.");
-
-						isActionExecuted = (index + 1) === expectedResults.length;
-						throw new Error(errorMessage);
-					})
-				});
-
-				let caughtErrors = 0;
-
-				// Use new promise that will be resolved when all promises are rejected.
-				// This way we'll be sure all of them are settled and we can verify the postAction is executed.
-				let mainPromise = new Promise((onFulfilled: Function, onRejected: Function) => {
-					_.each(getPromisesWithPostAction(), (promise: any) => promise.then((result: any) => {
-						throw new Error("Then method MUST not be called when promise is rejected!");
-					}, (err: Error) => {
-						caughtErrors++;
-						assert.deepEqual(err.message, errorMessage, "Error message of rejection should be the specified one.");
-						if (caughtErrors === expectedResults.length) {
-							onFulfilled();
-						}
-					}));
-				});
-
-				mainPromise
-					.then((result: any) => {
-						assert.isTrue(isPostActionExecuted, "Post action must be executed after all promises are resolved.");
-						assert.isTrue(isActionExecuted, "All actions must be executed after the promise is resolved.");
-						done();
-					})
-					.catch(done);
-			});
-
-			it("executes postAction after all some promises are rejected and others are resolved (function returning Promise<T>[] where some of the future throw)", (done: mocha.Done) => {
-				let calledActionsCount = 0;
-				expectedResults = ["result1", "result2", "result3", "result4"];
-				let errorMessage = "This future throws.";
-
-				$injector.register(moduleName, {
-					propertyName: () => _.map(expectedResults, async expectedResult => {
-						assert.isFalse(isPostActionExecuted, "Post action MUST NOT be called before all actions are executed.");
-
-						calledActionsCount++;
-						isActionExecuted = calledActionsCount === expectedResults.length;
-						if (calledActionsCount % 2 === 0) {
-							throw new Error(errorMessage);
-						} else {
-							return expectedResult;
-						}
-					})
-				});
-
-				let caughtErrors = 0,
-					resolvedPromises = 0;
-
-				// Use new promise that will be resolved when all promises are rejected.
-				// This way we'll be sure all of them are settled and we can verify the postAction is executed.
-				let mainPromise = new Promise(function (onFulfilled: Function, onRejected: Function) {
-					_.each(getPromisesWithPostAction(), (promise: any, index: number) => promise.then((result: any) => {
-						resolvedPromises++;
-						assert.deepEqual(result, expectedResults[index]);
-						if ((caughtErrors + resolvedPromises) === expectedResults.length) {
-							onFulfilled();
-						}
-					}, (err: Error) => {
-						caughtErrors++;
-						assert.deepEqual(err.message, errorMessage, "Error message of rejection should be the specified one.");
-						if ((caughtErrors + resolvedPromises) === expectedResults.length) {
-							onFulfilled();
-						}
-					}));
-				});
-
-				mainPromise
-					.then((result: any) => {
-						assert.isTrue(isPostActionExecuted, "Post action must be executed after all promises are resolved.");
-						assert.isTrue(isActionExecuted, "All actions must be executed after the promise is resolved.");
-						done();
-					})
-					.catch(done);
-			});
-		});
 	});
 
 	describe("exported", () => {
@@ -394,14 +54,142 @@ describe("decorators", () => {
 				generatePublicApiFromExportedDecorator();
 				let actualResult: any = $injector.publicApi.__modules__[moduleName][propertyName]();
 				assert.deepEqual(actualResult, expectedResult);
-			});
+		});
 
 			it(`passes correct arguments to original function, when argument type is: ${_.isArray(expectedResult) ? "array" : typeof (expectedResult)}`, () => {
 				$injector.register(moduleName, { propertyName: (arg: any) => arg });
 				generatePublicApiFromExportedDecorator();
 				let actualResult: any = $injector.publicApi.__modules__[moduleName][propertyName](expectedResult);
 				assert.deepEqual(actualResult, expectedResult);
-			});
+		});
+		});
+
+		it("returns Promise, which is resolved to correct value (function without arguments)", (done: mocha.Done) => {
+			let expectedResult = "result";
+			$injector.register(moduleName, { propertyName: async () => expectedResult });
+			generatePublicApiFromExportedDecorator();
+
+			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
+			promise.then((val: string) => {
+				assert.deepEqual(val, expectedResult);
+			}).then(done).catch(done);
+		});
+
+		it("returns Promise, which is resolved to correct value (function with arguments)", (done: mocha.Done) => {
+			let expectedArgs = ["result", "result1", "result2"];
+			$injector.register(moduleName, { propertyName: async (functionArgs: string[]) => functionArgs });
+			generatePublicApiFromExportedDecorator();
+
+			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName](expectedArgs);
+			promise.then((val: string[]) => {
+				assert.deepEqual(val, expectedArgs);
+			}).then(done).catch(done);
+		});
+
+		it("returns Promise, which is resolved to correct value (function returning Promise without arguments)", (done: mocha.Done) => {
+			let expectedResult = "result";
+			$injector.register(moduleName, { propertyName: async () => expectedResult });
+			generatePublicApiFromExportedDecorator();
+
+			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
+			promise.then((val: string) => {
+				assert.deepEqual(val, expectedResult);
+			}).then(done).catch(done);
+		});
+
+		it("returns Promise, which is resolved to correct value (function returning Promise with arguments)", (done: mocha.Done) => {
+			let expectedArgs = ["result", "result1", "result2"];
+			$injector.register(moduleName, { propertyName: async (args: string[]) => args });
+			generatePublicApiFromExportedDecorator();
+
+			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName](expectedArgs);
+			promise.then((val: string[]) => {
+				assert.deepEqual(val, expectedArgs);
+			}).then(done).catch(done);
+		});
+
+		it("rejects Promise, which is resolved to correct error (function without arguments throws)", (done: mocha.Done) => {
+			let expectedError = new Error("Test msg");
+			$injector.register(moduleName, { propertyName: async () => { throw expectedError; } });
+			generatePublicApiFromExportedDecorator();
+
+			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
+			promise.then((result: any) => {
+				throw new Error("Then method MUST not be called when promise is rejected!");
+			}, (err: Error) => {
+				assert.deepEqual(err, expectedError);
+			}).then(done).catch(done);
+		});
+
+		it("rejects Promise, which is resolved to correct error (function returning Promise without arguments throws)", (done: mocha.Done) => {
+			let expectedError = new Error("Test msg");
+			$injector.register(moduleName, { propertyName: async () => { throw expectedError; } });
+			generatePublicApiFromExportedDecorator();
+
+			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
+			promise.then((result: any) => {
+				throw new Error("Then method MUST not be called when promise is rejected!");
+			}, (err: Error) => {
+				assert.deepEqual(err.message, expectedError.message);
+			}).then(done).catch(done);
+		});
+
+		it("returns Promises, which are resolved to correct value (function returning Promise<T>[] without arguments)", (done: mocha.Done) => {
+			let expectedResultsArr = ["result1", "result2", "result3"];
+			$injector.register(moduleName, { propertyName: () => _.map(expectedResultsArr, async expectedResult => expectedResult) });
+			generatePublicApiFromExportedDecorator();
+
+			let promises: Promise<string>[] = $injector.publicApi.__modules__[moduleName][propertyName]();
+			Promise.all<string>(promises)
+				.then((promiseResults: string[]) => {
+					_.each(promiseResults, (val: string, index: number) => {
+						assert.deepEqual(val, expectedResultsArr[index]);
+					});
+				})
+				.then(() => done())
+				.catch(done);
+		});
+
+		it("rejects Promises, which are resolved to correct error (function returning Promise<T>[] without arguments throws)", (done: mocha.Done) => {
+			let expectedErrors = [new Error("result1"), new Error("result2"), new Error("result3")];
+			$injector.register(moduleName, { propertyName: () => _.map(expectedErrors, async expectedError => { throw expectedError; }) });
+			generatePublicApiFromExportedDecorator();
+
+			new Promise((onFulfilled: Function, onRejected: Function) => {
+				let promises: Promise<string>[] = $injector.publicApi.__modules__[moduleName][propertyName]();
+				_.each(promises, (promise, index) => promise.then((result: any) => {
+					onRejected(new Error(`Then method MUST not be called when promise is rejected!. Result of promise is: ${result}`));
+				}, (err: Error) => {
+					if (err.message !== expectedErrors[index].message) {
+						onRejected(new Error(`Error message of rejected promise is not the expected one: expected: "${expectedErrors[index].message}", but was: "${err.message}".`));
+					}
+
+					if (index + 1 === expectedErrors.length) {
+						onFulfilled();
+					}
+				}));
+			}).then(done).catch(done);
+		});
+
+		it("rejects only Promises which throw, resolves the others correctly (function returning Promise<T>[] without arguments)", (done: mocha.Done) => {
+			let expectedResultsArr: any[] = ["result1", new Error("result2")];
+			$injector.register(moduleName, { propertyName: () => _.map(expectedResultsArr, async expectedResult => expectedResult) });
+			generatePublicApiFromExportedDecorator();
+
+			new Promise((onFulfilled: Function, onRejected: Function) => {
+				let promises: Promise<string>[] = $injector.publicApi.__modules__[moduleName][propertyName]();
+				_.each(promises, (promise, index) => promise.then((val: string) => {
+					assert.deepEqual(val, expectedResultsArr[index]);
+					if (index + 1 === expectedResultsArr.length) {
+						onFulfilled();
+					}
+				}, (err: Error) => {
+					assert.deepEqual(err.message, expectedResultsArr[index].message);
+					if (index + 1 === expectedResultsArr.length) {
+						onFulfilled();
+					}
+				}));
+			}).then(done).catch(done);
 		});
 
 		it("when function throws, raises the error only when the public API is called, not when decorator is applied", () => {
@@ -410,13 +198,7 @@ describe("decorators", () => {
 			generatePublicApiFromExportedDecorator();
 			assert.throws(() => $injector.publicApi.__modules__[moduleName][propertyName](), errorMessage);
 		});
-
-		it("throws error when passed function returns Promise", () => {
-			$injector.register(moduleName, { propertyName: () => Promise.resolve(expectedResults) });
-			generatePublicApiFromExportedDecorator();
-			assert.throws(() => $injector.publicApi.__modules__[moduleName][propertyName](), "Cannot use exported decorator with function returning Promise<T>.");
 		});
-	});
 
 	describe("cache", () => {
 		it("executes implementation of method only once and returns the same result each time whent it is called (number return type)", () => {

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -1093,7 +1093,6 @@ describe("devicesService", () => {
 		});
 
 		afterEach(async () => {
-			await devicesService.stopDeviceDetectionInterval();
 			resetDefaultSetInterval();
 		});
 
@@ -1281,45 +1280,6 @@ describe("devicesService", () => {
 
 				assert.doesNotThrow(callback);
 			});
-		});
-	});
-
-	describe("stopDeviceDetectionInterval", () => {
-		beforeEach(() => {
-			mockSetInterval();
-		});
-
-		afterEach(async () => {
-			await devicesService.stopDeviceDetectionInterval();
-			resetDefaultSetInterval();
-		});
-
-		it("should stop the device detection interval.", async () => {
-			let setIntervalStartedCount = 0;
-
-			mockSetInterval(() => {
-				setIntervalStartedCount++;
-			});
-
-			await devicesService.startDeviceDetectionInterval();
-			await devicesService.stopDeviceDetectionInterval();
-			await devicesService.startDeviceDetectionInterval();
-
-			assert.deepEqual(setIntervalStartedCount, 2);
-		});
-
-		it("should not stop the device detection interval if there is not interval running.", async () => {
-			let clearIntervalCount = 0;
-
-			global.clearInterval = () => {
-				clearIntervalCount++;
-			};
-
-			await devicesService.startDeviceDetectionInterval();
-			await devicesService.stopDeviceDetectionInterval();
-			await devicesService.stopDeviceDetectionInterval();
-
-			assert.deepEqual(clearIntervalCount, 1);
 		});
 	});
 

--- a/test/unit-tests/mocks/public-api-mocks.ts
+++ b/test/unit-tests/mocks/public-api-mocks.ts
@@ -1,7 +1,7 @@
-import { exportedPromise } from "../../../decorators";
+import { exported } from "../../../decorators";
 
 export class TestPublicAPI {
-	@exportedPromise("testPublicApi")
+	@exported("testPublicApi")
 	public async myMethod(expectedResult: any): Promise<any> {
 		return expectedResult;
 	}


### PR DESCRIPTION
Delete `@exportedPromise` decorator as we no longer need it
Stop stopping device detection interval when deploying on iOS devices. These operations no longer conflict as the code is located in an external dependency.