### PR TITLE
Plamen5kov/refactoring

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -42,8 +42,8 @@ $injector.requireCommand("autocomplete|disable", "./commands/autocompletion");
 $injector.requireCommand("autocomplete|status", "./commands/autocompletion");
 
 $injector.requireCommand("device|*list", "./commands/device/list-devices");
-$injector.requireCommand("device|android", "./commands/device/list-devices");
-$injector.requireCommand("device|ios", "./commands/device/list-devices");
+$injector.requireCommand(["device|android", "devices|android"], "./commands/device/list-devices");
+$injector.requireCommand(["device|ios", "devices|ios"], "./commands/device/list-devices");
 
 $injector.requireCommand("device|log", "./commands/device/device-log-stream");
 $injector.requireCommand("device|run", "./commands/device/run-application");

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -22,7 +22,7 @@ $injector.require("messagesService", "./services/messages-service");
 
 $injector.require("cancellation", "./services/cancellation");
 $injector.require("hooksService", "./services/hooks-service");
-$injector.require("imageService", "./services/image-service");
+$injector.require("emulatorImageService", "./services/emulator-image-service");
 
 $injector.require("httpClient", "./http-client");
 $injector.require("childProcess", "./child-process");

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -22,6 +22,7 @@ $injector.require("messagesService", "./services/messages-service");
 
 $injector.require("cancellation", "./services/cancellation");
 $injector.require("hooksService", "./services/hooks-service");
+$injector.require("imageService", "./services/image-service");
 
 $injector.require("httpClient", "./http-client");
 $injector.require("childProcess", "./child-process");

--- a/commands/device/device-log-stream.ts
+++ b/commands/device/device-log-stream.ts
@@ -25,4 +25,4 @@ export class OpenDeviceLogStreamCommand implements ICommand {
 	}
 }
 
-$injector.registerCommand("device|log", OpenDeviceLogStreamCommand);
+$injector.registerCommand(["device|log", "devices|log"], OpenDeviceLogStreamCommand);

--- a/commands/device/get-file.ts
+++ b/commands/device/get-file.ts
@@ -22,4 +22,4 @@ export class GetFileCommand implements ICommand {
 	}
 }
 
-$injector.registerCommand("device|get-file", GetFileCommand);
+$injector.registerCommand(["device|get-file", "devices|get-file"], GetFileCommand);

--- a/commands/device/list-applications.ts
+++ b/commands/device/list-applications.ts
@@ -22,4 +22,4 @@ export class ListApplicationsCommand implements ICommand {
 		this.$logger.out(output.join(EOL));
 	}
 }
-$injector.registerCommand("device|list-applications", ListApplicationsCommand);
+$injector.registerCommand(["device|list-applications", "devices|list-applications"], ListApplicationsCommand);

--- a/commands/device/list-devices.ts
+++ b/commands/device/list-devices.ts
@@ -5,14 +5,14 @@ export class ListDevicesCommand implements ICommand {
 		private $logger: ILogger,
 		private $stringParameter: ICommandParameter,
 		private $mobileHelper: Mobile.IMobileHelper,
-		private $imageService: Mobile.IImageService,
+		private $emulatorImageService: Mobile.IEmulatorImageService,
 		private $options: ICommonOptions) { }
 
 	public allowedParameters = [this.$stringParameter];
 
 	public async execute(args: string[]): Promise<void> {
 		if (this.$options.availableDevices) {
-			await this.$imageService.listAvailableEmulators(this.$mobileHelper.validatePlatformName(args[0]));
+			await this.$emulatorImageService.listAvailableEmulators(this.$mobileHelper.validatePlatformName(args[0]));
 		}
 
 		this.$logger.out("\nConnected devices & emulators");

--- a/commands/device/list-devices.ts
+++ b/commands/device/list-devices.ts
@@ -5,14 +5,14 @@ export class ListDevicesCommand implements ICommand {
 		private $logger: ILogger,
 		private $stringParameter: ICommandParameter,
 		private $mobileHelper: Mobile.IMobileHelper,
-		private $emulatorPlatformService: IEmulatorPlatformService,
+		private $imageService: Mobile.IImageService,
 		private $options: ICommonOptions) { }
 
 	public allowedParameters = [this.$stringParameter];
 
 	public async execute(args: string[]): Promise<void> {
 		if (this.$options.availableDevices) {
-			await this.$emulatorPlatformService.listAvailableEmulators(this.$mobileHelper.validatePlatformName(args[0]));
+			await this.$imageService.listAvailableEmulators(this.$mobileHelper.validatePlatformName(args[0]));
 		}
 
 		this.$logger.out("\nConnected devices & emulators");

--- a/commands/device/list-devices.ts
+++ b/commands/device/list-devices.ts
@@ -4,11 +4,18 @@ export class ListDevicesCommand implements ICommand {
 	constructor(private $devicesService: Mobile.IDevicesService,
 		private $logger: ILogger,
 		private $stringParameter: ICommandParameter,
+		private $mobileHelper: Mobile.IMobileHelper,
+		private $emulatorPlatformService: IEmulatorPlatformService,
 		private $options: ICommonOptions) { }
 
 	public allowedParameters = [this.$stringParameter];
 
 	public async execute(args: string[]): Promise<void> {
+		if (this.$options.availableDevices) {
+			await this.$emulatorPlatformService.listAvailableEmulators(this.$mobileHelper.validatePlatformName(args[0]));
+		}
+
+		this.$logger.out("\nConnected devices & emulators");
 		let index = 1;
 		await this.$devicesService.initialize({ platform: args[0], deviceId: null, skipInferPlatform: true });
 
@@ -35,7 +42,7 @@ export class ListDevicesCommand implements ICommand {
 	}
 }
 
-$injector.registerCommand("device|*list", ListDevicesCommand);
+$injector.registerCommand(["device|*list", "devices|*list"], ListDevicesCommand);
 
 class ListAndroidDevicesCommand implements ICommand {
 	constructor(private $injector: IInjector,
@@ -50,7 +57,7 @@ class ListAndroidDevicesCommand implements ICommand {
 	}
 }
 
-$injector.registerCommand("device|android", ListAndroidDevicesCommand);
+$injector.registerCommand(["device|android", "devices|android"], ListAndroidDevicesCommand);
 
 class ListiOSDevicesCommand implements ICommand {
 	constructor(private $injector: IInjector,
@@ -65,4 +72,4 @@ class ListiOSDevicesCommand implements ICommand {
 	}
 }
 
-$injector.registerCommand("device|ios", ListiOSDevicesCommand);
+$injector.registerCommand(["device|ios", "devices|ios"], ListiOSDevicesCommand);

--- a/commands/device/list-files.ts
+++ b/commands/device/list-files.ts
@@ -23,4 +23,4 @@ export class ListFilesCommand implements ICommand {
 	}
 }
 
-$injector.registerCommand("device|list-files", ListFilesCommand);
+$injector.registerCommand(["device|list-files", "devices|list-files"], ListFilesCommand);

--- a/commands/device/put-file.ts
+++ b/commands/device/put-file.ts
@@ -20,4 +20,4 @@ export class PutFileCommand implements ICommand {
 		await this.$devicesService.execute(action);
 	}
 }
-$injector.registerCommand("device|put-file", PutFileCommand);
+$injector.registerCommand(["device|put-file", "devices|put-file"], PutFileCommand);

--- a/commands/device/run-application.ts
+++ b/commands/device/run-application.ts
@@ -19,4 +19,4 @@ export class RunApplicationOnDeviceCommand implements ICommand {
 	}
 }
 
-$injector.registerCommand("device|run", RunApplicationOnDeviceCommand);
+$injector.registerCommand(["device|run", "devices|run"], RunApplicationOnDeviceCommand);

--- a/commands/device/stop-application.ts
+++ b/commands/device/stop-application.ts
@@ -14,4 +14,4 @@ export class StopApplicationOnDeviceCommand implements ICommand {
 	}
 }
 
-$injector.registerCommand("device|stop", StopApplicationOnDeviceCommand);
+$injector.registerCommand(["device|stop", "devices|stop"], StopApplicationOnDeviceCommand);

--- a/commands/device/uninstall-application.ts
+++ b/commands/device/uninstall-application.ts
@@ -12,4 +12,4 @@ export class UninstallApplicationCommand implements ICommand {
 		await this.$devicesService.execute(action);
 	}
 }
-$injector.registerCommand("device|uninstall", UninstallApplicationCommand);
+$injector.registerCommand(["device|uninstall", "devices|uninstall"], UninstallApplicationCommand);

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -564,6 +564,24 @@ declare module Mobile {
 		getAllCapabilities(): IDictionary<Mobile.IPlatformCapabilities>;
 	}
 
+	//todo: plamen5kov: this is a duplicate of an interface (IEmulatorPlatformService) fix after 3.0-RC. nativescript-cli/lib/definitions/emulator-platform-service.d.ts
+	interface IImageService {
+		listAvailableEmulators(platform: string): Promise<void>;
+		getEmulatorInfo(platform: string, nameOfId: string): Promise<IEmulatorInfo>;
+		getiOSEmulators(): Promise<IEmulatorInfo[]>;
+		getAndroidEmulators(): IEmulatorInfo[];
+	}
+
+	//todo: plamen5kov: this is a duplicate of an interface (IEmulatorInfo) fix after 3.0-RC nativescript-cli/lib/definitions/emulator-platform-service.d.ts
+	interface IEmulatorInfo {
+		name: string;
+		version: string;
+		platform: string;
+		id: string;
+		type: string;
+		isRunning?: boolean;
+	}
+
 	interface IMobileHelper {
 		platformNames: string[];
 		isAndroidPlatform(platform: string): boolean;

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -351,7 +351,16 @@ declare module Mobile {
 	interface IDevicesService {
 		hasDevices: boolean;
 		deviceCount: number;
+
+		/**
+		 * Optionally starts emulator depending on the passed options.
+		 * @param {IDevicesServicesInitializationOptions} data Defines wheather to start default or specific emulator.
+		 * @return {Promise<void>}
+		 */
+		startEmulatorIfNecessary(data?: Mobile.IDevicesServicesInitializationOptions): Promise<void>;
+
 		execute(action: (device: Mobile.IDevice) => Promise<void>, canExecute?: (dev: Mobile.IDevice) => boolean, options?: { allowNoDevices?: boolean }): Promise<void>;
+
 		/**
 		 * Initializes DevicesService, so after that device operations could be executed.
 		 * @param {IDevicesServicesInitializationOptions} data Defines the options which will be used for whole devicesService.
@@ -363,7 +372,6 @@ declare module Mobile {
 		getDevicesForPlatform(platform: string): Mobile.IDevice[];
 		getDeviceInstances(): Mobile.IDevice[];
 		getDeviceByDeviceOption(): Mobile.IDevice;
-		getDeviceByName(name: string): Mobile.IDevice;
 		isAndroidDevice(device: Mobile.IDevice): boolean;
 		isiOSDevice(device: Mobile.IDevice): boolean;
 		isiOSSimulator(device: Mobile.IDevice): boolean;
@@ -375,7 +383,7 @@ declare module Mobile {
 		getDeviceByIdentifier(identifier: string): Mobile.IDevice;
 		mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string, framework: string): Promise<string>;
 		detectCurrentlyAttachedDevices(): Promise<void>;
-		startEmulator(platform?: string): Promise<void>;
+		startEmulator(platform?: string, emulatorImage?: string): Promise<void>;
 		isCompanionAppInstalledOnDevices(deviceIdentifiers: string[], framework: string): Promise<IAppInstalledInfo>[];
 		getDebuggableApps(deviceIdentifiers: string[]): Promise<Mobile.IDeviceApplicationInformation[]>[];
 		getDebuggableViews(deviceIdentifier: string, appIdentifier: string): Promise<Mobile.IDebugWebViewInfo[]>;
@@ -500,9 +508,10 @@ declare module Mobile {
 		 */
 		checkAvailability(dependsOnProject?: boolean): void;
 
-		startEmulator(): Promise<string>;
+		startEmulator(emulatorImage?: string): Promise<string>
 		runApplicationOnEmulator(app: string, emulatorOptions?: IEmulatorOptions): Promise<any>;
 		getEmulatorId(): Promise<string>;
+		getRunningEmulatorId(image: string): Promise<string>;
 	}
 
 	interface IAndroidEmulatorServices extends IEmulatorPlatformServices {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -565,7 +565,7 @@ declare module Mobile {
 	}
 
 	//todo: plamen5kov: this is a duplicate of an interface (IEmulatorPlatformService) fix after 3.0-RC. nativescript-cli/lib/definitions/emulator-platform-service.d.ts
-	interface IImageService {
+	interface IEmulatorImageService {
 		listAvailableEmulators(platform: string): Promise<void>;
 		getEmulatorInfo(platform: string, nameOfId: string): Promise<IEmulatorInfo>;
 		getiOSEmulators(): Promise<IEmulatorInfo[]>;

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -117,7 +117,7 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 			// unlock screen
 			await this.unlockScreen(emulatorId);
 		} else {
-			this.$errors.fail(`Could not find an emulator image or identifier to run your project. Please run: "tns device <platform> --available-devices"`);
+			this.$errors.fail(`Could not find an emulator image or identifier to run your project. Please run: "${this.$staticConfig.CLIENT_NAME} device <platform> --available-devices"`);
 		}
 
 		return emulatorId;

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -414,7 +414,7 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 		let minVersion = this.$emulatorSettingsService.minVersion;
 
 		let avdResults = this.getAvds();
-		if(suggestedImage) {
+		if (suggestedImage) {
 			avdResults = avdResults.filter(avd => avd === suggestedImage);
 		}
 

--- a/mobile/ios/simulator/ios-emulator-services.ts
+++ b/mobile/ios/simulator/ios-emulator-services.ts
@@ -12,6 +12,11 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 		return "";
 	}
 
+	public async getRunningEmulatorId(image: string): Promise<string> {
+		//todo: plamen5kov: fix later if necessary
+		return "";
+	}
+
 	public async checkDependencies(): Promise<void> {
 		return;
 	}
@@ -29,8 +34,11 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 		}
 	}
 
-	public async startEmulator(): Promise<string> {
-		return this.$iOSSimResolver.iOSSim.startSimulator();
+	public async startEmulator(emulatorImage?: string): Promise<string> {
+		return this.$iOSSimResolver.iOSSim.startSimulator({
+			id: emulatorImage,
+			state: "None"
+		});
 	}
 
 	public runApplicationOnEmulator(app: string, emulatorOptions?: Mobile.IEmulatorOptions): Promise<any> {

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -370,11 +370,11 @@ export class DevicesService implements Mobile.IDevicesService {
 If you are trying to run on specific emulator, use tns run –device <DeviceID>.`);
 		}
 
-		// are there any running devices
-		await this.detectCurrentlyAttachedDevices();
-		let deviceInstances = this.getDeviceInstances();
+		if (data && data.platform) {
+			// are there any running devices
+			await this.detectCurrentlyAttachedDevices();
+			let deviceInstances = this.getDeviceInstances();
 
-		if(data && data.platform) {
 			//if no --device is passed and no devices are found, the default emulator is started
 			if (!data.deviceId && _.isEmpty(deviceInstances)) {
 				return await this.startEmulator(data.platform);

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -366,8 +366,8 @@ export class DevicesService implements Mobile.IDevicesService {
 	 */
 	public async startEmulatorIfNecessary(data?: Mobile.IDevicesServicesInitializationOptions): Promise<void> {
 		if (data && data.deviceId && data.emulator) {
-			this.$errors.failWithoutHelp(`--device and –emulator are incompatible options.
-If you are trying to run on specific emulator, use tns run –device <DeviceID>.`);
+			this.$errors.failWithoutHelp(`--device and --emulator are incompatible options.
+			If you are trying to run on specific emulator, use "${this.$staticConfig.CLIENT_NAME} run --device <DeviceID>`);
 		}
 
 		if (data && data.platform) {
@@ -392,7 +392,7 @@ If you are trying to run on specific emulator, use tns run –device <DeviceID>.
 
 			// if only emulator flag is passed and no other emulators are running, start default emulator
 			if (data.emulator && deviceInstances.length) {
-				let runningDeviceInstance = _.some(deviceInstances, (value) => {return value.isEmulator; });
+				let runningDeviceInstance = _.some(deviceInstances, (value) => value.isEmulator);
 				if (!runningDeviceInstance) {
 					return await this.startEmulator(data.platform);
 				}

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -131,6 +131,9 @@ export class DevicesService implements Mobile.IDevicesService {
 		delete this._devices[device.deviceInfo.identifier];
 	}
 
+	/**
+	 * Starts looking for devices. Any found devices are pushed to "_devices" variable.
+	 */
 	public async detectCurrentlyAttachedDevices(): Promise<void> {
 		try {
 			await this.$iOSDeviceDiscovery.startLookingForDevices();
@@ -209,6 +212,11 @@ export class DevicesService implements Mobile.IDevicesService {
 		}
 	}
 
+	/**
+	 * Returns device that matches an identifier.
+	 * The identifier is expected to be the same as the running device declares it (emulator-5554 for android or GUID for ios).
+	 * @param identifier running emulator or device identifier
+	 */
 	public getDeviceByIdentifier(identifier: string): Mobile.IDevice {
 		let searchedDevice = _.find(this.getDeviceInstances(), (device: Mobile.IDevice) => { return device.deviceInfo.identifier === identifier; });
 		if (!searchedDevice) {
@@ -218,10 +226,9 @@ export class DevicesService implements Mobile.IDevicesService {
 		return searchedDevice;
 	}
 
-	public getDeviceByName(name: string): Mobile.IDevice {
-		return _.find(this.getDeviceInstances(), (device: Mobile.IDevice) => { return device.deviceInfo.displayName === name; });
-	}
-
+	/**
+	 * Starts looking for running devices. All found devices are pushed to _devices variable.
+	 */
 	private async startLookingForDevices(): Promise<void> {
 		this.$logger.trace("startLookingForDevices; platform is %s", this._platform);
 		if (!this._platform) {
@@ -237,21 +244,37 @@ export class DevicesService implements Mobile.IDevicesService {
 		}
 	}
 
+	/**
+	 * Returns device depending on the passed index.
+	 * The index refers to assigned number to listed devices by tns device command.
+	 * @param index assigned device number
+	 */
 	private getDeviceByIndex(index: number): Mobile.IDevice {
 		this.validateIndex(index - 1);
 		return this.getDeviceInstances()[index - 1];
 	}
 
+	/**
+	 * Returns running device for specified --device <DeviceId>.
+	 * Method expects running devices.
+	 * @param identifier parameter passed by the user to --device flag
+	 */
 	private async getDevice(deviceOption: string): Promise<Mobile.IDevice> {
 		await this.detectCurrentlyAttachedDevices();
 		let device: Mobile.IDevice = null;
 
-		if (this.hasDevice(deviceOption)) {
-			device = this.getDeviceByIdentifier(deviceOption);
+		let emulatorIdentifier = null;
+		if (this._platform) {
+			let emulatorService = this.resolveEmulatorServices();
+			emulatorIdentifier = await emulatorService.getRunningEmulatorId(deviceOption);
+		}
+
+		if (this.hasRunningDevice(emulatorIdentifier)) {
+			device = this.getDeviceByIdentifier(emulatorIdentifier);
 		} else if (helpers.isNumber(deviceOption)) {
 			device = this.getDeviceByIndex(parseInt(deviceOption, 10));
 		} else {
-			device = this.getDeviceByName(deviceOption);
+			device = this.getDeviceByIdentifier(deviceOption);
 		}
 
 		if (!device) {
@@ -261,12 +284,22 @@ export class DevicesService implements Mobile.IDevicesService {
 		return device;
 	}
 
+	/**
+	 * Method runs action for a --device (value), specified by the user.
+	 * @param action action to be executed if canExecute returns true
+	 * @param canExecute predicate to decide whether the command can be ran
+	 */
 	private async executeOnDevice(action: (dev: Mobile.IDevice) => Promise<void>, canExecute?: (_dev: Mobile.IDevice) => boolean): Promise<void> {
 		if (!canExecute || canExecute(this._device)) {
 			await action(this._device);
 		}
 	}
 
+	/**
+	 * Executes passed action for each found device.
+	 * @param action action to be executed if canExecute returns true
+	 * @param canExecute predicate to decide whether the command can be ran
+	 */
 	private async executeOnAllConnectedDevices(action: (dev: Mobile.IDevice) => Promise<void>, canExecute?: (_dev: Mobile.IDevice) => boolean): Promise<void> {
 		let devices = this.filterDevicesByPlatform();
 		let sortedDevices = _.sortBy(devices, device => device.deviceInfo.platform);
@@ -293,13 +326,19 @@ export class DevicesService implements Mobile.IDevicesService {
 		return _.map(deviceIdentifiers, deviceIdentifier => this.deployOnDevice(deviceIdentifier, packageFile, packageName));
 	}
 
+	/**
+	 * Runs the passed action if the predicate "canExecute" returns true
+	 * @param action action to be executed if canExecute returns true.
+	 * @param canExecute predicate to decide whether the command can be ran
+	 * @param options all possible options that can be passed to the command.
+	 */
 	public async execute(action: (device: Mobile.IDevice) => Promise<void>, canExecute?: (dev: Mobile.IDevice) => boolean, options?: { allowNoDevices?: boolean }): Promise<void> {
 		assert.ok(this._isInitialized, "Devices services not initialized!");
 
 		if (this.hasDevices) {
-			if (this.$hostInfo.isDarwin && this._platform && this.$mobileHelper.isiOSPlatform(this._platform) &&
-				this.$options.emulator && !this.isOnlyiOSSimultorRunning()) {
-				await this.startEmulator();
+			if (this.$hostInfo.isDarwin && this._platform
+					&& this.$mobileHelper.isiOSPlatform(this._platform)
+					&& this.$options.emulator && !this.isOnlyiOSSimultorRunning()) {
 				// Executes the command only on iOS simulator
 				let originalCanExecute = canExecute;
 				canExecute = (dev: Mobile.IDevice): boolean => this.isiOSSimulator(dev) && (!originalCanExecute || !!(originalCanExecute(dev)));
@@ -314,15 +353,64 @@ export class DevicesService implements Mobile.IDevicesService {
 				if (!this.$hostInfo.isDarwin && this._platform && this.$mobileHelper.isiOSPlatform(this._platform)) {
 					this.$errors.failWithoutHelp(message);
 				} else {
-					await this.startEmulator();
 					await this.executeCore(action, canExecute);
 				}
 			}
 		}
 	}
 
+	/**
+	 * Starts emulator or simulator if necessary depending on --device or --emulator flags.
+	 * If no options are passed runs default emulator/simulator if no devices are connected.
+	 * @param data mainly contains information about --emulator and --deviceId flags.
+	 */
+	public async startEmulatorIfNecessary(data?: Mobile.IDevicesServicesInitializationOptions): Promise<void> {
+		if (data && data.deviceId && data.emulator) {
+			this.$errors.failWithoutHelp(`--device and –emulator are incompatible options.
+If you are trying to run on specific emulator, use tns run –device <DeviceID>.`);
+		}
+
+		// are there any running devices
+		await this.detectCurrentlyAttachedDevices();
+		let deviceInstances = this.getDeviceInstances();
+
+		if(data && data.platform) {
+			//if no --device is passed and no devices are found, the default emulator is started
+			if (!data.deviceId && _.isEmpty(deviceInstances)) {
+				return await this.startEmulator(data.platform);
+			}
+
+			//check if --device(value) is running, if it's not or it's not the same as is specified, start with name from --device(value)
+			if (data.deviceId) {
+				if (!helpers.isNumber(data.deviceId))  {
+					let activeDeviceInstance = _.find(this.getDeviceInstances(), (device: Mobile.IDevice) => { return device.deviceInfo.identifier === data.deviceId; });
+					if (!activeDeviceInstance) {
+						return await this.startEmulator(data.platform, data.deviceId);
+					}
+				}
+			}
+
+			// if only emulator flag is passed and no other emulators are running, start default emulator
+			if (data.emulator && deviceInstances.length) {
+				let runningDeviceInstance = _.some(deviceInstances, (value) => {return value.isEmulator; });
+				if (!runningDeviceInstance) {
+					return await this.startEmulator(data.platform);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Takes care of gathering information about all running devices.
+	 * Sets "_isInitialized" to true after infomation is present.
+	 * Method expects running devices.
+	 * @param data mainly contains information about --emulator and --deviceId flags.
+	 */
 	@exported("devicesService")
 	public async initialize(data?: Mobile.IDevicesServicesInitializationOptions): Promise<void> {
+		this.$logger.out("Searching for devices...");
+		await this.startEmulatorIfNecessary(data);
+
 		if (this._isInitialized) {
 			return;
 		}
@@ -333,9 +421,9 @@ export class DevicesService implements Mobile.IDevicesService {
 		let deviceOption = data.deviceId;
 
 		if (platform && deviceOption) {
+			this._platform = this.getPlatform(data.platform);
 			this._device = await this.getDevice(deviceOption);
-			this._platform = this._device.deviceInfo.platform;
-			if (this._platform !== this.getPlatform(platform)) {
+			if (this._device.deviceInfo.platform !== this._platform) {
 				this.$errors.fail("Cannot resolve the specified connected device. The provided platform does not match the provided index or identifier." +
 					"To list currently connected devices and verify that the specified pair of platform and index or identifier exists, run 'device'.");
 			}
@@ -443,8 +531,14 @@ export class DevicesService implements Mobile.IDevicesService {
 		await device.applicationManager.tryStartApplication(packageName);
 	}
 
-	private hasDevice(identifier: string): boolean {
-		return _.some(this.getDeviceInstances(), (device: Mobile.IDevice) => { return device.deviceInfo.identifier === identifier; });
+	/**
+	 * Returns true if there's a running device with specified identifier.
+	 * @param identifier parameter passed by the user to --device flag
+	 */
+	private hasRunningDevice(identifier: string): boolean {
+		return _.some(this.getDeviceInstances(), (device: Mobile.IDevice) => {
+			return device.deviceInfo.identifier === identifier;
+		});
 	}
 
 	private filterDevicesByPlatform(): Mobile.IDevice[] {
@@ -467,8 +561,12 @@ export class DevicesService implements Mobile.IDevicesService {
 
 	private resolveEmulatorServices(platform?: string): Mobile.IEmulatorPlatformServices {
 		platform = platform || this._platform;
-		if (this.$mobileHelper.isiOSPlatform(platform) && this.$hostInfo.isDarwin) {
-			return this.$injector.resolve("iOSEmulatorServices");
+		if (this.$mobileHelper.isiOSPlatform(platform)) {
+			if (this.$hostInfo.isDarwin) {
+				return this.$injector.resolve("iOSEmulatorServices");
+			} else {
+				this.$errors.failWithoutHelp("You can use iOS simulator only on OS X.");
+			}
 		} else if (this.$mobileHelper.isAndroidPlatform(platform)) {
 			return this.$injector.resolve("androidEmulatorServices");
 		}
@@ -476,7 +574,12 @@ export class DevicesService implements Mobile.IDevicesService {
 		return null;
 	}
 
-	public async startEmulator(platform?: string): Promise<void> {
+	/**
+	 * Starts emulator for platform and makes sure started devices/emulators/simulators are in _devices array before finishing.
+	 * @param platform (optional) platform to start emulator/simulator for
+	 * @param emulatorImage (optional) emulator/simulator image identifier
+	 */
+	public async startEmulator(platform?: string, emulatorImage?: string): Promise<void> {
 
 		platform = platform || this._platform;
 
@@ -485,7 +588,7 @@ export class DevicesService implements Mobile.IDevicesService {
 			this.$errors.failWithoutHelp("Unable to detect platform for which to start emulator.");
 		}
 
-		await emulatorServices.startEmulator();
+		await emulatorServices.startEmulator(emulatorImage);
 
 		if (this.$mobileHelper.isAndroidPlatform(platform)) {
 			await this.$androidDeviceDiscovery.startLookingForDevices();

--- a/mobile/wp8/wp8-emulator-services.ts
+++ b/mobile/wp8/wp8-emulator-services.ts
@@ -20,6 +20,11 @@ class Wp8EmulatorServices implements Mobile.IEmulatorPlatformServices {
 		return "";
 	}
 
+	public async getRunningEmulatorId(image: string): Promise<string> {
+		//todo: plamen5kov: fix later if necessary
+		return "";
+	}
+
 	public async checkDependencies(): Promise<void> {
 		return;
 	}

--- a/services/emulator-image-service.ts
+++ b/services/emulator-image-service.ts
@@ -1,7 +1,7 @@
 import { createTable } from "../helpers";
 
 //todo: plamen5kov: moved most of emulator-service here as a temporary solution untill after 3.0-RC
-export class ImageService implements Mobile.IImageService {
+export class EmulatorImageService implements Mobile.IEmulatorImageService {
 
 	constructor(
 		private $mobileHelper: Mobile.IMobileHelper,
@@ -132,4 +132,4 @@ export class ImageService implements Mobile.IImageService {
 	}
 }
 
-$injector.register("imageService", ImageService);
+$injector.register("emulatorImageService", EmulatorImageService);

--- a/services/image-service.ts
+++ b/services/image-service.ts
@@ -1,0 +1,135 @@
+import { createTable } from "../helpers";
+
+//todo: plamen5kov: moved most of emulator-service here as a temporary solution untill after 3.0-RC
+export class ImageService implements Mobile.IImageService {
+
+	constructor(
+		private $mobileHelper: Mobile.IMobileHelper,
+		private $childProcess: IChildProcess,
+		private $devicesService: Mobile.IDevicesService,
+		private $logger: ILogger,
+		private $androidEmulatorServices: Mobile.IAndroidEmulatorServices) { }
+
+	public async getEmulatorInfo(platform: string, idOrName: string): Promise<Mobile.IEmulatorInfo> {
+		if (this.$mobileHelper.isAndroidPlatform(platform)) {
+			let androidEmulators = this.getAndroidEmulators();
+			let found = androidEmulators.filter((info: Mobile.IEmulatorInfo) => info.id === idOrName);
+			if (found.length > 0) {
+				return found[0];
+			}
+
+			await this.$devicesService.initialize({ platform: platform, deviceId: null, skipInferPlatform: true });
+			let info: Mobile.IEmulatorInfo = null;
+			let action = async (device: Mobile.IDevice) => {
+				if (device.deviceInfo.identifier === idOrName) {
+					info = {
+						id: device.deviceInfo.identifier,
+						name: device.deviceInfo.displayName,
+						version: device.deviceInfo.version,
+						platform: "Android",
+						type: "emulator",
+						isRunning: true
+					};
+				}
+			};
+			await this.$devicesService.execute(action, undefined, { allowNoDevices: true });
+			return info;
+		}
+
+		if (this.$mobileHelper.isiOSPlatform(platform)) {
+			let emulators = await this.getiOSEmulators();
+			let sdk: string = null;
+			let versionStart = idOrName.indexOf("(");
+			if (versionStart > 0) {
+				sdk = idOrName.substring(versionStart + 1, idOrName.indexOf(")", versionStart)).trim();
+				idOrName = idOrName.substring(0, versionStart - 1).trim();
+			}
+			let found = emulators.filter((info: Mobile.IEmulatorInfo) => {
+				let sdkMatch = sdk ? info.version === sdk : true;
+				return sdkMatch && info.id === idOrName || info.name === idOrName;
+			});
+			return found.length > 0 ? found[0] : null;
+		}
+
+		return null;
+
+	}
+
+	public async listAvailableEmulators(platform: string): Promise<void> {
+		let emulators: Mobile.IEmulatorInfo[] = [];
+		if (!platform || this.$mobileHelper.isiOSPlatform(platform)) {
+			let iosEmulators = await this.getiOSEmulators();
+			if (iosEmulators) {
+				emulators = emulators.concat(iosEmulators);
+			}
+		}
+
+		if (!platform || this.$mobileHelper.isAndroidPlatform(platform)) {
+			let androidEmulators = this.getAndroidEmulators();
+			if (androidEmulators) {
+				emulators = emulators.concat(androidEmulators);
+			}
+		}
+
+		this.outputEmulators("\nAvailable emulators", emulators);
+	}
+
+	public async getiOSEmulators(): Promise<Mobile.IEmulatorInfo[]> {
+		let output = await this.$childProcess.exec("xcrun simctl list --json");
+		let list = JSON.parse(output);
+		let emulators: Mobile.IEmulatorInfo[] = [];
+		for (let osName in list["devices"]) {
+			if (osName.indexOf("iOS") === -1) {
+				continue;
+			}
+			let os = list["devices"][osName];
+			let version = this.parseiOSVersion(osName);
+			for (let device of os) {
+				if (device["availability"] !== "(available)") {
+					continue;
+				}
+				let emulatorInfo: Mobile.IEmulatorInfo = {
+					id: device["udid"],
+					name: device["name"],
+					isRunning: device["state"] === "Booted",
+					type: "simulator",
+					version: version,
+					platform: "iOS"
+				};
+				emulators.push(emulatorInfo);
+			}
+		}
+
+		return emulators;
+	}
+
+	public getAndroidEmulators(): Mobile.IEmulatorInfo[] {
+		const androidVirtualDevices: Mobile.IAvdInfo[] = this.$androidEmulatorServices.getAvds().map(avd => this.$androidEmulatorServices.getInfoFromAvd(avd));
+
+		const emulators: Mobile.IEmulatorInfo[] = _.map(androidVirtualDevices, avd => {
+			return { name: avd.device, version: avd.target, id: avd.name, platform: "Android", type: "Emulator", isRunning: false };
+		});
+
+		return emulators;
+	}
+
+	private parseiOSVersion(osName: string): string {
+		osName = osName.replace("com.apple.CoreSimulator.SimRuntime.iOS-", "");
+		osName = osName.replace(/-/g, ".");
+		osName = osName.replace("iOS", "");
+		osName = osName.trim();
+		return osName;
+	}
+
+	private outputEmulators(title: string, emulators: Mobile.IEmulatorInfo[]) {
+		this.$logger.out(title);
+		let table: any = createTable(["Device Name", "Platform", "Version", "Device Identifier"], []);
+		for (let info of emulators) {
+			table.push([info.name, info.platform, info.version, info.id]);
+		}
+
+		this.$logger.out(table.toString());
+	}
+}
+
+$injector.register("imageService", ImageService);

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -476,9 +476,7 @@ describe("devicesService", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 			iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
 			androidDeviceDiscovery.emit("deviceFound", androidDevice);
-			let hostInfo = testInjector.resolve("hostInfo");
-			hostInfo.isDarwin = true;
-			await assert.isRejected(devicesService.initialize({ platform: "ios", deviceId: androidDevice.deviceInfo.identifier }), "Cannot resolve the specified connected device. The provided platform does not match the provided index or identifier.To list currently connected devices and verify that the specified pair of platform and index or identifier exists, run \'device\'.");
+			await assert.isRejected(devicesService.initialize({ platform: "ios", deviceId: androidDevice.deviceInfo.identifier }), "You can use iOS simulator only on OS X.");
 		});
 
 		describe("when only deviceIdentifier is passed", () => {

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -77,6 +77,9 @@ class AndroidEmulatorServices {
 		androidDeviceDiscovery.emit("deviceFound", androidEmulatorDevice);
 		return Promise.resolve();
 	}
+	public async getRunningEmulatorId(identifier: string): Promise<string> {
+		return Promise.resolve(identifier);
+	}
 }
 
 class IOSEmulatorServices {
@@ -87,6 +90,9 @@ class IOSEmulatorServices {
 			iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
 		}
 		return Promise.resolve();
+	}
+	public async getRunningEmulatorId(identifier: string): Promise<string> {
+		return Promise.resolve(identifier);
 	}
 }
 
@@ -231,10 +237,9 @@ describe("devicesService", () => {
 		devicesService: Mobile.IDevicesService,
 		androidEmulatorServices: any,
 		logger: CommonLoggerStub,
-		assertAndroidEmulatorIsStarted = async () => {
+		assertAndroidEmulatorIsStarted = async (options: any) => {
 			assert.isFalse(androidEmulatorServices.isStartEmulatorCalled);
-			await devicesService.execute(() => { counter++; return Promise.resolve(); }, () => true);
-			assert.deepEqual(counter, 1, "The action must be executed on only one device.");
+			await devicesService.initialize({ platform: "android" });
 			assert.isTrue(androidEmulatorServices.isStartEmulatorCalled);
 			androidDeviceDiscovery.emit("deviceLost", androidEmulatorDevice);
 			androidEmulatorServices.isStartEmulatorCalled = false;
@@ -405,8 +410,6 @@ describe("devicesService", () => {
 				androidDeviceDiscovery.emit("deviceLost", androidDevice);
 				androidDeviceDiscovery.emit("deviceLost", tempDevice);
 				counter = 0;
-				await assertAndroidEmulatorIsStarted();
-				counter = 0;
 				await devicesService.execute(() => { counter++; return Promise.resolve(); }, () => true, { allowNoDevices: true });
 				assert.deepEqual(counter, 0, "The action must not be executed when there are no devices.");
 				assert.isTrue(logger.output.indexOf(constants.ERROR_NO_DEVICES) !== -1);
@@ -439,6 +442,8 @@ describe("devicesService", () => {
 			it("does not fail when androidDeviceDiscovery startLookingForDevices fails", async () => {
 				(<any>androidDeviceDiscovery).startLookingForDevices = (): Promise<void> => { throw new Error("my error"); };
 				iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
+				let hostInfo = testInjector.resolve("hostInfo");
+				hostInfo.isDarwin = true;
 				await devicesService.initialize({ platform: "ios", deviceId: iOSDevice.deviceInfo.identifier });
 				assert.isTrue(logger.traceOutput.indexOf("my error") !== -1);
 			});
@@ -456,7 +461,7 @@ describe("devicesService", () => {
 		it("when initialize is called with platform and deviceId and such device cannot be found", async () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 
-			let expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIdentifierErrorMessage");
+			let expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIdentifierErrorMessageWithIdentifier", androidDevice.deviceInfo.identifier);
 			await assert.isRejected(devicesService.initialize({ platform: "android", deviceId: androidDevice.deviceInfo.identifier }), expectedErrorMessage);
 		});
 
@@ -471,6 +476,8 @@ describe("devicesService", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 			iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
 			androidDeviceDiscovery.emit("deviceFound", androidDevice);
+			let hostInfo = testInjector.resolve("hostInfo");
+			hostInfo.isDarwin = true;
 			await assert.isRejected(devicesService.initialize({ platform: "ios", deviceId: androidDevice.deviceInfo.identifier }), "Cannot resolve the specified connected device. The provided platform does not match the provided index or identifier.To list currently connected devices and verify that the specified pair of platform and index or identifier exists, run \'device\'.");
 		});
 
@@ -500,8 +507,6 @@ describe("devicesService", () => {
 				androidDeviceDiscovery.emit("deviceLost", androidDevice);
 				androidDeviceDiscovery.emit("deviceLost", tempDevice);
 				iOSDeviceDiscovery.emit("deviceLost", iOSDevice);
-				counter = 0;
-				await assertAndroidEmulatorIsStarted();
 				counter = 0;
 				await devicesService.execute(() => { counter++; return Promise.resolve(); }, () => true, { allowNoDevices: true });
 				assert.deepEqual(counter, 0, "The action must not be executed when there are no devices.");
@@ -541,25 +546,22 @@ describe("devicesService", () => {
 		});
 
 		describe("when only platform is passed", () => {
-			it("execute fails when platform is iOS on non-Darwin platform and there are no devices attached when --emulator is passed", async () => {
+			it("initialize fails when platform is iOS on non-Darwin platform and there are no devices attached when --emulator is passed", async () => {
 				testInjector.resolve("hostInfo").isDarwin = false;
-				await devicesService.initialize({ platform: "ios" });
-				testInjector.resolve("options").emulator = true;
-				await assert.isRejected(devicesService.execute(() => { counter++; return Promise.resolve(); }), "Cannot find connected devices. Reconnect any connected devices");
+				await assert.isRejected(devicesService.initialize({ platform: "ios" }), "You can use iOS simulator only on OS X.");
 			});
 
-			it("execute fails when platform is iOS on non-Darwin platform and there are no devices attached", async () => {
+			it("initialize fails when platform is iOS on non-Darwin platform and there are no devices attached", async () => {
 				testInjector.resolve("hostInfo").isDarwin = false;
-				await devicesService.initialize({ platform: "ios" });
+				await assert.isRejected(devicesService.initialize({ platform: "ios" }), "You can use iOS simulator only on OS X.");
 				assert.isFalse(devicesService.hasDevices, "MUST BE FALSE!!!");
-				await assert.isRejected(devicesService.execute(() => { counter++; return Promise.resolve(); }), "Cannot find connected devices. Reconnect any connected devices");
 			});
 
 			it("executes action only on iOS Simulator when iOS device is found and --emulator is passed", async () => {
 				testInjector.resolve("options").emulator = true;
 				testInjector.resolve("hostInfo").isDarwin = true;
 				iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
-				await devicesService.initialize({ platform: "ios" });
+				await devicesService.initialize({ platform: "ios", emulator: true});
 				let deviceIdentifier: string;
 				counter = 0;
 				await devicesService.execute((d: Mobile.IDevice) => { deviceIdentifier = d.deviceInfo.identifier; counter++; return Promise.resolve(); });
@@ -605,10 +607,9 @@ describe("devicesService", () => {
 				counter = 0;
 				await devicesService.execute(() => { counter++; return Promise.resolve(); }, () => true);
 				assert.deepEqual(counter, 1, "The action must be executed on only one device.");
+				counter = 0;
 				androidDeviceDiscovery.emit("deviceLost", tempDevice);
-				counter = 0;
-				await assertAndroidEmulatorIsStarted();
-				counter = 0;
+				await assertAndroidEmulatorIsStarted({ platform: "android" });
 				await devicesService.execute(() => { counter++; return Promise.resolve(); }, () => true, { allowNoDevices: true });
 				assert.deepEqual(counter, 0, "The action must not be executed when there are no devices.");
 				assert.isTrue(logger.output.indexOf(constants.ERROR_NO_DEVICES) !== -1);
@@ -645,8 +646,6 @@ describe("devicesService", () => {
 			androidDeviceDiscovery.emit("deviceLost", tempDevice);
 			iOSDeviceDiscovery.emit("deviceLost", iOSDevice);
 			counter = 0;
-			await assert.isRejected(devicesService.execute(() => { counter++; return Promise.resolve(); }, () => true), "Unable to detect platform for which to start emulator.");
-			counter = 0;
 			devicesService.execute(() => { counter++; return Promise.resolve(); }, () => true, { allowNoDevices: true });
 			assert.deepEqual(counter, 0, "The action must not be executed when there are no devices.");
 			assert.isTrue(logger.output.indexOf(constants.ERROR_NO_DEVICES) !== -1);
@@ -677,8 +676,6 @@ describe("devicesService", () => {
 			await devicesService.execute(() => { counter++; return Promise.resolve(); }, () => true);
 			assert.deepEqual(counter, 1, "The action must be executed on only one device.");
 			androidDeviceDiscovery.emit("deviceLost", tempDevice);
-			counter = 0;
-			await assertAndroidEmulatorIsStarted();
 			counter = 0;
 			await devicesService.execute(() => { counter++; return Promise.resolve(); }, () => true, { allowNoDevices: true });
 			assert.deepEqual(counter, 0, "The action must not be executed when there are no devices.");


### PR DESCRIPTION
Moved functionality from `tns emulate` to `tns run` command.

Main changes:
* --device flag starts emulator/simulator if necessary
* --available-devices lists all available images to start along with all connected devices (shows Device Identifier)
* can start device by using the `Device Identifier` for both android and ios emulators/simulators
* can run application on device using it's: `Device Identifier` and index.

related issue: https://github.com/NativeScript/nativescript-cli/issues/2349