### PR TITLE
Fix directory creation to not try to recreate it if it exists

### DIFF
--- a/mobile/ios/simulator/ios-simulator-file-system.ts
+++ b/mobile/ios/simulator/ios-simulator-file-system.ts
@@ -40,7 +40,7 @@ export class IOSSimulatorFileSystem implements Mobile.IDeviceFileSystem {
 	public async transferFile(localFilePath: string, deviceFilePath: string): Promise<void> {
 		this.$logger.trace(`Transferring from ${localFilePath} to ${deviceFilePath}`);
 		if (this.$fs.getFsStats(localFilePath).isDirectory()) {
-			shelljs.mkdir(deviceFilePath);
+			this.$fs.ensureDirectoryExists(deviceFilePath);
 		} else {
 			this.$fs.ensureDirectoryExists(path.dirname(deviceFilePath));
 			shelljs.cp("-f", localFilePath, deviceFilePath);


### PR DESCRIPTION
When copying directory over an existing directory and the LiveSync is working it tracks that a directory should be created and tries to re-create it on the device with "mkdir" which conflicts". The errors observed are:

`Unable to sync files. Error is: Multiple errors were thrown:
EEXIST: file already exists, mkdir '/Users/yosifov/Library/Developer/CoreSimulator/Devices/BF4EC4A7-0D62-46F0-BF90-CD2BFA071A23/data/Containers/Bundle/Application/171F45A9-E810-4FBF-AFAB-A6715B00EFB0/Test.app/app/dummy/dummy'`

The issue is fixed by just ensuring the directory exists, so that we don't try to create it if it already exists.