### PR TITLE
Fix ios-device-operations dispose

### DIFF
--- a/mobile/ios/device/ios-application-manager.ts
+++ b/mobile/ios/device/ios-application-manager.ts
@@ -98,6 +98,9 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 
 	private async runApplicationCore(appIdentifier: string): Promise<void> {
 		await this.$iosDeviceOperations.start([{ deviceId: this.device.deviceInfo.identifier, appId: appIdentifier, ddi: this.$options.ddi }]);
+		if (!this.$options.justlaunch) {
+			await this.device.openDeviceLogStream();
+		}
 	}
 
 	public canStartApplication(): boolean {

--- a/mobile/ios/device/ios-device-operations.ts
+++ b/mobile/ios/device/ios-device-operations.ts
@@ -7,9 +7,14 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 	public shouldDispose: boolean;
 	private deviceLib: IOSDeviceLib.IOSDeviceLib;
 
-	constructor(private $logger: ILogger) {
+	constructor(private $logger: ILogger,
+		private $processService: IProcessService) {
 		this.isInitialized = false;
 		this.shouldDispose = true;
+		this.$processService.attachToProcessExitSignals(this, () => {
+			this.setShouldDispose(true);
+			this.dispose();
+		});
 	}
 
 	public async install(ipaPath: string, deviceIdentifiers: string[], errorHandler: DeviceOperationErrorHandler): Promise<IOSDeviceResponse> {

--- a/mobile/ios/ios-log-filter.ts
+++ b/mobile/ios/ios-log-filter.ts
@@ -1,5 +1,5 @@
 export class IOSLogFilter implements Mobile.IPlatformLogFilter {
-	private static INFO_FILTER_REGEX = /^.*?(AppBuilder|Cordova|NativeScript).*?(<Notice>:.*?|<Warning>:.*?|<Error>:.*?)$/im;
+	protected infoFilterRegex = /^.*?(AppBuilder|Cordova|NativeScript).*?(<Notice>:.*?|<Warning>:.*?|<Error>:.*?)$/im;
 
 	constructor(private $loggingLevels: Mobile.ILoggingLevels) { }
 
@@ -11,11 +11,12 @@ export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 				return data && data.indexOf(`[${pid}]`) !== -1 ? data.trim() : null;
 			}
 
-			let matchingInfoMessage = data.match(IOSLogFilter.INFO_FILTER_REGEX);
+			let matchingInfoMessage = data.match(this.infoFilterRegex);
 			return matchingInfoMessage ? matchingInfoMessage[2] : null;
 		}
 
 		return data;
 	}
 }
+
 $injector.register("iOSLogFilter", IOSLogFilter);


### PR DESCRIPTION
We need to check if the justlaunch flag is passed before we set the should dispose property to false. If we set it to false unconditionally when we pass justlaunch flag the process will never exit.