### PR TITLE
skip the hidden files when livesyncing

### DIFF
--- a/services/livesync-service-base.ts
+++ b/services/livesync-service-base.ts
@@ -45,7 +45,17 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 			}
 		});
 
+		// skip hidden files, to prevent reload of the app for hidden files
+		// created temporarily by the IDEs
+		if (this.isUnixHiddenPath(filePath)) {
+			isFileExcluded = true;
+		}
+
 		return isFileExcluded;
+	}
+
+	private isUnixHiddenPath(filePath: string): boolean {
+		return (/(^|\/)\.[^\/\.]/g).test(filePath);
 	}
 
 	private partialSync(data: ILiveSyncData[], syncWorkingDirectory: string, projectId: string): void {


### PR DESCRIPTION
Add filter for files which are hidden in linux/Mac to be skipped when livesync-ing the app. Some IDEs create them to backup the currently edited file and this causes a re-deploy/re-run of the Application although it's not necessary.
