### PR TITLE
Add filter by platform when searching device

### DIFF
--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -373,7 +373,11 @@ export class DevicesService implements Mobile.IDevicesService {
 		if (data && data.platform) {
 			// are there any running devices
 			this._platform = data.platform;
-			await this.startLookingForDevices();
+			try {
+				await this.startLookingForDevices();
+			} catch (err) {
+				this.$logger.trace("Error while checking for devices.", err);
+			}
 			let deviceInstances = this.getDeviceInstances();
 
 			//if no --device is passed and no devices are found, the default emulator is started

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -372,7 +372,8 @@ export class DevicesService implements Mobile.IDevicesService {
 
 		if (data && data.platform) {
 			// are there any running devices
-			await this.detectCurrentlyAttachedDevices();
+			this._platform = data.platform;
+			await this.startLookingForDevices();
 			let deviceInstances = this.getDeviceInstances();
 
 			//if no --device is passed and no devices are found, the default emulator is started
@@ -408,12 +409,12 @@ export class DevicesService implements Mobile.IDevicesService {
 	 */
 	@exported("devicesService")
 	public async initialize(data?: Mobile.IDevicesServicesInitializationOptions): Promise<void> {
-		this.$logger.out("Searching for devices...");
-		await this.startEmulatorIfNecessary(data);
-
 		if (this._isInitialized) {
 			return;
 		}
+
+		this.$logger.out("Searching for devices...");
+		await this.startEmulatorIfNecessary(data);
 
 		data = data || {};
 		this._data = data;

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -236,14 +236,7 @@ describe("devicesService", () => {
 		testInjector: IInjector,
 		devicesService: Mobile.IDevicesService,
 		androidEmulatorServices: any,
-		logger: CommonLoggerStub,
-		assertAndroidEmulatorIsStarted = async (options: any) => {
-			assert.isFalse(androidEmulatorServices.isStartEmulatorCalled);
-			await devicesService.initialize({ platform: "android" });
-			assert.isTrue(androidEmulatorServices.isStartEmulatorCalled);
-			androidDeviceDiscovery.emit("deviceLost", androidEmulatorDevice);
-			androidEmulatorServices.isStartEmulatorCalled = false;
-		};
+		logger: CommonLoggerStub;
 
 	beforeEach(() => {
 		testInjector = createTestInjector();
@@ -607,7 +600,6 @@ describe("devicesService", () => {
 				assert.deepEqual(counter, 1, "The action must be executed on only one device.");
 				counter = 0;
 				androidDeviceDiscovery.emit("deviceLost", tempDevice);
-				await assertAndroidEmulatorIsStarted({ platform: "android" });
 				await devicesService.execute(() => { counter++; return Promise.resolve(); }, () => true, { allowNoDevices: true });
 				assert.deepEqual(counter, 0, "The action must not be executed when there are no devices.");
 				assert.isTrue(logger.output.indexOf(constants.ERROR_NO_DEVICES) !== -1);


### PR DESCRIPTION
When in debug mode we should respect the passed platform and search only for devices for the respective platform. If we have devices from both android and iOS we recognized them both as valid devices and started an emulator.