### PR TITLE
Add debug method to the public API

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1547,6 +1547,21 @@ interface INet {
 	 * @return {Promise<number>} The port.
 	 */
 	getFreePort(): Promise<number>;
+
+	/**
+	 * Returns the first available port in the provided range.
+	 * @param {number} startPort the first port to check.
+	 * @param {number} @optional endPort the last port to check. The default value is 65534.
+	 * @return {Promise<number>} returns the first available prot in the given range.
+	 */
+	getAvailablePortInRange(startPort: number, endPort?: number): Promise<number>;
+
+	/**
+	 * Checks if the candidate port is available.
+	 * @param {number} port the candidate port.
+	 * @return {Promise<boolean>} true if the port is available.
+	 */
+	isPortAvailable(port: number): Promise<boolean>;
 }
 
 interface IProcessService {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -348,6 +348,11 @@ declare module Mobile {
 		skipDeviceDetectionInterval?: boolean;
 	}
 
+	interface IDeviceActionResult<T> {
+		deviceIdentifier: string;
+		result: T;
+	}
+
 	interface IDevicesService {
 		hasDevices: boolean;
 		deviceCount: number;
@@ -359,7 +364,7 @@ declare module Mobile {
 		 */
 		startEmulatorIfNecessary(data?: Mobile.IDevicesServicesInitializationOptions): Promise<void>;
 
-		execute(action: (device: Mobile.IDevice) => Promise<void>, canExecute?: (dev: Mobile.IDevice) => boolean, options?: { allowNoDevices?: boolean }): Promise<void>;
+		execute<T>(action: (device: Mobile.IDevice) => Promise<T>, canExecute?: (dev: Mobile.IDevice) => boolean, options?: { allowNoDevices?: boolean }): Promise<IDeviceActionResult<T>[]>;
 
 		/**
 		 * Initializes DevicesService, so after that device operations could be executed.

--- a/helpers.ts
+++ b/helpers.ts
@@ -388,49 +388,6 @@ export async function connectEventuallyUntilTimeout(factory: () => net.Socket, t
 	});
 }
 
-export function isPortAvailable(candidatePort: number): Promise<boolean> {
-	return new Promise<boolean>((resolve, reject) => {
-		let isResolved = false;
-		let server = net.createServer();
-
-		server.on("error", (err: Error) => {
-			if (!isResolved) {
-				isResolved = true;
-				resolve(false);
-			}
-		});
-
-		server.once("close", () => {
-			if (!isResolved) { // "close" will be emitted right after "error"
-				isResolved = true;
-				resolve(true);
-			}
-		});
-
-		server.on("listening", (err: Error) => {
-			if (err && !isResolved) {
-				isResolved = true;
-				resolve(false);
-			}
-
-			server.close();
-		});
-
-		server.listen(candidatePort, "localhost");
-	});
-}
-
-export async function getAvailablePort(port: number): Promise<number> {
-	while (!(await isPortAvailable(port))) {
-		port++;
-		if (port > 65534) {
-			this.$errors.failWithoutHelp("Unable to find free local port.");
-		}
-	}
-
-	return port;
-}
-
 //--- begin part copied from AngularJS
 
 //The MIT License

--- a/helpers.ts
+++ b/helpers.ts
@@ -388,6 +388,49 @@ export async function connectEventuallyUntilTimeout(factory: () => net.Socket, t
 	});
 }
 
+export function isPortAvailable(candidatePort: number): Promise<boolean> {
+	return new Promise<boolean>((resolve, reject) => {
+		let isResolved = false;
+		let server = net.createServer();
+
+		server.on("error", (err: Error) => {
+			if (!isResolved) {
+				isResolved = true;
+				resolve(false);
+			}
+		});
+
+		server.once("close", () => {
+			if (!isResolved) { // "close" will be emitted right after "error"
+				isResolved = true;
+				resolve(true);
+			}
+		});
+
+		server.on("listening", (err: Error) => {
+			if (err && !isResolved) {
+				isResolved = true;
+				resolve(false);
+			}
+
+			server.close();
+		});
+
+		server.listen(candidatePort, "localhost");
+	});
+}
+
+export async function getAvailablePort(port: number): Promise<number> {
+	while (!(await isPortAvailable(port))) {
+		port++;
+		if (port > 65534) {
+			this.$errors.failWithoutHelp("Unable to find free local port.");
+		}
+	}
+
+	return port;
+}
+
 //--- begin part copied from AngularJS
 
 //The MIT License


### PR DESCRIPTION
We need to add debug service to the public API of the {N} CLI. This service should have method which starts debugging and returns the chrome devtools url. With this service it will be possible to use the CLI as a library and start debugging.
This PR includes:
- Return the results from the action in devicesService.execute(action)