### PR TITLE
Increase discover iOS devices timeout

### DIFF
--- a/mobile/ios/device/ios-device-operations.ts
+++ b/mobile/ios/device/ios-device-operations.ts
@@ -38,7 +38,7 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 
 			// We need this because we need to make sure that we have devices.
 			await new Promise((resolve, reject) => {
-				setTimeout(resolve, 1500);
+				setTimeout(resolve, 3000);
 			});
 		}
 	}


### PR DESCRIPTION
For older iOS devices, they cannot be enlisted by the:

`tns device ios`

command, as they're discovered slower. I've tested with 3.0 seconds which is double the current value and it seems to have worked every time for an old iPad of ours. 

Best,
Yosif