### PR TITLE
Adding tick-tack mechanism to incrementally wait for devices

### DIFF
--- a/mobile/ios/device/ios-device-operations.ts
+++ b/mobile/ios/device/ios-device-operations.ts
@@ -35,10 +35,10 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 		this.isInitialized = true;
 		if (!this.deviceLib) {
 			let foundDevice = false;
-			let wrappedDeviceFoundCallback = (deviceInfoCallback: DeviceInfoCallback) => {
+			let wrappedDeviceFoundCallback = (deviceInfo: IOSDeviceLib.IDeviceActionInfo) => {
 				foundDevice = true;
 
-				return deviceFoundCallback(deviceInfoCallback);
+				return deviceFoundCallback(deviceInfo);
 			};
 
 			this.deviceLib = new IOSDeviceLibModule(wrappedDeviceFoundCallback, deviceLostCallback);
@@ -48,7 +48,7 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 				let iterationsCount = 0,
 					maxIterationsCount = 10;
 
-				let intervalHandle: number = setInterval(() => {
+				let intervalHandle: NodeJS.Timer = setInterval(() => {
 					if (foundDevice) {
 						resolve();
 						return clearInterval(intervalHandle);

--- a/mobile/ios/device/ios-device-operations.ts
+++ b/mobile/ios/device/ios-device-operations.ts
@@ -49,13 +49,13 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 					maxIterationsCount = 10;
 
 				let intervalHandle: number = setInterval(() => {
-					if(foundDevice) {
+					if (foundDevice) {
 						resolve();
 						return clearInterval(intervalHandle);
 					}
 
 					iterationsCount++;
-					if(iterationsCount >= maxIterationsCount) {
+					if (iterationsCount >= maxIterationsCount) {
 						clearInterval(intervalHandle);
 						return resolve();
 					}


### PR DESCRIPTION
In order to improve the hard-coded "wait for 5 seconds" timeout and then check if some iOS Devices have been detected, we change to iteratively checking for iOS Device results on every 0.5 seconds, so that the 5 seconds would be a worst case for very very slow iOS devices or no iOS devices connected at all.