### PR TITLE
Validate proxy url

### DIFF
--- a/commands/proxy/proxy-get.ts
+++ b/commands/proxy/proxy-get.ts
@@ -1,4 +1,3 @@
-import { EOL } from "os";
 import { ProxyCommandBase } from "./proxy-base";
 
 const proxyGetCommandName = "proxy|*get";
@@ -11,21 +10,7 @@ export class ProxyGetCommand extends ProxyCommandBase {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		let message = "";
-		const proxyCache: IProxyCache = this.$proxyService.getCache();
-		if (proxyCache) {
-			const proxyCredentials = await this.$proxyService.getCredentials();
-			message = `Proxy Url: ${proxyCache.PROXY_PROTOCOL}://${proxyCache.PROXY_HOSTNAME}:${proxyCache.PROXY_PORT}`;
-			if (proxyCredentials && proxyCredentials.username) {
-				message += `${EOL}Username: ${proxyCredentials.username}`;
-			}
-
-			message += `${EOL}Proxy is Enabled`;
-		} else {
-			message = "No proxy set";
-		}
-
-		this.$logger.out(message);
+		this.$logger.out(await this.$proxyService.getInfo());
 		await this.tryTrackUsage();
 	}
 }

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -718,27 +718,37 @@ interface IProxyService {
 	 * @returns {Promise<ICredentials>} The cache.
 	 */
 	setCache(cacheData: IProxyCache): IProxyCache;
+
 	/**
 	 * Retrieves proxy cache data.
 	 * @returns {IProxyCache} The cache.
 	 */
 	getCache(): IProxyCache;
+
 	/**
 	 * Clears proxy cache data.
 	 * @returns {void}
 	 */
 	clearCache(): void;
+
 	/**
 	 * Sets the provided proxy credentials in the OS' secure storage.
 	 * @param credentials {ICredentials} Proxy credentials to be stored.
 	 * @returns {Promise<ICredentials>} The stored proxy credentials.
 	 */
 	setCredentials(credentials: ICredentials): Promise<ICredentials>;
+
 	/**
 	 * Retrieves proxy credentials from the OS' secure storage with the given key.
 	 * @returns {Promise<ICredentials>} The stored proxy credentials.
 	 */
 	getCredentials(): Promise<ICredentials>;
+
+	/**
+	 * Gets info about the proxy that can be printed and shown to the user.
+	 * @returns {Promise<string>} Info about the proxy.
+	 */
+	getInfo(): Promise<string>
 }
 
 interface IDynamicHelpProvider {

--- a/services/proxy-service.ts
+++ b/services/proxy-service.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import { EOL } from "os";
 import { Proxy } from "../constants";
 
 export class ProxyService implements IProxyService {
@@ -25,6 +26,24 @@ export class ProxyService implements IProxyService {
 	public clearCache(): void {
 		this.$fs.deleteFile(this.proxyCacheFilePath);
 		this.$credentialsService.clearCredentials(this.credentialsKey);
+	}
+
+	public async getInfo(): Promise<string> {
+		let message = "";
+		const proxyCache: IProxyCache = this.getCache();
+		if (proxyCache) {
+			const proxyCredentials = await this.getCredentials();
+			message = `Proxy Url: ${proxyCache.PROXY_PROTOCOL}//${proxyCache.PROXY_HOSTNAME}:${proxyCache.PROXY_PORT}`;
+			if (proxyCredentials && proxyCredentials.username) {
+				message += `${EOL}Username: ${proxyCredentials.username}`;
+			}
+
+			message += `${EOL}Proxy is Enabled`;
+		} else {
+			message = "No proxy set";
+		}
+
+		return message;
 	}
 
 	public async getCredentials(): Promise<ICredentials> {


### PR DESCRIPTION
* Prompt the user for a full url in case an incomplete or incorrect one is passed (for example 127.0.0.1 instead of http://127.0.0.1
* Fix UI bug in `proxy get` command where `:` is displayed twice after protocol (i.e. http:://127.0.0.1)
* Print proxy info after `proxy set`

Ping @TsvetanMilanov @rosen-vladimirov 