### PR TITLE
Fix proxy usage on macOS and Linux and fix using npm proxy

### DIFF
--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as os from "os";
 import * as constants from "../../constants";
-import { fromWindowsRelativePathToUnix } from "../../helpers";
+import { fromWindowsRelativePathToUnix, toBoolean } from "../../helpers";
 import { exportedPromise } from "../../decorators";
 import * as url from "url";
 
@@ -341,14 +341,16 @@ export class NpmService implements INpmService {
 	private async getNpmProxySettings(): Promise<IProxySettings> {
 		if (!this._hasCheckedNpmProxy) {
 			try {
-				let npmProxy = (await this.$childProcess.exec("npm config get proxy") || "").toString().trim();
+				const npmProxy = (await this.$childProcess.exec("npm config get proxy") || "").toString().trim();
 
 				// npm will return null as string in case there's no proxy set.
 				if (npmProxy && npmProxy !== "null") {
-					let uri = url.parse(npmProxy);
+					const strictSslString = (await this.$childProcess.exec("npm config get strict-ssl") || "").toString().trim();
+					const uri = url.parse(npmProxy);
 					this._proxySettings = {
 						hostname: uri.hostname,
-						port: uri.port
+						port: uri.port,
+						rejectUnauthorized: toBoolean(strictSslString)
 					};
 				}
 			} catch (err) {

--- a/commands/proxy/proxy-set.ts
+++ b/commands/proxy/proxy-set.ts
@@ -3,7 +3,7 @@ import { isInteractive } from "../../helpers";
 import { ProxyCommandBase } from "./proxy-base";
 import { HttpProtocolToPort } from "../../constants";
 import { parse } from "url";
-import { EOL } from "os";
+import { platform, EOL } from "os";
 
 const proxySetCommandName = "proxy|set";
 
@@ -17,6 +17,7 @@ export class ProxySetCommand extends ProxyCommandBase {
 	constructor(private $errors: IErrors,
 		private $injector: IInjector,
 		private $prompter: IPrompter,
+		private $hostInfo: IHostInfo,
 		protected $analyticsService: IAnalyticsService,
 		protected $logger: ILogger,
 		protected $options: ICommonOptions,
@@ -97,6 +98,10 @@ export class ProxySetCommand extends ProxyCommandBase {
 			PROXY_PROTOCOL: urlObj.protocol,
 			ALLOW_INSECURE: this.$options.insecure
 		};
+
+		if (!this.$hostInfo.isWindows) {
+			this.$logger.warn(`Note that storing credentials is not supported on ${platform()} yet.`);
+		}
 
 		this.$proxyService.setCache(proxyCache);
 		this.$logger.out(`Successfully setup proxy.${EOL}`);

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1704,6 +1704,11 @@ interface IProxySettings {
 	 * Protocol of the proxy - http or https
 	 */
 	protocol?: string;
+
+	/**
+	 * Defines if NODE_TLS_REJECT_UNAUTHORIZED should be set to true or false. Default value is true.
+	 */
+	rejectUnauthorized: boolean;
 }
 
 /**

--- a/http-client.ts
+++ b/http-client.ts
@@ -291,7 +291,7 @@ export class HttpClient implements Server.IHttpClient {
 
 			// Note that proto ends with :
 			options.proxy = `${proto}//${credentialsPart}${host}:${port}`;
-			options.rejectUnauthorized = proxyCache ? !proxyCache.ALLOW_INSECURE : true;
+			options.rejectUnauthorized = proxySettings ? proxySettings.rejectUnauthorized : (proxyCache ? !proxyCache.ALLOW_INSECURE : true);
 
 			this.$logger.trace("Using proxy: %s", options.proxy);
 		}

--- a/services/credentials-service.ts
+++ b/services/credentials-service.ts
@@ -8,7 +8,8 @@ export class CredentialsService implements ICredentialsService {
 	private pathToWindowsCredentialsManager: string;
 
 	constructor(private $childProcess: IChildProcess,
-		private $hostInfo: IHostInfo) {
+		private $hostInfo: IHostInfo,
+		private $logger: ILogger) {
 		this.pathToWindowsCredentialsManager = path.join(__dirname, "..", "vendor", platform(), "CredentialsManager.exe");
 	}
 
@@ -30,7 +31,7 @@ export class CredentialsService implements ICredentialsService {
 				password: credentialsSplit && this.decrypt(credentialsSplit[1])
 			};
 		} else {
-			throw new Error(`Storing credentials is not supported on ${platform()} yet.`);
+			this.$logger.trace(`Storing credentials is not supported on ${platform()} yet.`);
 		}
 	}
 


### PR DESCRIPTION
Fix using proxy on macOS and Linux - the getCredentials method should not fail - it should return null on OSes that are not supported.
Fix using npm proxy - CLI automatically detects the proxy and uses it for calls to npm registry. However we have not set the rejectUnauthorized variable and all requests to our internal npm proxy were failing. So in such cases set the rejectUnauthorized to the value of strict-ssl npm config variable.