### PR TITLE
Add helper method for getting PID of app from iOS Sim logs

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -389,6 +389,24 @@ export async function connectEventuallyUntilTimeout(factory: () => net.Socket, t
 	});
 }
 
+/**
+ * Tries to find the process id (PID) of the specified application identifier.
+ * This is specific implementation for iOS Simulator, where the running applications are real processes.
+ * Their PIDs are printed in a specific format in the the logs, once the application is started.
+ * @param {string} applicationIdentifier Application Identifier of the app for which we try to get the PID.
+ * @param {string} logLine Line that may contain the PID of the process.
+ * @returns {string} The PID of the searched application identifier in case it's found in the current line, null otherwise.
+ */
+export function getPidFromiOSSimulatorLogs(applicationIdentifier: string, logLine: string): string {
+	if (logLine) {
+		const pidRegExp = new RegExp(`${applicationIdentifier}:\\s?(\\d+)`);
+		const pidMatch = logLine.match(pidRegExp);
+		return pidMatch ? pidMatch[1] : null;
+	}
+
+	return null;
+}
+
 //--- begin part copied from AngularJS
 
 //The MIT License

--- a/test/unit-tests/helpers.ts
+++ b/test/unit-tests/helpers.ts
@@ -10,8 +10,8 @@ interface ITestData {
 
 describe("helpers", () => {
 
-	let assertTestData = (testData: ITestData, method: Function) => {
-		let actualResult = method(testData.input);
+	const assertTestData = (testData: ITestData, method: Function) => {
+		const actualResult = method(testData.input);
 		assert.deepEqual(actualResult, testData.expectedResult, `For input ${testData.input}, the expected result is: ${testData.expectedResult}, but actual result is: ${actualResult}.`);
 	};
 
@@ -376,6 +376,85 @@ describe("helpers", () => {
 					done();
 				})
 				.catch(done);
+		});
+	});
+
+	describe("getPidFromiOSSimulatorLogs", () => {
+		interface IiOSSimulatorPidTestData extends ITestData {
+			appId?: string;
+		};
+
+		const appId = "abc.def.ghi";
+		const pid = "12345";
+
+		const assertPidTestData = (testData: IiOSSimulatorPidTestData) => {
+			const actualResult = helpers.getPidFromiOSSimulatorLogs(testData.appId || appId, testData.input);
+			assert.deepEqual(actualResult, testData.expectedResult, `For input ${testData.input}, the expected result is: ${testData.expectedResult}, but actual result is: ${actualResult}.`);
+		};
+
+		const getPidFromiOSSimulatorLogsTestData: IiOSSimulatorPidTestData[] = [
+			{
+				// Real log lines that contain the PID are in this format
+				input: `${appId}: ${appId}: ${pid}`,
+				expectedResult: pid
+			},
+			{
+				input: `${appId}: ${appId}:          ${pid}`,
+				expectedResult: null
+			},
+			{
+				input: `${appId}: ${appId}:${pid}`,
+				expectedResult: pid
+			},
+			{
+				input: `${appId}: ${appId}: ${pid} some other data`,
+				expectedResult: pid
+			},
+			{
+				input: `${appId}: ${appId}: ${pid} some other data ending with numbers 123`,
+				expectedResult: pid
+			},
+			{
+				input: `${appId}: ${pid}`,
+				expectedResult: pid
+			},
+			{
+				input: `some not valid app id with: ${pid}`,
+				expectedResult: null
+			},
+			{
+				input: null,
+				expectedResult: null
+			},
+			{
+				input: undefined,
+				expectedResult: null
+			},
+			{
+				input: '',
+				expectedResult: null
+			},
+			{
+				input: '        ',
+				expectedResult: null
+			},
+			{
+				input: '',
+				expectedResult: null
+			},
+			{
+				input: `${appId}: ${appId}\n: ${pid}`,
+				expectedResult: null
+			},
+			{
+				input: `org.nativescript.app123456: org.nativescript.app123456: ${pid}`,
+				appId: "org.nativescript.app123456",
+				expectedResult: pid
+			}
+		];
+
+		it("returns expected result", () => {
+			_.each(getPidFromiOSSimulatorLogsTestData, testData => assertPidTestData(testData));
 		});
 	});
 });


### PR DESCRIPTION
Add new helper method to get the process ID of an application from iOS Simulator Logs. Whenever we start an application on iOS Simulator, in its logs we can find the PID of the process in the following format:
```
<app id>: <app id>: <PID>
```
Add unit tests for the method.