### PR TITLE
Chmod parent dirs when syncing files on Android

### DIFF
--- a/mobile/android/android-device-file-system.ts
+++ b/mobile/android/android-device-file-system.ts
@@ -54,8 +54,11 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 		await Promise.all(
 			_(localToDevicePaths)
 				.filter(localToDevicePathData => this.$fs.getFsStats(localToDevicePathData.getLocalPath()).isFile())
-				.map(async localToDevicePathData =>
-					await this.adb.executeCommand(["push", localToDevicePathData.getLocalPath(), localToDevicePathData.getDevicePath()])
+				.map(async localToDevicePathData => {
+					const devicePath = localToDevicePathData.getDevicePath();
+					await this.adb.executeCommand(["push", localToDevicePathData.getLocalPath(), devicePath]);
+					await this.adb.executeShellCommand(["chmod", "0777", path.dirname(devicePath)]);
+				}
 				)
 				.value()
 		);


### PR DESCRIPTION
Pushing files as part of the livesync procedure on Android doesn't always update parent directories' permissions on the device unless the changes require a rebuild of the application, at which point they will be included in a list of files and directories to be chmod`d.

I propose that files being pushed in that temporary directory always have their parent's permissions explicitly set to 777 to allow their removal when necessary.