### PR TITLE
Increase the timeout of initial ios device detection

### DIFF
--- a/mobile/ios/device/ios-device-operations.ts
+++ b/mobile/ios/device/ios-device-operations.ts
@@ -46,7 +46,7 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 			// We need this because we need to make sure that we have devices.
 			await new Promise((resolve, reject) => {
 				let iterationsCount = 0,
-					maxIterationsCount = 10;
+					maxIterationsCount = 3;
 
 				let intervalHandle: NodeJS.Timer = setInterval(() => {
 					if (foundDevice) {
@@ -59,7 +59,7 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 						clearInterval(intervalHandle);
 						return resolve();
 					}
-				}, 500);
+				}, 2000);
 			});
 		}
 	}


### PR DESCRIPTION
Currently we have logic to find the intially attached (at the moment of starting the CLI) iOS devices. Its executed at the beginning of each device related commands and it checks on 500ms for device found.
However this is a problem as we may find one device and skip the others devices (in case more than one device is attached). So first CLI operations are excuted only for one device. The next operations however are executed over all devices found. For example `tns run ios` we execute several operations - install on all devices, upload files to all devices, etc. However in case the install operation is executed, only the first device is discovered. After that the upload files operations are executed on all devices. Due to the fact that the application is not installed on the other devices, the operation fails.

So increas the initial timeout to 2 seconds. Also increas the overall timeout that we wait for discovering iOS devices from 5 to 6 seconds.