### PR TITLE
Fix getting debuggable NativeScript apps

### DIFF
--- a/mobile/mobile-core/android-process-service.ts
+++ b/mobile/mobile-core/android-process-service.ts
@@ -150,7 +150,7 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 
 	private async getNativeScriptApplicationInformation(adb: Mobile.IDeviceAndroidDebugBridge, deviceIdentifier: string, information: string): Promise<Mobile.IDeviceApplicationInformation> {
 		// Search for appIdentifier (@<appIdentifier-debug>).
-		let nativeScriptAppIdentifierRegExp = /@(.+)-debug/g;
+		let nativeScriptAppIdentifierRegExp = /@(.+)-(debug|inspectorServer)/g;
 		let nativeScriptAppIdentifierMatches = nativeScriptAppIdentifierRegExp.exec(information);
 
 		if (nativeScriptAppIdentifierMatches && nativeScriptAppIdentifierMatches.length > 0) {


### PR DESCRIPTION
When you can debug NativeScript application, there must be a unix socket including the application identifier on the device. CLI searches the currently running sockets and searches for `<appid>-debug`. However with latest (3.0.0) runtime, the socket is called `<appid>-inspectorServer`. Fix regex to work with both of the versions.

NOTE: I'll add tests later.