### PR TITLE
Do not start emulator when `--available-devices` is passed

### DIFF
--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -373,7 +373,7 @@ export class DevicesService implements Mobile.IDevicesService {
 			If you are trying to run on specific emulator, use "${this.$staticConfig.CLIENT_NAME} run --device <DeviceID>`);
 		}
 
-		if (data && data.platform) {
+		if (data && data.platform && !data.skipInferPlatform) {
 			// are there any running devices
 			this._platform = data.platform;
 			try {

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -322,6 +322,12 @@ describe("devicesService", () => {
 				assert.equal((<IOSDeviceDiscoveryStub>iOSDeviceDiscovery).count, 0);
 				assert.equal((<IOSSimulatorDiscoveryStub>iOSSimulatorDiscovery).count, 0);
 			});
+			it("deviceId is NOT passed, platform is passed and skipInferPlatform is passed - should not start emulator", async () => {
+				assert.deepEqual(devicesService.getDeviceInstances(), [], "Initially getDevicesInstances must return empty array.");
+				await devicesService.startEmulatorIfNecessary({ platform: "android", skipInferPlatform: true });
+				assert.deepEqual(devicesService.getDeviceInstances(), []);
+				assert.deepEqual(devicesService.getDevices(), []);
+			});
 		});
 	});
 


### PR DESCRIPTION
In case there's no devices attached and no emulators running, trying `<cli name> devices <platform> --available-devices` will start emulator.
In order to fix this, modify the `startEmulatorIfNecessary` method to skip the starting in case `skipInferPlatform` option is passed. This option indicates that we are not concerned of specific platform, so the method does not know which is the target platform for which to start emulator.
Add unit test for this behavior.