### PR TITLE
Add generic method to injector's .d.ts

### DIFF
--- a/definitions/yok.d.ts
+++ b/definitions/yok.d.ts
@@ -10,11 +10,14 @@ interface IInjector extends IDisposable {
 	 * The injector will create new instances for every call.
 	 */
 	resolve(ctor: Function, ctorArguments?: { [key: string]: any }): any;
+	resolve<T>(ctor: Function, ctorArguments?: { [key: string]: any }): T;
 	/**
 	 * Resolves an implementation by name.
 	 * The injector will create only one instance per name and return the same instance on subsequent calls.
 	 */
 	resolve(name: string, ctorArguments?: IDictionary<any>): any;
+	resolve<T>(name: string, ctorArguments?: IDictionary<any>): T;
+
 	resolveCommand(name: string): ICommand;
 	register(name: string, resolver: any, shared?: boolean): void;
 	registerCommand(name: string, resolver: any): void;


### PR DESCRIPTION
Add Generics for two of the methods in the injector, which will allow us to skip explicit casts. Most useful in tests. For examle:
Before:
```TypeScript
const a: ISomeInterface = testInejctor.resolve("a");
```

Now:
```TypeScript
const a = testInejctor.resolve<ISomeInterface>("a");
```