### PR TITLE
Try catch printCommandHelp

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -422,6 +422,7 @@ interface ICommandOptions {
 }
 
 declare const enum ErrorCodes {
+	UNCAUGHT = 120,
 	UNKNOWN = 127,
 	INVALID_ARGUMENT = 128,
 	RESOURCE_PROBLEM = 129,

--- a/errors.ts
+++ b/errors.ts
@@ -154,7 +154,11 @@ export class Errors implements IErrors {
 				: "\x1B[31;1m" + ex.message + "\x1B[0m");
 
 			if (!ex.suppressCommandHelp) {
-				await printCommandHelp();
+				try {
+					await printCommandHelp();
+				} catch (printHelpException) {
+					console.error("Failed to display command help", printHelpException);
+				}
 			}
 
 			tryTrackException(ex, this.$injector);


### PR DESCRIPTION
In case `printCommandHelp` fails (when for example CLI doesn't have permissions to write to the `--profile-dir`) we get an uncaught exception.

Ping @yyosifov @rosen-vladimirov 