### PR TITLE
Pass correct args to ios-sim-portable's stopApplication

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -238,7 +238,7 @@ declare module Mobile {
 		uninstallApplication(appIdentifier: string): Promise<void>;
 		reinstallApplication(appIdentifier: string, packageFilePath: string): Promise<void>;
 		startApplication(appIdentifier: string): Promise<void>;
-		stopApplication(appIdentifier: string): Promise<void>;
+		stopApplication(appIdentifier: string, appName?: string): Promise<void>;
 		restartApplication(appIdentifier: string, appName?: string): Promise<void>;
 		canStartApplication(): boolean;
 		checkForApplicationUpdates(): Promise<void>;

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -17,7 +17,7 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 	}
 
 	public async restartApplication(appIdentifier: string, appName?: string): Promise<void> {
-		await this.stopApplication(appName || appIdentifier);
+		await this.stopApplication(appIdentifier, appName);
 		await this.startApplication(appIdentifier);
 	}
 
@@ -70,7 +70,7 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 	public abstract async installApplication(packageFilePath: string): Promise<void>;
 	public abstract async uninstallApplication(appIdentifier: string): Promise<void>;
 	public abstract async startApplication(appIdentifier: string): Promise<void>;
-	public abstract async stopApplication(appIdentifier: string): Promise<void>;
+	public abstract async stopApplication(appIdentifier: string, appName?: string): Promise<void>;
 	public abstract async getInstalledApplications(): Promise<string[]>;
 	public abstract async getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo>;
 	public abstract canStartApplication(): boolean;

--- a/mobile/ios/device/ios-application-manager.ts
+++ b/mobile/ios/device/ios-application-manager.ts
@@ -87,12 +87,12 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 		this.$logger.info(`Successfully run application ${appIdentifier} on device with ID ${this.device.deviceInfo.identifier}.`);
 	}
 
-	public async stopApplication(appIdentifier: string): Promise<void> {
+	public async stopApplication(appIdentifier: string, appName?: string): Promise<void> {
 		await this.$iosDeviceOperations.stop([{ deviceId: this.device.deviceInfo.identifier, ddi: this.$options.ddi, appId: appIdentifier }]);
 	}
 
-	public async restartApplication(applicationId: string): Promise<void> {
-		await this.stopApplication(applicationId);
+	public async restartApplication(applicationId: string, appName?: string): Promise<void> {
+		await this.stopApplication(applicationId, appName);
 		await this.runApplicationCore(applicationId);
 	}
 

--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -20,7 +20,6 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		return this.iosSim.getInstalledApplications(this.identifier);
 	}
 
-	// TODO: Remove Promise, reason: readDirectory - cannot until android and iOS implementatios have async calls.
 	@hook('install')
 	public async installApplication(packageFilePath: string): Promise<void> {
 		if (this.$fs.exists(packageFilePath) && path.extname(packageFilePath) === ".zip") {
@@ -50,8 +49,8 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		}
 	}
 
-	public async stopApplication(cfBundleExecutable: string): Promise<void> {
-		return this.iosSim.stopApplication(this.identifier, cfBundleExecutable);
+	public async stopApplication(appIdentifier: string, appName: string): Promise<void> {
+		return this.iosSim.stopApplication(this.identifier, appIdentifier, appName);
 	}
 
 	public canStartApplication(): boolean {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "iconv-lite": "0.4.3",
     "inquirer": "0.8.2",
     "ios-device-lib": "~0.3.0",
-    "ios-sim-portable": "~2.0.0",
+    "ios-sim-portable": "~3.0.0",
     "lodash": "4.13.1",
     "log4js": "0.6.9",
     "marked": "0.3.3",


### PR DESCRIPTION
When Xcode 8 or later is installed, ios-sim-portable will spawn `xcrun simctl terminate <device id> <app id>` in order to stop the application.
For earlier version the command for stopping the app is `killall <app name>`. So pass correct args to the method.

NOTE: Merge only after the ios-sim-portable version is bumped (i.e. after merging https://github.com/telerik/ios-sim-portable/pull/90).