### PR TITLE
Fix UserId passing to the Eqatec

### DIFF
--- a/services/analytics-service-base.ts
+++ b/services/analytics-service-base.ts
@@ -194,7 +194,7 @@ export class AnalyticsServiceBase implements IAnalyticsService {
 		this._eqatecMonitor.setInstallationID(guid);
 
 		try {
-			await this._eqatecMonitor.setUserID(this.$analyticsSettingsService.getUserId());
+			await this._eqatecMonitor.setUserID(await this.$analyticsSettingsService.getUserId());
 			let currentCount = await this.$analyticsSettingsService.getUserSessionsCount(analyticsProjectKey);
 			// increment with 1 every time and persist the new value so next execution will be marked as new session
 			await this.$analyticsSettingsService.setUserSessionsCount(++currentCount, analyticsProjectKey);


### PR DESCRIPTION
When passing UserId to the Eqatec we're currently passing the Promise. We should pass the awaited promise though, as the eqatec library works with string/guid and doesn't work with the promise, therefore all our 3.x users are saved under the same UserId currently.