### PR TITLE
Add a way to plug device-discoveries

### DIFF
--- a/appbuilder/device-emitter.ts
+++ b/appbuilder/device-emitter.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import { DeviceDiscoveryEventNames } from "../constants";
 
 export class DeviceEmitter extends EventEmitter {
 	constructor(private $androidDeviceDiscovery: Mobile.IAndroidDeviceDiscovery,
@@ -21,8 +22,8 @@ export class DeviceEmitter extends EventEmitter {
 	}
 
 	public initialize(): void {
-		this.$androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
-			this.emit("deviceFound", device.deviceInfo);
+		this.$androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
+			this.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, device.deviceInfo);
 
 			this.attachApplicationChangedHandlers(device);
 
@@ -30,28 +31,28 @@ export class DeviceEmitter extends EventEmitter {
 			device.openDeviceLogStream();
 		});
 
-		this.$androidDeviceDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
-			this.emit("deviceLost", device.deviceInfo);
+		this.$androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_LOST, (device: Mobile.IDevice) => {
+			this.emit(DeviceDiscoveryEventNames.DEVICE_LOST, device.deviceInfo);
 		});
 
-		this.$iOSDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
-			this.emit("deviceFound", device.deviceInfo);
+		this.$iOSDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
+			this.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, device.deviceInfo);
 			this.attachApplicationChangedHandlers(device);
 			device.openDeviceLogStream();
 		});
 
-		this.$iOSDeviceDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
-			this.emit("deviceLost", device.deviceInfo);
+		this.$iOSDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_LOST, (device: Mobile.IDevice) => {
+			this.emit(DeviceDiscoveryEventNames.DEVICE_LOST, device.deviceInfo);
 		});
 
-		this.$iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
-			this.emit("deviceFound", device.deviceInfo);
+		this.$iOSSimulatorDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
+			this.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, device.deviceInfo);
 			device.openDeviceLogStream();
 			this.attachApplicationChangedHandlers(device);
 		});
 
-		this.$iOSSimulatorDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
-			this.emit("deviceLost", device.deviceInfo);
+		this.$iOSSimulatorDiscovery.on(DeviceDiscoveryEventNames.DEVICE_LOST, (device: Mobile.IDevice) => {
+			this.emit(DeviceDiscoveryEventNames.DEVICE_LOST, device.deviceInfo);
 		});
 
 		this.$deviceLogProvider.on("data", (identifier: string, data: any) => {

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -57,9 +57,6 @@ $injector.requireCommand("device|put-file", "./commands/device/put-file");
 
 $injector.require("iosDeviceOperations", "./mobile/ios/device/ios-device-operations");
 
-$injector.require("deviceFound", "./mobile/mobile-core/device-discovery");
-$injector.require("deviceLost", "./mobile/mobile-core/device-discovery");
-
 $injector.require("iTunesValidator", "./validators/iTunes-validator");
 $injector.require("deviceDiscovery", "./mobile/mobile-core/device-discovery");
 $injector.require("iOSDeviceDiscovery", "./mobile/mobile-core/ios-device-discovery");

--- a/constants.ts
+++ b/constants.ts
@@ -27,6 +27,11 @@ export class LiveSyncConstants {
 	static IOS_PROJECT_PATH = "/Documents/AppBuilder/LiveSync";
 }
 
+export class DeviceDiscoveryEventNames {
+	static DEVICE_FOUND = "deviceFound";
+	static DEVICE_LOST = "deviceLost";
+}
+
 export const TARGET_FRAMEWORK_IDENTIFIERS = {
 	Cordova: "Cordova",
 	NativeScript: "NativeScript"

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -314,7 +314,7 @@ declare module Mobile {
 	}
 
 	interface IDeviceDiscovery extends NodeJS.EventEmitter {
-		startLookingForDevices(): Promise<void>;
+		startLookingForDevices(platform?: string): Promise<void>;
 		checkForDevices(): Promise<void>;
 	}
 
@@ -372,6 +372,13 @@ declare module Mobile {
 		 * @return {Promise<void>}
 		 */
 		initialize(data?: IDevicesServicesInitializationOptions): Promise<void>;
+
+		/**
+		 * Add an IDeviceDiscovery instance which will from now on report devices. The instance should implement IDeviceDiscovery and raise "deviceFound" and "deviceLost" events.
+		 * @param {IDeviceDiscovery} deviceDiscovery Instance, implementing IDeviceDiscovery and raising raise "deviceFound" and "deviceLost" events.
+		 * @return {void}
+		 */
+		addDeviceDiscovery(deviceDiscovery: IDeviceDiscovery): void;
 		platform: string;
 		getDevices(): Mobile.IDeviceInfo[];
 		getDevicesForPlatform(platform: string): Mobile.IDevice[];

--- a/mobile/mobile-core/device-discovery.ts
+++ b/mobile/mobile-core/device-discovery.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import { DeviceDiscoveryEventNames } from "../../constants";
 
 export class DeviceDiscovery extends EventEmitter implements Mobile.IDeviceDiscovery {
 	private devices: IDictionary<Mobile.IDevice> = {};
@@ -26,12 +27,11 @@ export class DeviceDiscovery extends EventEmitter implements Mobile.IDeviceDisco
 	}
 
 	private raiseOnDeviceFound(device: Mobile.IDevice) {
-		this.emit("deviceFound", device);
+		this.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, device);
 	}
 
 	private raiseOnDeviceLost(device: Mobile.IDevice) {
-		this.emit("deviceLost", device);
+		this.emit(DeviceDiscoveryEventNames.DEVICE_LOST, device);
 	}
 }
-
 $injector.register("deviceDiscovery", DeviceDiscovery);

--- a/test/unit-tests/appbuilder/device-emitter.ts
+++ b/test/unit-tests/appbuilder/device-emitter.ts
@@ -3,7 +3,7 @@ import { assert } from "chai";
 import { EventEmitter } from "events";
 import { ProjectConstants } from "../../../appbuilder/project-constants";
 import { DeviceEmitter } from "../../../appbuilder/device-emitter";
-
+import { DeviceDiscoveryEventNames } from "../../../constants";
 // Injector dependencies must be classes.
 // EventEmitter is function, so our annotate method will fail.
 class CustomEventEmitter extends EventEmitter {
@@ -91,7 +91,7 @@ describe("deviceEmitter", () => {
 			};
 		});
 
-		_.each(["deviceFound", "deviceLost"], (deviceEvent: string) => {
+		_.each([DeviceDiscoveryEventNames.DEVICE_FOUND, DeviceDiscoveryEventNames.DEVICE_LOST], deviceEvent => {
 			describe(deviceEvent, () => {
 				let attachDeviceEventVerificationHandler = (expectedDeviceInfo: any, done: mocha.Done) => {
 					deviceEmitter.on(deviceEvent, (deviceInfo: Mobile.IDeviceInfo) => {
@@ -121,7 +121,7 @@ describe("deviceEmitter", () => {
 
 		describe("openDeviceLogStream", () => {
 			let attachDeviceEventVerificationHandler = (expectedDeviceInfo: any, done: mocha.Done) => {
-				deviceEmitter.on("deviceFound", (deviceInfo: Mobile.IDeviceInfo) => {
+				deviceEmitter.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (deviceInfo: Mobile.IDeviceInfo) => {
 					assert.deepEqual(deviceInfo, expectedDeviceInfo);
 
 					// Wait for all operations to be completed and call done after that.
@@ -134,17 +134,17 @@ describe("deviceEmitter", () => {
 
 			it("is called when working with android device", (done: mocha.Done) => {
 				attachDeviceEventVerificationHandler(androidDevice.deviceInfo, done);
-				androidDeviceDiscovery.emit("deviceFound", androidDevice);
+				androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
 			});
 
 			it("is called when working with iOS device", (done: mocha.Done) => {
 				attachDeviceEventVerificationHandler(iOSDevice.deviceInfo, done);
-				iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
+				iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
 			});
 
 			it("is called when working with iOS simulator", (done: mocha.Done) => {
 				attachDeviceEventVerificationHandler(iOSSimulator.deviceInfo, done);
-				iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
+				iOSSimulatorDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSSimulator);
 			});
 
 		});
@@ -170,19 +170,19 @@ describe("deviceEmitter", () => {
 
 				it("is called when android device reports data", (done: mocha.Done) => {
 					attachDeviceLogDataVerificationHandler(androidDevice.deviceInfo.identifier, done);
-					androidDeviceDiscovery.emit("deviceFound", androidDevice);
+					androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
 					deviceLogProvider.emit("data", androidDevice.deviceInfo.identifier, expectedDeviceLogData);
 				});
 
 				it("is called when iOS device reports data", (done: mocha.Done) => {
 					attachDeviceLogDataVerificationHandler(iOSDevice.deviceInfo.identifier, done);
-					iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
+					iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
 					deviceLogProvider.emit("data", iOSDevice.deviceInfo.identifier, expectedDeviceLogData);
 				});
 
 				it("is called when iOS simulator reports data", (done: mocha.Done) => {
 					attachDeviceLogDataVerificationHandler(iOSSimulator.deviceInfo.identifier, done);
-					iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
+					iOSSimulatorDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSSimulator);
 					deviceLogProvider.emit("data", iOSSimulator.deviceInfo.identifier, expectedDeviceLogData);
 				});
 
@@ -205,19 +205,19 @@ describe("deviceEmitter", () => {
 
 				it("is raised when working with android device", (done: mocha.Done) => {
 					attachApplicationEventVerificationHandler(androidDevice.deviceInfo.identifier, done);
-					androidDeviceDiscovery.emit("deviceFound", androidDevice);
+					androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
 					androidDevice.applicationManager.emit(applicationEvent, expectedApplicationIdentifier);
 				});
 
 				it("is raised when working with iOS device", (done: mocha.Done) => {
 					attachApplicationEventVerificationHandler(iOSDevice.deviceInfo.identifier, done);
-					iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
+					iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
 					iOSDevice.applicationManager.emit(applicationEvent, expectedApplicationIdentifier);
 				});
 
 				it("is raised when working with iOS simulator", (done: mocha.Done) => {
 					attachApplicationEventVerificationHandler(iOSSimulator.deviceInfo.identifier, done);
-					iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
+					iOSSimulatorDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSSimulator);
 					iOSSimulator.applicationManager.emit(applicationEvent, expectedApplicationIdentifier);
 				});
 			});
@@ -243,7 +243,7 @@ describe("deviceEmitter", () => {
 					};
 
 					attachDebuggableEventVerificationHandler(debuggableAppInfo, done);
-					androidDeviceDiscovery.emit("deviceFound", androidDevice);
+					androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
 					androidDevice.applicationManager.emit(applicationEvent, debuggableAppInfo);
 				});
 
@@ -255,7 +255,7 @@ describe("deviceEmitter", () => {
 					};
 
 					attachDebuggableEventVerificationHandler(debuggableAppInfo, done);
-					iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
+					iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
 					iOSDevice.applicationManager.emit(applicationEvent, debuggableAppInfo);
 				});
 
@@ -267,7 +267,7 @@ describe("deviceEmitter", () => {
 					};
 
 					attachDebuggableEventVerificationHandler(debuggableAppInfo, done);
-					iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
+					iOSSimulatorDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSSimulator);
 					iOSSimulator.applicationManager.emit(applicationEvent, debuggableAppInfo);
 				});
 			});
@@ -307,7 +307,7 @@ describe("deviceEmitter", () => {
 					let expectedDebuggableViewInfo: Mobile.IDebugWebViewInfo = createDebuggableWebView("test1");
 
 					attachDebuggableEventVerificationHandler(androidDevice.deviceInfo.identifier, appId, expectedDebuggableViewInfo, done);
-					androidDeviceDiscovery.emit("deviceFound", androidDevice);
+					androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
 					androidDevice.applicationManager.emit(applicationEvent, appId, expectedDebuggableViewInfo);
 				});
 
@@ -315,7 +315,7 @@ describe("deviceEmitter", () => {
 					let expectedDebuggableViewInfo: Mobile.IDebugWebViewInfo = createDebuggableWebView("test1");
 
 					attachDebuggableEventVerificationHandler(iOSDevice.deviceInfo.identifier, appId, expectedDebuggableViewInfo, done);
-					iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
+					iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
 					iOSDevice.applicationManager.emit(applicationEvent, appId, expectedDebuggableViewInfo);
 				});
 
@@ -323,7 +323,7 @@ describe("deviceEmitter", () => {
 					let expectedDebuggableViewInfo: Mobile.IDebugWebViewInfo = createDebuggableWebView("test1");
 
 					attachDebuggableEventVerificationHandler(iOSSimulator.deviceInfo.identifier, appId, expectedDebuggableViewInfo, done);
-					iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
+					iOSSimulatorDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSSimulator);
 					iOSSimulator.applicationManager.emit(applicationEvent, appId, expectedDebuggableViewInfo);
 				});
 			});
@@ -345,7 +345,7 @@ describe("deviceEmitter", () => {
 
 						it("when working with android device", (done: mocha.Done) => {
 							attachCompanionEventVerificationHandler(androidDevice.deviceInfo.identifier, done);
-							androidDeviceDiscovery.emit("deviceFound", androidDevice);
+							androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
 							androidDevice.applicationManager.emit("applicationInstalled", companionAppIdentifersForPlatform["android"]);
 							if (applicationEvent === "companionAppUninstalled") {
 								androidDevice.applicationManager.emit("applicationUninstalled", companionAppIdentifersForPlatform["android"]);
@@ -354,7 +354,7 @@ describe("deviceEmitter", () => {
 
 						it("when working with iOS device", (done: mocha.Done) => {
 							attachCompanionEventVerificationHandler(iOSDevice.deviceInfo.identifier, done);
-							iOSDeviceDiscovery.emit("deviceFound", iOSDevice);
+							iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
 							iOSDevice.applicationManager.emit("applicationInstalled", companionAppIdentifersForPlatform["ios"]);
 							if (applicationEvent === "companionAppUninstalled") {
 								iOSDevice.applicationManager.emit("applicationUninstalled", companionAppIdentifersForPlatform["ios"]);
@@ -363,7 +363,7 @@ describe("deviceEmitter", () => {
 
 						it("when working with iOS simulator", (done: mocha.Done) => {
 							attachCompanionEventVerificationHandler(iOSSimulator.deviceInfo.identifier, done);
-							iOSSimulatorDiscovery.emit("deviceFound", iOSSimulator);
+							iOSSimulatorDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSSimulator);
 							iOSSimulator.applicationManager.emit("applicationInstalled", companionAppIdentifersForPlatform["ios"]);
 							if (applicationEvent === "companionAppUninstalled") {
 								iOSSimulator.applicationManager.emit("applicationUninstalled", companionAppIdentifersForPlatform["ios"]);

--- a/test/unit-tests/mobile/android-device-discovery.ts
+++ b/test/unit-tests/mobile/android-device-discovery.ts
@@ -2,6 +2,7 @@ import { AndroidDeviceDiscovery } from "../../../mobile/mobile-core/android-devi
 import { AndroidDebugBridge } from "../../../mobile/android/android-debug-bridge";
 import { AndroidDebugBridgeResultHandler } from "../../../mobile/android/android-debug-bridge-result-handler";
 import { Yok } from "../../../yok";
+import { DeviceDiscoveryEventNames } from "../../../constants";
 
 import { EventEmitter } from "events";
 import { EOL } from "os";
@@ -91,7 +92,7 @@ describe("androidDeviceDiscovery", () => {
 
 	describe("startLookingForDevices", () => {
 		it("finds correctly one device", async () => {
-			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+			androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 				devicesFound.push(device);
 			});
 
@@ -119,7 +120,7 @@ describe("androidDeviceDiscovery", () => {
 	describe("checkForDevices", () => {
 		it("finds correctly one device", async () => {
 			let promise: Promise<void>;
-			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+			androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 				promise = new Promise<void>((resolve, reject) => {
 					devicesFound.push(device);
 					resolve();
@@ -141,7 +142,7 @@ describe("androidDeviceDiscovery", () => {
 
 		it("finds correctly more than one device", async () => {
 			let promise: Promise<void>;
-			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+			androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 				promise = new Promise<void>((resolve, reject) => {
 					devicesFound.push(device);
 					if (devicesFound.length === 2) {
@@ -166,7 +167,7 @@ describe("androidDeviceDiscovery", () => {
 		});
 
 		it("does not find any devices when there are no devices", async () => {
-			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+			androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 				throw new Error("Devices should not be found.");
 			});
 
@@ -182,7 +183,7 @@ describe("androidDeviceDiscovery", () => {
 
 		const validateDeviceFoundWhenAdbReportsAdditionalMessages = async (adbMessage: string) => {
 			let promise: Promise<void>;
-			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+			androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 				promise = new Promise<void>((resolve, reject) => {
 					devicesFound.push(device);
 					resolve();
@@ -224,7 +225,7 @@ describe("androidDeviceDiscovery", () => {
 			let defaultAdbOutput = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}${EOL}`;
 			beforeEach(async () => {
 				let promise: Promise<void>;
-				androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+				androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 					promise = new Promise<void>((resolve, reject) => {
 						devicesFound.push(device);
 						resolve();
@@ -238,11 +239,11 @@ describe("androidDeviceDiscovery", () => {
 
 				await androidDeviceDiscovery.checkForDevices();
 				await promise;
-				androidDeviceDiscovery.removeAllListeners("deviceFound");
+				androidDeviceDiscovery.removeAllListeners(DeviceDiscoveryEventNames.DEVICE_FOUND);
 			});
 
 			it("does not report it as found next time when checkForDevices is called and same device is still connected", async () => {
-				androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+				androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 					throw new Error("Should not report same device as found");
 				});
 
@@ -260,7 +261,7 @@ describe("androidDeviceDiscovery", () => {
 			it("reports it as removed next time when called and device is removed", async () => {
 				let promise: Promise<Mobile.IDevice>;
 
-				androidDeviceDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+				androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_LOST, (device: Mobile.IDevice) => {
 					promise = Promise.resolve(device);
 				});
 
@@ -278,7 +279,7 @@ describe("androidDeviceDiscovery", () => {
 			it("does not report it as removed two times when called and device is removed", async () => {
 				let promise: Promise<Mobile.IDevice>;
 
-				androidDeviceDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+				androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_LOST, (device: Mobile.IDevice) => {
 					promise = Promise.resolve(device);
 				});
 
@@ -294,7 +295,7 @@ describe("androidDeviceDiscovery", () => {
 				assert.deepEqual(lostDevice.deviceInfo.identifier, androidDeviceIdentifier);
 				assert.deepEqual(lostDevice.deviceInfo.status, androidDeviceStatus);
 
-				androidDeviceDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+				androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_LOST, (device: Mobile.IDevice) => {
 					throw new Error("Should not report device as removed next time after it has been already reported.");
 				});
 
@@ -310,12 +311,12 @@ describe("androidDeviceDiscovery", () => {
 				let deviceLostPromise: Promise<Mobile.IDevice>;
 				let deviceFoundPromise: Promise<Mobile.IDevice>;
 
-				androidDeviceDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+				androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_LOST, (device: Mobile.IDevice) => {
 					_.remove(devicesFound, d => d.deviceInfo.identifier === device.deviceInfo.identifier);
 					deviceLostPromise = Promise.resolve(device);
 				});
 
-				androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+				androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 					devicesFound.push(device);
 					deviceFoundPromise = Promise.resolve(device);
 				});
@@ -349,7 +350,7 @@ describe("androidDeviceDiscovery", () => {
 		});
 
 		it("throws error when adb writes on stderr", async () => {
-			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+			androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 				throw new Error("Devices should not be found.");
 			});
 
@@ -388,7 +389,7 @@ describe("androidDeviceDiscovery", () => {
 		});
 
 		it("throws error when adb's child process throws error", async () => {
-			androidDeviceDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+			androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 				throw new Error("Devices should not be found.");
 			});
 			let error = new Error("ADB Error");

--- a/test/unit-tests/mobile/ios-simulator-discovery.ts
+++ b/test/unit-tests/mobile/ios-simulator-discovery.ts
@@ -2,6 +2,7 @@ import { IOSSimulatorDiscovery } from "../../../mobile/mobile-core/ios-simulator
 import { Yok } from "../../../yok";
 
 import { assert } from "chai";
+import { DeviceDiscoveryEventNames } from "../../../constants";
 import { DevicePlatformsConstants } from "../../../mobile/device-platforms-constants";
 
 let currentlyRunningSimulator: any,
@@ -42,7 +43,7 @@ describe("ios-simulator-discovery", () => {
 
 			isCurrentlyRunning = true;
 			currentlyRunningSimulator = _.cloneDeep(runningSimulator);
-			iOSSimulatorDiscovery.once("deviceFound", (device: Mobile.IDevice) => {
+			iOSSimulatorDiscovery.once(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 				resolve(device);
 			});
 			// no need to await startLookingForDevices, current promise will be resolved after execution of startLookingForDevices is completed.
@@ -54,7 +55,7 @@ describe("ios-simulator-discovery", () => {
 		isCurrentlyRunning = false;
 		currentlyRunningSimulator = null;
 		return new Promise<Mobile.IDevice>((resolve, reject) => {
-			iOSSimulatorDiscovery.once("deviceLost", (device: Mobile.IDevice) => {
+			iOSSimulatorDiscovery.once(DeviceDiscoveryEventNames.DEVICE_LOST, (device: Mobile.IDevice) => {
 				resolve(device);
 			});
 
@@ -68,11 +69,11 @@ describe("ios-simulator-discovery", () => {
 		let lostDevicePromise: Promise<Mobile.IDevice>,
 			foundDevicePromise: Promise<Mobile.IDevice>;
 
-		iOSSimulatorDiscovery.on("deviceLost", (device: Mobile.IDevice) => {
+		iOSSimulatorDiscovery.on(DeviceDiscoveryEventNames.DEVICE_LOST, (device: Mobile.IDevice) => {
 			lostDevicePromise = Promise.resolve(device);
 		});
 
-		iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+		iOSSimulatorDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 			foundDevicePromise = Promise.resolve(device);
 		});
 
@@ -145,7 +146,7 @@ describe("ios-simulator-discovery", () => {
 	it("finds new device when it is attached and reports it as new only once", async () => {
 		let device = await detectNewSimulatorAttached(defaultRunningSimulator);
 		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
-		iOSSimulatorDiscovery.on("deviceFound", (d: Mobile.IDevice) => {
+		iOSSimulatorDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (d: Mobile.IDevice) => {
 			throw new Error("Device found should not be raised for the same device.");
 		});
 
@@ -160,7 +161,7 @@ describe("ios-simulator-discovery", () => {
 
 		isCurrentlyRunning = true;
 
-		iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+		iOSSimulatorDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 			throw new Error("Device found should not be raised when getting running iOS Simulator fails.");
 		});
 
@@ -171,7 +172,7 @@ describe("ios-simulator-discovery", () => {
 		testInjector.resolve("hostInfo").isDarwin = false;
 		isCurrentlyRunning = true;
 
-		iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+		iOSSimulatorDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 			throw new Error("Device found should not be raised when OS is not OS X.");
 		});
 
@@ -181,7 +182,7 @@ describe("ios-simulator-discovery", () => {
 	it("checkForDevices return future", async () => {
 		testInjector.resolve("hostInfo").isDarwin = false;
 		isCurrentlyRunning = true;
-		iOSSimulatorDiscovery.on("deviceFound", (device: Mobile.IDevice) => {
+		iOSSimulatorDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 			throw new Error("Device found should not be raised when OS is not OS X.");
 		});
 		await iOSSimulatorDiscovery.checkForDevices();


### PR DESCRIPTION
Provide a way for extensions to plug their own `IDeviceDiscovery` instances. 
`$devicesService` will call `startLookingForDevices` for every one of them and make sure to attach to `deviceLost`/`deviceFound` events

Ping @rosen-vladimirov @TsvetanMilanov @yyosifov 