### PR TITLE
Adding isBuildForDevice flag

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -346,6 +346,10 @@ declare module Mobile {
 		 * If passed along with skipInferPlatform then the device detection interval will not be started but instead the currently attached devices will be detected.
 		 */
 		skipDeviceDetectionInterval?: boolean;
+		/**
+		 * Specifies whether this is a ForDevice build.
+		 */
+		isBuildForDevice?: boolean;
 	}
 
 	interface IDeviceActionResult<T> {

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -421,9 +421,13 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 		}
 
 		this.$logger.out("Searching for devices...");
-		await this.startEmulatorIfNecessary(data);
 
 		data = data || {};
+
+		if (!data.isBuildForDevice) {
+			await this.startEmulatorIfNecessary(data);
+		}
+
 		this._data = data;
 		let platform = data.platform;
 		let deviceOption = data.deviceId;


### PR DESCRIPTION
We need this flag, so that we don't fire up the Simulator/Emulator when we are executing:

`tns build {platform} --forDevice`

as obviously we don't need the Simulator/Emulator and we need to build ipa/apk for real device.