### PR TITLE
Remove .bash_profile alter for autocomplete #1358

### DIFF
--- a/services/auto-completion-service.ts
+++ b/services/auto-completion-service.ts
@@ -22,7 +22,6 @@ export class AutoCompletionService implements IAutoCompletionService {
 	@cache()
 	private get shellProfiles(): string[] {
 		return [
-			this.getHomePath(".bash_profile"),
 			this.getHomePath(".bashrc"),
 			this.getHomePath(".zshrc") // zsh - http://www.acm.uiuc.edu/workshops/zsh/startup_files.html
 		];


### PR DESCRIPTION
1. When we turn the autocomplete ON, for users which don't have `.bash_profile` we create one and add `source ~/.tnsrc` there.
2. This breaks users without `.bash_profile` files, as their Terminal has automatically been picking `.bashrc` and now it's not `sourced` in `.bash_profile`, therefore they lose their environment variables which is bad.
3. So we're left sourcing the .tnsrc file only in `.bashrc` and `.zshrc`. In case user has bash_profile, he would have sourced the `.bashrc` there.