### PR TITLE
Save all unexistent folders and chown them after creation

### DIFF
--- a/services/user-settings-service.ts
+++ b/services/user-settings-service.ts
@@ -49,7 +49,7 @@ export class UserSettingsServiceBase implements IUserSettingsService {
 
 				this.$fs.writeFile(this.userSettingsFilePath, null);
 
-				// when running under 'sudo' we create the /.local/share dir with root as owner
+				// when running under 'sudo' we create the <path to home dir>/.local/share/.nativescript-cli dir with root as owner
 				// and other Applications cannot access this directory anymore. (bower/heroku/etc)
 				if (process.env.SUDO_USER) {
 					for (let dir of unexistingDirs) {

--- a/services/user-settings-service.ts
+++ b/services/user-settings-service.ts
@@ -1,3 +1,5 @@
+import * as path from "path";
+
 export class UserSettingsServiceBase implements IUserSettingsService {
 	private userSettingsFilePath: string = null;
 	protected userSettingsData: any = null;
@@ -43,10 +45,34 @@ export class UserSettingsServiceBase implements IUserSettingsService {
 	public async loadUserSettingsFile(): Promise<void> {
 		if (!this.userSettingsData) {
 			if (!this.$fs.exists(this.userSettingsFilePath)) {
+				let unexistingDirs = this.getUnexistingDirectories(this.userSettingsFilePath);
+
 				this.$fs.writeFile(this.userSettingsFilePath, null);
+
+				// when running under 'sudo' we create the /.local/share dir with root as owner
+				// and other Applications cannot access this directory anymore. (bower/heroku/etc)
+				if (process.env.SUDO_USER) {
+					for (let dir of unexistingDirs) {
+						await this.$fs.setCurrentUserAsOwner(dir, process.env.SUDO_USER);
+					}
+				}
 			}
 
 			this.userSettingsData = this.$fs.readJson(this.userSettingsFilePath);
 		}
+	}
+
+	private getUnexistingDirectories(filePath: string): Array<string> {
+		let unexistingDirs: Array<string> = [];
+		let currentDir = path.join(filePath, "..");
+		while (true) {
+			// this directory won't be created.
+			if (this.$fs.exists(currentDir)) {
+				break;
+			}
+			unexistingDirs.push(currentDir);
+			currentDir = path.join(currentDir, "..");
+		}
+		return unexistingDirs;
 	}
 }


### PR DESCRIPTION
If the user didn't have ~/.local/share/.nativescript-cli we create it for them and if the setup is ran with `sudo` the owner of all these directories would be root.

Now we track what will be created and after the creation we `chown` them.