### PR TITLE
Fix analytics

### DIFF
--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -14,9 +14,11 @@ class AnalyticsCommand implements ICommand {
 		switch (arg.toLowerCase()) {
 			case "enable":
 				await this.$analyticsService.setStatus(this.settingName, true);
+				await this.$analyticsService.track(this.settingName, "enabled");
 				this.$logger.info(`${this.humanReadableSettingName} is now enabled.`);
 				break;
 			case "disable":
+				await this.$analyticsService.track(this.settingName, "disabled");
 				await this.$analyticsService.setStatus(this.settingName, false);
 				this.$logger.info(`${this.humanReadableSettingName} is now disabled.`);
 				break;

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -505,7 +505,7 @@ interface IAnalyticsService {
 	checkConsent(): Promise<void>;
 	trackFeature(featureName: string): Promise<void>;
 	trackException(exception: any, message: string): Promise<void>;
-	setStatus(settingName: string, enabled: boolean, doNotTrackSetting?: boolean): Promise<void>;
+	setStatus(settingName: string, enabled: boolean): Promise<void>;
 	getStatusMessage(settingName: string, jsonFormat: boolean, readableSettingName: string): Promise<string>;
 	isEnabled(settingName: string): Promise<boolean>;
 	track(featureName: string, featureValue: string): Promise<void>;


### PR DESCRIPTION
Fix analytics, so we'll no longer track information for users, who have not allowed us to do so. There are several problems:
* Whenever the terminal is not interactive and we do not know if user allows us to track them, we set the value of TrackExceptions to true. Also we immediately send information to Analytics that we've set the value to true. So all CI builds are tracked as new users, as we start a session for them and send the value of TrackExceptions (enabled).
* `setStatus` method almost always sends data to Analytics. This method should not send information. It does not care if we have allowed to be tracked - it always sends data. Remove this logic.
* `tns usage-reporting <value>` and `tns error-reporting <values>` always send information to Analytics - in fact the commands are calling "setStatus", that's why they send information. In order to track them, use the "trackFeature" method which will track information ONLY when user had allowed this.
* Fix `getStatus` method which had incorrect behavior - the if has been using the values of the enum (0,1,2) and we were getting in the body of the if statement in a very inaccurate cases.
* Remove unit tests for `setStatus` and add new ones for checkConsent logic.