### PR TITLE
Do not wait for ios device when Fusion start.

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -314,7 +314,7 @@ declare module Mobile {
 	}
 
 	interface IDeviceDiscovery extends NodeJS.EventEmitter {
-		startLookingForDevices(platform?: string): Promise<void>;
+		startLookingForDevices(options?: IDeviceLookingOptions): Promise<void>;
 		checkForDevices(): Promise<void>;
 	}
 
@@ -626,6 +626,11 @@ declare module Mobile {
 		resolveProductName(deviceType: string): string;
 	}
 
+	interface IDeviceLookingOptions {
+		shouldReturnImmediateResult: boolean;
+		platform: string
+	}
+
 	interface IAndroidDeviceHashService {
 		/**
 		 * Returns the hash file path on device
@@ -756,7 +761,7 @@ interface IIOSDeviceOperations extends IDisposable {
 
 	uninstall(appIdentifier: string, deviceIdentifiers: string[], errorHandler?: DeviceOperationErrorHandler): Promise<IOSDeviceResponse>;
 
-	startLookingForDevices(deviceFoundCallback: DeviceInfoCallback, deviceLostCallback: DeviceInfoCallback): Promise<void>;
+	startLookingForDevices(deviceFoundCallback: DeviceInfoCallback, deviceLostCallback: DeviceInfoCallback, options?: Mobile.IDeviceLookingOptions): Promise<void>;
 
 	startDeviceLog(deviceIdentifier: string, printLogFunction: (response: IOSDeviceLib.IDeviceLogData) => void): void;
 

--- a/mobile/ios/device/ios-device-operations.ts
+++ b/mobile/ios/device/ios-device-operations.ts
@@ -30,7 +30,7 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 	}
 
 	@cache()
-	public async startLookingForDevices(deviceFoundCallback: DeviceInfoCallback, deviceLostCallback: DeviceInfoCallback): Promise<void> {
+	public async startLookingForDevices(deviceFoundCallback: DeviceInfoCallback, deviceLostCallback: DeviceInfoCallback, options?: Mobile.IDeviceLookingOptions): Promise<void> {
 		this.$logger.trace("Starting to look for iOS devices.");
 		this.isInitialized = true;
 		if (!this.deviceLib) {
@@ -42,6 +42,9 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 			};
 
 			this.deviceLib = new IOSDeviceLibModule(wrappedDeviceFoundCallback, deviceLostCallback);
+			if (options && options.shouldReturnImmediateResult) {
+				return;
+			}
 
 			// We need this because we need to make sure that we have devices.
 			await new Promise((resolve, reject) => {

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -146,10 +146,10 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	/**
 	 * Starts looking for devices. Any found devices are pushed to "_devices" variable.
 	 */
-	public async detectCurrentlyAttachedDevices(): Promise<void> {
+	public async detectCurrentlyAttachedDevices(options?: Mobile.IDeviceLookingOptions): Promise<void> {
 		for (const deviceDiscovery of this._allDeviceDiscoveries) {
 			try {
-				await deviceDiscovery.startLookingForDevices();
+				await deviceDiscovery.startLookingForDevices(options);
 			} catch (err) {
 				this.$logger.trace("Error while checking for devices.", err);
 			}
@@ -217,10 +217,10 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	/**
 	 * Starts looking for running devices. All found devices are pushed to _devices variable.
 	 */
-	private async startLookingForDevices(): Promise<void> {
+	private async startLookingForDevices(options?: Mobile.IDeviceLookingOptions): Promise<void> {
 		this.$logger.trace("startLookingForDevices; platform is %s", this._platform);
 		if (!this._platform) {
-			await this.detectCurrentlyAttachedDevices();
+			await this.detectCurrentlyAttachedDevices(options);
 			await this.startDeviceDetectionInterval();
 		} else {
 			if (this.$mobileHelper.isiOSPlatform(this._platform)) {
@@ -232,7 +232,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 
 			for (const deviceDiscovery of this._otherDeviceDiscoveries) {
 				try {
-					await deviceDiscovery.startLookingForDevices(this._platform);
+					await deviceDiscovery.startLookingForDevices(options);
 				} catch (err) {
 					this.$logger.trace("Error while checking for new devices.", err);
 				}
@@ -451,7 +451,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 				if (data.skipDeviceDetectionInterval) {
 					await this.detectCurrentlyAttachedDevices();
 				} else {
-					await this.startLookingForDevices();
+					await this.startLookingForDevices({ shouldReturnImmediateResult: true, platform: this._platform });
 				}
 			} else {
 				await this.detectCurrentlyAttachedDevices();

--- a/mobile/mobile-core/ios-device-discovery.ts
+++ b/mobile/mobile-core/ios-device-discovery.ts
@@ -23,13 +23,13 @@ export class IOSDeviceDiscovery extends DeviceDiscovery {
 		return !this._iTunesErrorMessage;
 	}
 
-	public async startLookingForDevices(): Promise<void> {
+	public async startLookingForDevices(options?: Mobile.IDeviceLookingOptions): Promise<void> {
 		if (this.validateiTunes()) {
 			await this.$iosDeviceOperations.startLookingForDevices((deviceInfo: IOSDeviceLib.IDeviceActionInfo) => {
 				this.createAndAddDevice(deviceInfo);
 			}, (deviceInfo: IOSDeviceLib.IDeviceActionInfo) => {
 				this.removeDevice(deviceInfo.deviceId);
-			});
+			}, options);
 		}
 	}
 


### PR DESCRIPTION
Provide an option to avoid waiting for the time interval when the method is called from Fusion.