### PR TITLE
Fix not listing iOS devices and confusing messages during reinstall app

### DIFF
--- a/commands/device/list-devices.ts
+++ b/commands/device/list-devices.ts
@@ -17,7 +17,7 @@ export class ListDevicesCommand implements ICommand {
 
 		this.$logger.out("\nConnected devices & emulators");
 		let index = 1;
-		await this.$devicesService.initialize({ platform: args[0], deviceId: null, skipInferPlatform: true });
+		await this.$devicesService.initialize({ platform: args[0], deviceId: null, skipInferPlatform: true, skipDeviceDetectionInterval: true });
 
 		let table: any = createTable(["#", "Device Name", "Platform", "Device Identifier", "Type", "Status"], []);
 		let action: (_device: Mobile.IDevice) => Promise<void>;

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -12,7 +12,12 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 	}
 
 	public async reinstallApplication(appIdentifier: string, packageFilePath: string): Promise<void> {
-		await this.uninstallApplication(appIdentifier);
+		const isApplicationInstalled = await this.isApplicationInstalled(appIdentifier);
+
+		if (isApplicationInstalled) {
+			await this.uninstallApplication(appIdentifier);
+		}
+
 		await this.installApplication(packageFilePath, appIdentifier);
 	}
 

--- a/test/unit-tests/mobile/application-manager-base.ts
+++ b/test/unit-tests/mobile/application-manager-base.ts
@@ -718,6 +718,8 @@ describe("ApplicationManagerBase", () => {
 				return Promise.resolve();
 			};
 
+			applicationManager.isApplicationInstalled = (appIdentifier: string) => Promise.resolve(true);
+
 			await applicationManager.reinstallApplication("appId", "packageFilePath");
 			assert.deepEqual(uninstallApplicationAppIdParam, "appId");
 		});
@@ -736,6 +738,8 @@ describe("ApplicationManagerBase", () => {
 		it("calls uninstallApplication and installApplication in correct order", async () => {
 			let isInstallApplicationCalled = false,
 				isUninstallApplicationCalled = false;
+
+			applicationManager.isApplicationInstalled = (appIdentifier: string) => Promise.resolve(true);
 
 			applicationManager.uninstallApplication = (appId: string) => {
 				assert.isFalse(isInstallApplicationCalled, "When uninstallApplication is called, installApplication should not have been called.");


### PR DESCRIPTION
## Fix `tns devices` not listing attached iOS devices
When `skipDeviceDetectionInterval` option is not passed to `devicesService`, it does not wait the default timeout (6 seconds) for looking for iOS devices.
It takes some time to detect the devices, but we resolve the promise immediately (as the deviceDetection interval will report the new devices later).
However `tns devices` command is a short-living process and it exits before receiving the iOS devices. Fix the command by passing `skipDeviceDetectionInterval` option.

## Do not call uninstall applicaiton when app is not installed
In reinstallApplication we always call uninstallApplication even when the app is not installed. This produces confusing warnings on stdout.
Add check and call uninstallApplication only when app is installed.