### PR TITLE
Add build method to plist module

### DIFF
--- a/definitions/plist.d.ts
+++ b/definitions/plist.d.ts
@@ -1,3 +1,4 @@
 declare module "plist" {
 	export function parse(data: any): IDictionary<any>;
+	export function build(data: any): string;
 }


### PR DESCRIPTION
plist module has build event that is missing from our .d.ts