### PR TITLE
Rename isBuildForDevice option to skipEmulatorStart

### DIFF
--- a/commands/device/list-devices.ts
+++ b/commands/device/list-devices.ts
@@ -17,7 +17,7 @@ export class ListDevicesCommand implements ICommand {
 
 		this.$logger.out("\nConnected devices & emulators");
 		let index = 1;
-		await this.$devicesService.initialize({ platform: args[0], deviceId: null, skipInferPlatform: true, skipDeviceDetectionInterval: true });
+		await this.$devicesService.initialize({ platform: args[0], deviceId: null, skipInferPlatform: true, skipDeviceDetectionInterval: true, skipEmulatorStart: true });
 
 		let table: any = createTable(["#", "Device Name", "Platform", "Device Identifier", "Type", "Status"], []);
 		let action: (_device: Mobile.IDevice) => Promise<void>;

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -355,9 +355,9 @@ declare module Mobile {
 		 */
 		skipDeviceDetectionInterval?: boolean;
 		/**
-		 * Specifies whether this is a ForDevice build.
+		 * Specifies whether we should skip the emulator starting.
 		 */
-		isBuildForDevice?: boolean;
+		skipEmulatorStart?: boolean;
 	}
 
 	interface IDeviceActionResult<T> {

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -377,7 +377,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 			If you are trying to run on specific emulator, use "${this.$staticConfig.CLIENT_NAME} run --device <DeviceID>`);
 		}
 
-		if (data && data.platform && !data.skipInferPlatform) {
+		if (data && data.platform && !data.skipEmulatorStart) {
 			// are there any running devices
 			this._platform = data.platform;
 			try {
@@ -432,7 +432,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 
 		data = data || {};
 
-		if (!data.isBuildForDevice) {
+		if (!data.skipEmulatorStart) {
 			await this.startEmulatorIfNecessary(data);
 		}
 

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -345,9 +345,9 @@ describe("devicesService", () => {
 				assert.equal((<IOSDeviceDiscoveryStub>iOSDeviceDiscovery).count, 0);
 				assert.equal((<IOSSimulatorDiscoveryStub>iOSSimulatorDiscovery).count, 0);
 			});
-			it("deviceId is NOT passed, platform is passed and skipInferPlatform is passed - should not start emulator", async () => {
+			it("deviceId is NOT passed, platform is passed and skipEmulatorStart is passed - should not start emulator", async () => {
 				assert.deepEqual(devicesService.getDeviceInstances(), [], "Initially getDevicesInstances must return empty array.");
-				await devicesService.startEmulatorIfNecessary({ platform: "android", skipInferPlatform: true });
+				await devicesService.startEmulatorIfNecessary({ platform: "android", skipEmulatorStart: true });
 				assert.deepEqual(devicesService.getDeviceInstances(), []);
 				assert.deepEqual(devicesService.getDevices(), []);
 			});


### PR DESCRIPTION
DevicesService.initialize method has option called `isBuildForDevice`. Its real purpose is to disable start of simulator, so rename it and use it on correct places.