### PR TITLE
Replace grunt-tslint with direct calling to tslint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,8 @@
-var util = require("util");
-var os = require("os");
+const util = require("util");
+const os = require("os");
+const childProcess = require("child_process");
 
-var now = new Date().toISOString();
+const now = new Date().toISOString();
 
 function shallowCopy(obj) {
 	var result = {};
@@ -54,17 +55,6 @@ module.exports = function (grunt) {
 				options: {
 					sourceMap: false,
 					removeComments: true
-				}
-			}
-		},
-
-		tslint: {
-			build: {
-				files: {
-					src: ["**/*.ts", "!node_modules/**/*.ts", "!messages/**/*.ts", "!**/*.d.ts"]
-				},
-				options: {
-					configuration: grunt.file.readJSON("./tslint.json")
 				}
 			}
 		},
@@ -132,13 +122,16 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks("grunt-contrib-watch");
 	grunt.loadNpmTasks("grunt-shell");
 	grunt.loadNpmTasks("grunt-ts");
-	grunt.loadNpmTasks("grunt-tslint");
 
 	grunt.registerTask("set_package_version", function (version) {
 		var buildVersion = getBuildVersion(version);
 		var packageJson = grunt.file.readJSON("package.json");
 		packageJson.buildVersion = buildVersion;
 		grunt.file.write("package.json", JSON.stringify(packageJson, null, "  "));
+	});
+
+	grunt.registerTask("tslint:build", function (version) {
+		childProcess.execSync("npm run tslint", { stdio: "inherit" });
 	});
 
 	grunt.registerTask("setPackageName", function (version) {

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -1,3 +1,20 @@
+export class AnalyticsCommandParameter implements ICommandParameter {
+	constructor(private $errors: IErrors) { }
+	mandatory = false;
+	async validate(validationValue: string): Promise<boolean> {
+		let val = validationValue || "";
+		switch (val.toLowerCase()) {
+			case "enable":
+			case "disable":
+			case "status":
+			case "":
+				return true;
+			default:
+				this.$errors.fail(`The value '${validationValue}' is not valid. Valid values are 'enable', 'disable' and 'status'.`);
+		}
+	}
+}
+
 class AnalyticsCommand implements ICommand {
 	constructor(protected $analyticsService: IAnalyticsService,
 		private $logger: ILogger,
@@ -61,20 +78,3 @@ export class ErrorReportingCommand extends AnalyticsCommand {
 	}
 }
 $injector.registerCommand("error-reporting", ErrorReportingCommand);
-
-export class AnalyticsCommandParameter implements ICommandParameter {
-	constructor(private $errors: IErrors) { }
-	mandatory = false;
-	async validate(validationValue: string): Promise<boolean> {
-		let val = validationValue || "";
-		switch (val.toLowerCase()) {
-			case "enable":
-			case "disable":
-			case "status":
-			case "":
-				return true;
-			default:
-				this.$errors.fail(`The value '${validationValue}' is not valid. Valid values are 'enable', 'disable' and 'status'.`);
-		}
-	}
-}

--- a/messages/messages.ts
+++ b/messages/messages.ts
@@ -1,7 +1,7 @@
 //
 // automatically generated code; do not edit manually!
 //
-
+/* tslint:disable:all */
 export class Messages implements IMessages{
 			Devices = {
 			NotFoundDeviceByIdentifierErrorMessage: "Devices.NotFoundDeviceByIdentifierErrorMessage",
@@ -11,3 +11,4 @@ export class Messages implements IMessages{
 
 }
 $injector.register('messages', Messages);
+/* tslint:enable */

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "mocha": "node test-scripts/mocha.js",
-    "test": "node test-scripts/istanbul.js"
+    "test": "node test-scripts/istanbul.js",
+    "tslint": "tslint -p tsconfig.json --type-check"
   },
   "main": "./common-lib.js",
   "repository": {
@@ -87,7 +88,6 @@
     "grunt-contrib-watch": "1.0.0",
     "grunt-shell": "2.1.0",
     "grunt-ts": "6.0.0-beta.16",
-    "grunt-tslint": "5.0.1",
     "istanbul": "0.4.5",
     "mocha": "3.2.0",
     "spec-xunit-file": "0.0.1-3",

--- a/services/analytics-service-base.ts
+++ b/services/analytics-service-base.ts
@@ -5,6 +5,12 @@ cliGlobal.XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 cliGlobal.XMLHttpRequest.prototype.withCredentials = false;
 // HACK -end
 
+export enum AnalyticsStatus {
+	enabled,
+	disabled,
+	notConfirmed
+}
+
 export class AnalyticsServiceBase implements IAnalyticsService {
 	private static MAX_WAIT_SENDING_INTERVAL = 30000; // in milliseconds
 	private _eqatecMonitor: any;
@@ -298,10 +304,4 @@ export class AnalyticsServiceBase implements IAnalyticsService {
 			}
 		});
 	}
-}
-
-export enum AnalyticsStatus {
-	enabled,
-	disabled,
-	notConfirmed
 }

--- a/services/message-contract-generator.ts
+++ b/services/message-contract-generator.ts
@@ -16,11 +16,13 @@ export class MessageContractGenerator implements IServiceContractGenerator {
 		implementationsFile.writeLine("//");
 		implementationsFile.writeLine("// automatically generated code; do not edit manually!");
 		implementationsFile.writeLine("//");
+		implementationsFile.writeLine("/* tslint:disable:all */");
 		implementationsFile.writeLine("");
 
 		interfacesFile.writeLine("//");
 		interfacesFile.writeLine("// automatically generated code; do not edit manually!");
 		interfacesFile.writeLine("//");
+		interfacesFile.writeLine("/* tslint:disable:all */");
 
 		let messagesClass = new Block("export class Messages implements IMessages");
 		let messagesInterface = new Block("interface IMessages");
@@ -37,9 +39,13 @@ export class MessageContractGenerator implements IServiceContractGenerator {
 		});
 
 		interfacesFile.addBlock(messagesInterface);
+		interfacesFile.writeLine("/* tslint:enable */");
+		interfacesFile.writeLine("");
 
 		implementationsFile.addBlock(messagesClass);
 		implementationsFile.writeLine("$injector.register('messages', Messages);");
+		implementationsFile.writeLine("/* tslint:enable */");
+		implementationsFile.writeLine("");
 
 		let codePrinter = new CodePrinter();
 		return {


### PR DESCRIPTION
Some rules in our tslint.json require passing `--type-check` flag to `tslint` executable.
However grunt-tslint does not support it. So remove the `grunt-tslint` and spawn the `tslint` via npm script.
Add the new `tslint` script, so now the project can be linted by calling:
* grunt lint
* grunt tslint:build /for backwards compatibility/
* npm run tslint

Fix the errors that are received after passing `--type-check` flag.
Disable all linter errors for all automatically generated files (for messages).