### PR TITLE
Add check in iOS device discovery if platform is Android.

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -413,7 +413,7 @@ declare module Mobile {
 		startDeviceDetectionInterval(): Promise<void>;
 		getDeviceByIdentifier(identifier: string): Mobile.IDevice;
 		mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string, framework: string): Promise<string>;
-		detectCurrentlyAttachedDevices(): Promise<void>;
+		detectCurrentlyAttachedDevices(options?: Mobile.IDeviceLookingOptions): Promise<void>;
 		startEmulator(platform?: string, emulatorImage?: string): Promise<void>;
 		isCompanionAppInstalledOnDevices(deviceIdentifiers: string[], framework: string): Promise<IAppInstalledInfo>[];
 		getDebuggableApps(deviceIdentifiers: string[]): Promise<Mobile.IDeviceApplicationInformation[]>[];

--- a/mobile/mobile-core/android-device-discovery.ts
+++ b/mobile/mobile-core/android-device-discovery.ts
@@ -13,7 +13,8 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery implements Mobile.IA
 	private isStarted: boolean;
 
 	constructor(private $injector: IInjector,
-		private $adb: Mobile.IAndroidDebugBridge) {
+		private $adb: Mobile.IAndroidDebugBridge,
+		private $mobileHelper: Mobile.IMobileHelper) {
 		super();
 	}
 
@@ -29,7 +30,10 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery implements Mobile.IA
 		this.removeDevice(deviceIdentifier);
 	}
 
-	public async startLookingForDevices(): Promise<void> {
+	public async startLookingForDevices(options?: Mobile.IDeviceLookingOptions): Promise<void> {
+		if (options && options.platform && !this.$mobileHelper.isAndroidPlatform(options.platform)) {
+			return;
+		}
 		await this.ensureAdbServerStarted();
 		await this.checkForDevices();
 	}

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -174,7 +174,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 
 					for (const deviceDiscovery of this._allDeviceDiscoveries) {
 						try {
-							await deviceDiscovery.startLookingForDevices();
+							await deviceDiscovery.startLookingForDevices({ shouldReturnImmediateResult: false, platform: this._platform });
 						} catch (err) {
 							this.$logger.trace("Error while checking for new devices.", err);
 						}
@@ -219,15 +219,18 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	 */
 	private async startLookingForDevices(options?: Mobile.IDeviceLookingOptions): Promise<void> {
 		this.$logger.trace("startLookingForDevices; platform is %s", this._platform);
+		if (!options) {
+			options = {shouldReturnImmediateResult: false, platform: this._platform};
+		}
 		if (!this._platform) {
 			await this.detectCurrentlyAttachedDevices(options);
 			await this.startDeviceDetectionInterval();
 		} else {
 			if (this.$mobileHelper.isiOSPlatform(this._platform)) {
-				await this.$iOSDeviceDiscovery.startLookingForDevices();
-				await this.$iOSSimulatorDiscovery.startLookingForDevices();
+				await this.$iOSDeviceDiscovery.startLookingForDevices(options);
+				await this.$iOSSimulatorDiscovery.startLookingForDevices(options);
 			} else if (this.$mobileHelper.isAndroidPlatform(this._platform)) {
-				await this.$androidDeviceDiscovery.startLookingForDevices();
+				await this.$androidDeviceDiscovery.startLookingForDevices(options);
 			}
 
 			for (const deviceDiscovery of this._otherDeviceDiscoveries) {
@@ -606,9 +609,9 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 		await emulatorServices.startEmulator(emulatorImage);
 
 		if (this.$mobileHelper.isAndroidPlatform(platform)) {
-			await this.$androidDeviceDiscovery.startLookingForDevices();
+			await this.$androidDeviceDiscovery.startLookingForDevices({ shouldReturnImmediateResult: false, platform: platform });
 		} else if (this.$mobileHelper.isiOSPlatform(platform) && this.$hostInfo.isDarwin) {
-			await this.$iOSSimulatorDiscovery.startLookingForDevices();
+			await this.$iOSSimulatorDiscovery.startLookingForDevices({ shouldReturnImmediateResult: false, platform: platform });
 		}
 	}
 

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -256,7 +256,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	 * @param identifier parameter passed by the user to --device flag
 	 */
 	public async getDevice(deviceOption: string): Promise<Mobile.IDevice> {
-		await this.detectCurrentlyAttachedDevices();
+		await this.detectCurrentlyAttachedDevices({ shouldReturnImmediateResult: false, platform: this._platform });
 		let device: Mobile.IDevice = null;
 
 		let emulatorIdentifier = null;

--- a/mobile/mobile-core/ios-device-discovery.ts
+++ b/mobile/mobile-core/ios-device-discovery.ts
@@ -7,6 +7,7 @@ export class IOSDeviceDiscovery extends DeviceDiscovery {
 	constructor(private $injector: IInjector,
 		private $logger: ILogger,
 		private $iTunesValidator: Mobile.IiTunesValidator,
+		private $mobileHelper: Mobile.IMobileHelper,
 		private $iosDeviceOperations: IIOSDeviceOperations) {
 		super();
 	}
@@ -24,6 +25,9 @@ export class IOSDeviceDiscovery extends DeviceDiscovery {
 	}
 
 	public async startLookingForDevices(options?: Mobile.IDeviceLookingOptions): Promise<void> {
+		if (options && options.platform && !this.$mobileHelper.isiOSPlatform(options.platform)) {
+			return;
+		}
 		if (this.validateiTunes()) {
 			await this.$iosDeviceOperations.startLookingForDevices((deviceInfo: IOSDeviceLib.IDeviceActionInfo) => {
 				this.createAndAddDevice(deviceInfo);

--- a/mobile/mobile-core/ios-simulator-discovery.ts
+++ b/mobile/mobile-core/ios-simulator-discovery.ts
@@ -7,11 +7,16 @@ export class IOSSimulatorDiscovery extends DeviceDiscovery {
 	constructor(private $injector: IInjector,
 		private $childProcess: IChildProcess,
 		private $iOSSimResolver: Mobile.IiOSSimResolver,
+		private $mobileHelper: Mobile.IMobileHelper,
 		private $hostInfo: IHostInfo) {
 		super();
 	}
 
-	public async startLookingForDevices(): Promise<void> {
+	public async startLookingForDevices(options?: Mobile.IDeviceLookingOptions): Promise<void> {
+		if (options && options.platform && !this.$mobileHelper.isiOSPlatform(options.platform)) {
+			return;
+		}
+
 		return new Promise<void>((resolve, reject) => {
 			return this.checkForDevices(resolve, reject);
 		});

--- a/test/unit-tests/mobile/android-device-discovery.ts
+++ b/test/unit-tests/mobile/android-device-discovery.ts
@@ -40,6 +40,11 @@ function createTestInjector(): IInjector {
 	injector.register("errors", {});
 	injector.register("logger", {});
 	injector.register("androidDebugBridgeResultHandler", AndroidDebugBridgeResultHandler);
+	injector.register("mobileHelper", {
+		isAndroidPlatform: () => {
+			return true;
+		}
+	});
 	injector.register("childProcess", {
 		spawn: (command: string, args?: string[], options?: any) => {
 			mockChildProcess = new MockEventEmitter();

--- a/test/unit-tests/mobile/ios-simulator-discovery.ts
+++ b/test/unit-tests/mobile/ios-simulator-discovery.ts
@@ -25,6 +25,12 @@ function createTestInjector(): IInjector {
 
 	injector.register("devicePlatformsConstants", DevicePlatformsConstants);
 
+	injector.register("mobileHelper", {
+		isiOSPlatform: () => {
+			return true;
+		}
+	});
+
 	injector.register("iOSSimulatorDiscovery", IOSSimulatorDiscovery);
 
 	injector.register("iOSSimulatorLogProvider", {});


### PR DESCRIPTION
This PR is part of the resolution of https://github.com/NativeScript/nativescript-cli/issues/2361.
The device discovery services didn't check the platform parameter before performing the validations needed for the specified platform.

The resolution is to always pass platform parameter to the device discovery services if specified and add a platform check inside each device discovery service.