### PR TITLE
Make devicesService.getDevice public

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -393,6 +393,13 @@ declare module Mobile {
 		addDeviceDiscovery(deviceDiscovery: IDeviceDiscovery): void;
 		platform: string;
 		getDevices(): Mobile.IDeviceInfo[];
+
+		/**
+		 * Gets device instance by specified identifier or number.
+		 * @param {string} deviceOption The specified device identifier or number.
+		 * @returns {Promise<Mobile.IDevice>} Instance of IDevice.
+		 */
+		getDevice(deviceOption: string): Promise<Mobile.IDevice>;
 		getDevicesForPlatform(platform: string): Mobile.IDevice[];
 		getDeviceInstances(): Mobile.IDevice[];
 		getDeviceByDeviceOption(): Mobile.IDevice;

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -255,7 +255,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	 * Method expects running devices.
 	 * @param identifier parameter passed by the user to --device flag
 	 */
-	private async getDevice(deviceOption: string): Promise<Mobile.IDevice> {
+	public async getDevice(deviceOption: string): Promise<Mobile.IDevice> {
 		await this.detectCurrentlyAttachedDevices();
 		let device: Mobile.IDevice = null;
 


### PR DESCRIPTION
`devicesService.getDevice` method returns device instance based on specified device identifier or number (from the list of devices).
Make it public, so it can be used in `tns debug <platform>` command.