### PR TITLE
Do not attach to the device log on every application start.

### DIFF
--- a/mobile/ios/device/ios-application-manager.ts
+++ b/mobile/ios/device/ios-application-manager.ts
@@ -1,6 +1,7 @@
 import { EOL } from "os";
 import { hook } from "../../../helpers";
 import { ApplicationManagerBase } from "../../application-manager-base";
+import { cache } from "../../../decorators";
 
 export class IOSApplicationManager extends ApplicationManagerBase {
 	private applicationsLiveSyncInfos: Mobile.ILiveSyncApplicationInfo[];
@@ -105,8 +106,13 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 	private async runApplicationCore(appIdentifier: string): Promise<void> {
 		await this.$iosDeviceOperations.start([{ deviceId: this.device.deviceInfo.identifier, appId: appIdentifier, ddi: this.$options.ddi }]);
 		if (!this.$options.justlaunch) {
-			await this.device.openDeviceLogStream();
+			await this.startDeviceLog();
 		}
+	}
+
+	@cache()
+	private async startDeviceLog(): Promise<void> {
+		await this.device.openDeviceLogStream();
 	}
 
 	public canStartApplication(): boolean {


### PR DESCRIPTION
Cache the startDeviceLog method to ensure that we are attached only once to the device log.

[#2941](https://github.com/NativeScript/nativescript-cli/issues/2941)