### PR TITLE
Filter android logs by process id

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -170,7 +170,7 @@ declare module Mobile {
 		 * @param {string} deviceIdentifier The unique identifier of the device.
 		 * @param {string} pid The Process ID of the currently running application for which we need the logs.
 		 */
-		setApplictionPidForDevice(deviceIdentifier: string, pid: string): void;
+		setApplicationPidForDevice(deviceIdentifier: string, pid: string): void;
 	}
 
 	/**
@@ -448,6 +448,14 @@ declare module Mobile {
 		 * @return {Promise<IDictionary<number>>} Dictionary, where the keys are app identifiers and the values are local ports.
 		 */
 		getMappedAbstractToTcpPorts(deviceIdentifier: string, appIdentifiers: string[], framework: string): Promise<IDictionary<number>>;
+
+		/**
+		 * Gets the PID of a running application.
+		 * @param deviceIdentifier {string} The identifier of the device.
+		 * @param appIdentifier The identifier of the application.
+		 * @return {string} Returns the process id matching the application identifier in the device process list.
+		 */
+		getAppProcessId(deviceIdentifier: string, appIdentifier: string): Promise<string>;
 	}
 
 	/**

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -11,6 +11,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		private $logcatHelper: Mobile.ILogcatHelper,
 		private $androidProcessService: Mobile.IAndroidProcessService,
 		private $httpClient: Server.IHttpClient,
+		private $deviceLogProvider: Mobile.IDeviceLogProvider,
 		$logger: ILogger,
 		$hooksService: IHooksService) {
 		super($logger, $hooksService);
@@ -49,6 +50,12 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 			"1"]);
 
 		if (!this.$options.justlaunch) {
+			const deviceIdentifier = this.identifier;
+			const processIdentifier = await this.$androidProcessService.getAppProcessId(deviceIdentifier, appIdentifier);
+			if (processIdentifier) {
+				this.$deviceLogProvider.setApplicationPidForDevice(deviceIdentifier, processIdentifier);
+			}
+
 			await this.$logcatHelper.start(this.identifier);
 		}
 	}

--- a/mobile/android/android-log-filter.ts
+++ b/mobile/android/android-log-filter.ts
@@ -7,14 +7,14 @@ export class AndroidLogFilter implements Mobile.IPlatformLogFilter {
 
 	// sample line is "11-23 12:39:07.310  1584  1597 I art     : Background sticky concurrent mark sweep GC freed 21966(1780KB) AllocSpace objects, 4(80KB) LOS objects, 77% free, 840KB/3MB, paused 4.018ms total 158.629ms"
 	// or '12-28 10:45:08.020  3329  3329 W chromium: [WARNING:data_reduction_proxy_settings.cc(328)] SPDY proxy OFF at startup'
-	private static API_LEVEL_23_LINE_REGEX = /.+?\s+?(?:[A-Z]\s+?)([A-Za-z ]+?)\s*?\: (.*)/;
+	private static API_LEVEL_23_LINE_REGEX = /.+?\s+?(?:[A-Z]\s+?)([A-Za-z \.]+?)\s*?\: (.*)/;
 
 	constructor(private $loggingLevels: Mobile.ILoggingLevels) { }
 
-	public filterData(data: string, logLevel: string): string {
-		let specifiedLogLevel = (logLevel || '').toUpperCase();
+	public filterData(data: string, logLevel: string, pid: string): string {
+		const specifiedLogLevel = (logLevel || '').toUpperCase();
 		if (specifiedLogLevel === this.$loggingLevels.info) {
-			let log = this.getConsoleLogFromLine(data);
+			const log = this.getConsoleLogFromLine(data, pid);
 			if (log) {
 				if (log.tag) {
 					return `${log.tag}: ${log.message}` + os.EOL;
@@ -29,15 +29,28 @@ export class AndroidLogFilter implements Mobile.IPlatformLogFilter {
 		return data + os.EOL;
 	}
 
-	private getConsoleLogFromLine(lineText: string): any {
-		let acceptedTags = ["chromium", "Web Console", "JS"];
-		let match = lineText.match(AndroidLogFilter.LINE_REGEX) || lineText.match(AndroidLogFilter.API_LEVEL_23_LINE_REGEX);
+	private getConsoleLogFromLine(lineText: string, pid: string): any {
+		// filter log line if it does not belong to the current application process id
+		if (pid && lineText.indexOf(pid) < 0) {
+			return null;
+		}
+
+		const acceptedTags = ["chromium", "Web Console", "JS", "ActivityManager", "System.err"];
+
+		let consoleLogMessage: { tag?: string, message: string };
+
+		const match = lineText.match(AndroidLogFilter.LINE_REGEX) || lineText.match(AndroidLogFilter.API_LEVEL_23_LINE_REGEX);
 
 		if (match && acceptedTags.indexOf(match[1].trim()) !== -1) {
-			return { tag: match[1].trim(), message: match[2] };
+			consoleLogMessage = { tag: match[1].trim(), message: match[2] };
 		}
-		let matchingTag = _.some(acceptedTags, (tag: string) => { return lineText.indexOf(tag) !== -1; });
-		return matchingTag ? { message: lineText } : null;
+
+		if (!consoleLogMessage) {
+			const matchingTag = _.some(acceptedTags, (tag: string) => { return lineText.indexOf(tag) !== -1; });
+			consoleLogMessage = matchingTag ? { message: lineText } : null;
+		}
+
+		return consoleLogMessage;
 	}
 }
 $injector.register("androidLogFilter", AndroidLogFilter);

--- a/mobile/device-log-provider-base.ts
+++ b/mobile/device-log-provider-base.ts
@@ -13,7 +13,7 @@ export abstract class DeviceLogProviderBase extends EventEmitter implements Mobi
 
 	public abstract setLogLevel(logLevel: string, deviceIdentifier?: string): void;
 
-	public setApplictionPidForDevice(deviceIdentifier: string, pid: string): void {
+	public setApplicationPidForDevice(deviceIdentifier: string, pid: string): void {
 		this.setDeviceLogOptionsProperty(deviceIdentifier, (deviceLogOptions: Mobile.IDeviceLogOptions) => deviceLogOptions.applicationPid, pid);
 	}
 

--- a/mobile/device-log-provider.ts
+++ b/mobile/device-log-provider.ts
@@ -8,7 +8,6 @@ export class DeviceLogProvider extends DeviceLogProviderBase {
 
 	public logData(lineText: string, platform: string, deviceIdentifier: string): void {
 		let applicationPid = this.getApplicationPidForDevice(deviceIdentifier);
-
 		let data = this.$logFilter.filterData(platform, lineText, applicationPid);
 		if (data) {
 			this.$logger.write(data);

--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -44,7 +44,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 
 		if (!this.$options.justlaunch) {
 			let pid = launchResult.split(":")[1].trim();
-			this.$deviceLogProvider.setApplictionPidForDevice(this.identifier, pid);
+			this.$deviceLogProvider.setApplicationPidForDevice(this.identifier, pid);
 			this.$iOSSimulatorLogProvider.startLogProcess(this.identifier);
 		}
 	}

--- a/mobile/mobile-core/android-process-service.ts
+++ b/mobile/mobile-core/android-process-service.ts
@@ -118,6 +118,13 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 			.value();
 	}
 
+	public async getAppProcessId(deviceIdentifier: string, appIdentifier: string): Promise<string> {
+		const adb = this.getAdb(deviceIdentifier);
+		const processId = (await this.getProcessIds(adb, [appIdentifier]))[appIdentifier];
+
+		return processId ? processId.toString() : null;
+	}
+
 	private async getApplicationInfoFromWebViewPortInformation(adb: Mobile.IDeviceAndroidDebugBridge, deviceIdentifier: string, information: string): Promise<Mobile.IDeviceApplicationInformation> {
 		// Need to search by processId to check for old Android webviews (@webview_devtools_remote_<processId>).
 		let processIdRegExp = /@webview_devtools_remote_(.+)/g,

--- a/test/unit-tests/android-log-filter.ts
+++ b/test/unit-tests/android-log-filter.ts
@@ -6,7 +6,7 @@ import { EOL } from "os";
 
 let androidApiLevel23TestData = [
 	{ input: '12-28 10:14:15.977    99    99 D Genymotion: Received Set Clipboard', output: null },
-	{ input: '12-28 10:14:31.303   779   790 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=com.telerik.app1/.TelerikCallbackActivity (has extras)} from uid 10008 on display 0', output: null },
+	{ input: '12-28 10:14:31.303   779   790 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=com.telerik.app1/.TelerikCallbackActivity (has extras)} from uid 10008 on display 0', output: 'ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=com.telerik.app1/.TelerikCallbackActivity (has extras)} from uid 10008 on display 0' },
 	{ input: '--------- beginning of main', output: null },
 	{ input: '12-28 10:14:31.314  3593  3593 I art     : Late-enabling -Xcheck:jni', output: null },
 	{ input: '12-28 10:14:31.348  3593  3593 W System  : ClassLoader referenced unknown path: /data/app/com.telerik.app1-1/lib/x86', output: null },
@@ -27,7 +27,7 @@ let androidApiLevel23TestData = [
 		input: '12-28 10:16:26.239  3659  3659 I chromium: [INFO:CONSOLE(1)] "Uncaught ReferenceError: start is not defined", source: file:///data/user/0/com.telerik.app1/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2/index.html (1)',
 		output: 'chromium: [INFO:CONSOLE(1)] "Uncaught ReferenceError: start is not defined", source: file:///data/user/0/com.telerik.app1/files/12590FAA-5EDD-4B12-856D-F52A0A1599F2/index.html (1)'
 	},
-	{ input: '12-28 10:16:49.267   779  1172 I ActivityManager: Start proc 3714:org.nativescript.appDebug1/u0a60 for activity org.nativescript.appDebug1/com.tns.NativeScriptActivity', output: null },
+	{ input: '12-28 10:16:49.267   779  1172 I ActivityManager: Start proc 3714:org.nativescript.appDebug1/u0a60 for activity org.nativescript.appDebug1/com.tns.NativeScriptActivity', output: 'ActivityManager: Start proc 3714:org.nativescript.appDebug1/u0a60 for activity org.nativescript.appDebug1/com.tns.NativeScriptActivity' },
 	{ input: '12-28 10:16:49.316  3714  3714 I TNS.Native: NativeScript Runtime Version 1.5.1, commit c27e977f059e37b3f8230722a4687e16acf43a7f', output: null },
 	{ input: '12-28 10:16:49.710  3714  3714 V JS      : TAPPED: 42', output: 'JS: TAPPED: 42' },
 	{ input: '12-28 10:16:49.775  3714  3714 D NativeScriptActivity: NativeScriptActivity.onCreate called', output: null },
@@ -42,8 +42,8 @@ let androidApiLevel22TestData = [
 	{ input: 'D/Genymotion(   82): Received Ping', output: null },
 	{ input: '--------- beginning of main', output: null },
 	{ input: 'W/AudioTrack( 1804): AUDIO_OUTPUT_FLAG_FAST denied by client', output: null },
-	{ input: 'I/ActivityManager( 1804): START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=com.telerik.hybridApp/.TelerikCallbackActivity (has extras)} from uid 10039 on display 0', output: null },
-	{ input: 'I/ActivityManager( 1804): Start proc 2971:com.telerik.hybridApp/u0a60 for activity com.telerik.hybridApp/.TelerikCallbackActivity', output: null },
+	{ input: 'I/ActivityManager( 1804): START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=com.telerik.hybridApp/.TelerikCallbackActivity (has extras)} from uid 10039 on display 0', output: 'ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=com.telerik.hybridApp/.TelerikCallbackActivity (has extras)} from uid 10039 on display 0' },
+	{ input: 'I/ActivityManager( 1804): Start proc 2971:com.telerik.hybridApp/u0a60 for activity com.telerik.hybridApp/.TelerikCallbackActivity', output: 'ActivityManager: Start proc 2971:com.telerik.hybridApp/u0a60 for activity com.telerik.hybridApp/.TelerikCallbackActivity' },
 	{ input: 'I/art     ( 2971): Late-enabling -Xcheck:jni', output: null },
 	{ input: 'D/        ( 1789): HostConnection::get() New Host Connection established 0xb68c9390, tid 2626', output: null },
 	{ input: 'I/CordovaLog( 2971): Changing log level to DEBUG(3)', output: null },
@@ -92,13 +92,126 @@ let androidApiLevel22TestData = [
 	}
 ];
 
+let androidApiLevel23MapForPid8141 = [
+	{ input: "--------- beginning of main", output: null },
+	{ input: "07-25 06:36:22.590  8141  8141 D TNS.Native: lenNodes=71568, lenNames=824195, lenValues=963214", output: null },
+	{ input: "07-25 06:36:22.590  8141  8141 D TNS.Native: time=1", output: null },
+	{ input: "07-25 06:36:23.065   739   760 I Choreographer: Skipped 54 frames!  The application may be doing too much work on its main thread.", output: null },
+	{ input: "07-25 06:36:23.149  8141  8141 W art     : Before Android 4.1, method android.graphics.PorterDuffColorFilter android.support.graphics.drawable.VectorDrawableCompat.updateTintFilter(android.graphics.PorterDuffColorFilter, android.content.res.ColorStateList, android.graphics.PorterDuff$Mode) would have incorrectly overridden the package-private method in android.graphics.drawable.Drawable", output: null },
+	{ input: "07-25 06:36:23.298  8141  8141 D         : HostConnection::get() New Host Connection established 0xd3916970, tid 8141", output: null },
+	{ input: "07-25 06:36:23.364  8141  8173 D libEGL  : Emulator has host GPU support, qemu.gles is set to 1.", output: null },
+	{ input: "07-25 06:36:23.365  8141  8173 E libEGL  : load_driver(/system/lib/egl/libGLES_emulation.so): dlopen failed: library \"/system/lib/egl/libGLES_emulation.so\" not found", output: null },
+	{ input: "07-25 06:36:23.376  8141  8173 D libEGL  : loaded /system/lib/egl/libEGL_emulation.so", output: null },
+	{ input: "07-25 06:36:23.386  8141  8173 D libEGL  : loaded /system/lib/egl/libGLESv1_CM_emulation.so", output: null },
+	{ input: "07-25 06:36:23.397  8141  8173 D libEGL  : loaded /system/lib/egl/libGLESv2_emulation.so", output: null },
+	{ input: "07-25 06:36:23.422  8141  8173 D         : HostConnection::get() New Host Connection established 0xf17879f0, tid 8173", output: null },
+	{ input: "07-25 06:36:23.463  8141  8173 I OpenGLRenderer: Initialized EGL, version 1.4", output: null },
+	{ input: "07-25 06:36:23.464  8141  8173 D OpenGLRenderer: Swap behavior 1", output: null },
+	{ input: "07-25 06:36:23.862   739   760 I ActivityManager: Displayed org.nativescript.personalalarm/com.tns.NativeScriptActivity: +1s830ms", output: null },
+	{ input: "--------- beginning of system", output: null },
+	{ input: "07-25 06:36:23.913   739   963 I WindowManager: Destroying surface Surface(name=com.android.launcher3/com.android.launcher3.Launcher) called by com.android.server.wm.WindowStateAnimator.destroySurface:2014 com.android.server.wm.WindowStateAnimator.destroySurfaceLocked:881 com.android.server.wm.WindowState.destroyOrSaveSurface:2073 com.android.server.wm.AppWindowToken.destroySurfaces:363 com.android.server.wm.AppWindowToken.notifyAppStopped:389 com.android.server.wm.WindowManagerService.notifyAppStopped:4456 ", output: null },
+	{ input: "07-25 06:36:27.877  8141  8141 V JS      : Set up an alarm for: 1500978987875", output: "JS: Set up an alarm for: 1500978987875" },
+	{ input: "07-25 06:36:30.830   739   775 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.HOME] flg=0x10200000 cmp=com.android.launcher3/.Launcher (has extras)} from uid 1000 on display 0", output: null },
+	{ input: "07-25 06:36:30.882   493   493 E EGL_emulation: tid 493: eglCreateSyncKHR(1285): error 0x3004 (EGL_BAD_ATTRIBUTE)", output: null },
+	{ input: "07-25 06:36:31.095   739   751 W art     : Long monitor contention with owner InputDispatcher (775) at int com.android.server.am.ActivityStarter.startActivityMayWait(android.app.IApplicationThread, int, java.lang.String, android.content.Intent, java.lang.String, android.service.voice.IVoiceInteractionSession, com.android.internal.app.IVoiceInteractor, android.os.IBinder, java.lang.String, int, int, android.app.ProfilerInfo, android.app.IActivityManager$WaitResult, android.content.res.Configuration, android.os.Bundle, boolean, int, android.app.IActivityContainer, com.android.server.am.TaskRecord)(ActivityStarter.java:725) waiters=2 in android.app.ActivityOptions com.android.server.am.ActivityManagerService.getActivityOptions(android.os.IBinder) for 258ms", output: null },
+	{ input: "07-25 06:36:31.103  1181  1333 I OpenGLRenderer: Initialized EGL, version 1.4", output: null },
+	{ input: "07-25 06:36:31.103  1181  1333 D OpenGLRenderer: Swap behavior 1", output: null },
+	{ input: "07-25 06:36:31.896  1181  1333 W OpenGLRenderer: Incorrectly called buildLayer on View: ShortcutAndWidgetContainer, destroying layer...", output: null },
+	{ input: "07-25 06:36:38.320   739  1092 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=org.nativescript.a2test/com.tns.NativeScriptActivity (has extras)} from uid 10014 on display 0", output: null },
+	{ input: "07-25 06:36:38.327  8183  8183 I art     : Late-enabling -Xcheck:jni", output: null },
+	{ input: "07-25 06:36:38.327  8183  8183 W art     : Unexpected CPU variant for X86 using defaults: x86", output: null },
+	{ input: "07-25 06:36:38.335   739  1212 I ActivityManager: Start proc 8183:org.nativescript.a2test/u0a122 for activity org.nativescript.a2test/com.tns.NativeScriptActivity", output: null },
+	{ input: "07-25 06:36:38.406  8183  8183 I TNS.Native: NativeScript Runtime Version 3.0.1, commit 733bfa5fab5d4c156eab156eaf01946eb36dab1e", output: null },
+	{ input: "07-25 06:36:38.406  8183  8183 D TNS.Native: JNI_ONLoad", output: null },
+	{ input: "07-25 06:36:38.406  8183  8183 D TNS.Native: JNI_ONLoad END", output: null },
+	{ input: "07-25 06:36:38.424  8183  8183 D TNS.Native: Failed to load snapshot: dlopen failed: library \"libsnapshot.so\" not found", output: null },
+	{ input: "07-25 06:36:38.534  8183  8183 D TNS.Native: V8 version 5.5.372.32", output: null },
+	{ input: "07-25 06:36:38.675  8183  8183 D TNS.Native: lenNodes=66492, lenNames=775380, lenValues=899324", output: null },
+	{ input: "07-25 06:36:38.675  8183  8183 D TNS.Native: time=24", output: null },
+	{ input: "07-25 06:36:39.376   739   760 I Choreographer: Skipped 55 frames!  The application may be doing too much work on its main thread.", output: null },
+	{ input: "07-25 06:36:39.638  8183  8183 W art     : Before Android 4.1, method android.graphics.PorterDuffColorFilter android.support.graphics.drawable.VectorDrawableCompat.updateTintFilter(android.graphics.PorterDuffColorFilter, android.content.res.ColorStateList, android.graphics.PorterDuff$Mode) would have incorrectly overridden the package-private method in android.graphics.drawable.Drawable", output: null },
+	{ input: "07-25 06:36:39.701  8183  8183 D         : HostConnection::get() New Host Connection established 0xd39aad30, tid 8183", output: null },
+	{ input: "07-25 06:36:39.807  8183  8207 D libEGL  : Emulator has host GPU support, qemu.gles is set to 1.", output: null },
+	{ input: "07-25 06:36:39.807  8183  8207 E libEGL  : load_driver(/system/lib/egl/libGLES_emulation.so): dlopen failed: library \"/system/lib/egl/libGLES_emulation.so\" not found", output: null },
+	{ input: "07-25 06:36:39.811  8183  8207 D libEGL  : loaded /system/lib/egl/libEGL_emulation.so", output: null },
+	{ input: "07-25 06:36:39.914  8183  8207 I OpenGLRenderer: Initialized EGL, version 1.4", output: null },
+	{ input: "07-25 06:36:39.914  8183  8207 D OpenGLRenderer: Swap behavior 1", output: null },
+	{ input: "07-25 06:36:40.136   739   760 I ActivityManager: Displayed org.nativescript.a2test/com.tns.NativeScriptActivity: +1s812ms", output: null },
+	{ input: "07-25 06:36:42.455   739   750 I ActivityManager: START u0 {flg=0x10804000 cmp=com.android.systemui/.recents.RecentsActivity} from uid 10023 on display 0", output: null },
+	{ input: "07-25 06:36:42.505   493   493 E EGL_emulation: tid 493: eglCreateSyncKHR(1285): error 0x3004 (EGL_BAD_ATTRIBUTE)", output: null },
+	{ input: "07-25 06:36:44.189   739  1213 E ActivityManager: applyOptionsLocked: Unknown animationType=0", output: null },
+	{ input: "07-25 06:36:44.386  8141  8173 I OpenGLRenderer: Initialized EGL, version 1.4", output: null },
+	{ input: "07-25 06:36:44.386  8141  8173 D OpenGLRenderer: Swap behavior 1", output: null },
+	{ input: "07-25 06:36:44.978   739  1213 I WindowManager: Destroying surface Surface(name=com.android.systemui/com.android.systemui.recents.RecentsActivity) called by com.android.server.wm.WindowStateAnimator.destroySurface:2014 com.android.server.wm.WindowStateAnimator.destroySurfaceLocked:881 com.android.server.wm.WindowState.destroyOrSaveSurface:2073 com.android.server.wm.WindowManagerService.tryStartExitingAnimation:3017 com.android.server.wm.WindowManagerService.relayoutWindow:2897 com.android.server.wm.Session.relayout:215 android.view.IWindowSession$Stub.onTransact:286 com.android.server.wm.Session.onTransact:136 ", output: null },
+	{ input: "07-25 06:36:54.367   137   137 D Genyd   : Received Set Clipboard", output: null },
+	{ input: "07-25 06:36:54.367   137   137 D Genymotion: Received Set Clipboard", output: null },
+	{ input: "07-25 06:36:59.432  8216  8216 D AndroidRuntime: >>>>>> START com.android.internal.os.RuntimeInit uid 0 <<<<<<", output: null },
+	{ input: "07-25 06:36:59.434  8216  8216 D AndroidRuntime: CheckJNI is OFF", output: null },
+	{ input: "07-25 06:36:59.447  8216  8216 W art     : Unexpected CPU variant for X86 using defaults: x86", output: null },
+	{ input: "07-25 06:36:59.449  8216  8216 D ICU     : No timezone override file found: /data/misc/zoneinfo/current/icu/icu_tzdata.dat", output: null },
+	{ input: "07-25 06:36:59.460  8216  8216 E memtrack: Couldn't load memtrack module (No such file or directory)", output: null },
+	{ input: "07-25 06:36:59.461  8216  8216 E android.os.Debug: failed to load memtrack module: -2", output: null },
+	{ input: "07-25 06:36:59.461  8216  8216 I Radio-JNI: register_android_hardware_Radio DONE", output: null },
+	{ input: "07-25 06:36:59.465  8216  8216 D AndroidRuntime: Calling main entry com.android.commands.pm.Pm", output: null },
+	{ input: "07-25 06:36:59.472  8216  8216 I art     : System.exit called, status: 0", output: null },
+	{ input: "07-25 06:36:59.472  8216  8216 I AndroidRuntime: VM exiting with result code 0.", output: null },
+	{ input: "07-25 06:37:00.051   739   753 I ProcessStatsService: Prepared write state in 1ms", output: null },
+	{ input: "07-25 06:37:00.233  8141  8144 I art     : Do partial code cache collection, code=30KB, data=29KB", output: null },
+	{ input: "07-25 06:37:00.237  8141  8144 I art     : After code cache collection, code=30KB, data=29KB", output: null },
+	{ input: "07-25 06:37:00.237  8141  8144 I art     : Increasing code cache capacity to 128KB", output: null },
+	{ input: "07-25 06:37:04.993  8141  8141 D AndroidRuntime: Shutting down VM", output: null },
+	{ input: "07-25 06:37:04.995  8141  8141 W System.err: com.tns.NativeScriptException: ", output: "System.err: com.tns.NativeScriptException: " },
+	{ input: "07-25 06:37:04.997  8141  8141 W System.err: Calling js method onClick failed", output: "System.err: Calling js method onClick failed" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: ", output: "System.err: " },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: TypeError: Cannot read property 'stop' of undefined", output: "System.err: TypeError: Cannot read property 'stop' of undefined" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: File: \"file:///data/data/org.nativescript.personalalarm/files/app/main-view-model.js, line: 23, column: 18", output: "System.err: File: \"file:///data/data/org.nativescript.personalalarm/files/app/main-view-model.js, line: 23, column: 18" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: ", output: "System.err: " },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: StackTrace: ", output: "System.err: StackTrace: " },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	Frame: function:'viewModel.snooze', file:'file:///data/data/org.nativescript.personalalarm/files/app/main-view-model.js', line: 23, column: 19", output: "System.err: 	Frame: function:'viewModel.snooze', file:'file:///data/data/org.nativescript.personalalarm/files/app/main-view-model.js', line: 23, column: 19" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	Frame: function:'Observable.notify', file:'file:///data/data/org.nativescript.personalalarm/files/app/tns_modules/tns-core-modules/data/observable/observable.js', line: 100, column: 32", output: "System.err: 	Frame: function:'Observable.notify', file:'file:///data/data/org.nativescript.personalalarm/files/app/tns_modules/tns-core-modules/data/observable/observable.js', line: 100, column: 32" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	Frame: function:'Observable._emit', file:'file:///data/data/org.nativescript.personalalarm/files/app/tns_modules/tns-core-modules/data/observable/observable.js', line: 120, column: 18", output: "System.err: 	Frame: function:'Observable._emit', file:'file:///data/data/org.nativescript.personalalarm/files/app/tns_modules/tns-core-modules/data/observable/observable.js', line: 120, column: 18" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	Frame: function:'ClickListenerImpl.onClick', file:'file:///data/data/org.nativescript.personalalarm/files/app/tns_modules/tns-core-modules/ui/button/button.js', line: 23, column: 24", output: "System.err: 	Frame: function:'ClickListenerImpl.onClick', file:'file:///data/data/org.nativescript.personalalarm/files/app/tns_modules/tns-core-modules/ui/button/button.js', line: 23, column: 24" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: ", output: "System.err: " },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at com.tns.Runtime.callJSMethodNative(Native Method)", output: "System.err: 	at com.tns.Runtime.callJSMethodNative(Native Method)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at com.tns.Runtime.dispatchCallJSMethodNative(Runtime.java:1043)", output: "System.err: 	at com.tns.Runtime.dispatchCallJSMethodNative(Runtime.java:1043)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at com.tns.Runtime.callJSMethodImpl(Runtime.java:925)", output: "System.err: 	at com.tns.Runtime.callJSMethodImpl(Runtime.java:925)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at com.tns.Runtime.callJSMethod(Runtime.java:912)", output: "System.err: 	at com.tns.Runtime.callJSMethod(Runtime.java:912)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at com.tns.Runtime.callJSMethod(Runtime.java:896)", output: "System.err: 	at com.tns.Runtime.callJSMethod(Runtime.java:896)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at com.tns.Runtime.callJSMethod(Runtime.java:888)", output: "System.err: 	at com.tns.Runtime.callJSMethod(Runtime.java:888)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at com.tns.gen.java.lang.Object_frnal_ts_helpers_l58_c38__ClickListenerImpl.onClick(Object_frnal_ts_helpers_l58_c38__ClickListenerImpl.java:12)", output: "System.err: 	at com.tns.gen.java.lang.Object_frnal_ts_helpers_l58_c38__ClickListenerImpl.onClick(Object_frnal_ts_helpers_l58_c38__ClickListenerImpl.java:12)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at android.view.View.performClick(View.java:5609)", output: "System.err: 	at android.view.View.performClick(View.java:5609)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at android.view.View$PerformClick.run(View.java:22259)", output: "System.err: 	at android.view.View$PerformClick.run(View.java:22259)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at android.os.Handler.handleCallback(Handler.java:751)", output: "System.err: 	at android.os.Handler.handleCallback(Handler.java:751)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at android.os.Handler.dispatchMessage(Handler.java:95)", output: "System.err: 	at android.os.Handler.dispatchMessage(Handler.java:95)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at android.os.Looper.loop(Looper.java:154)", output: "System.err: 	at android.os.Looper.loop(Looper.java:154)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at android.app.ActivityThread.main(ActivityThread.java:6077)", output: "System.err: 	at android.app.ActivityThread.main(ActivityThread.java:6077)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at java.lang.reflect.Method.invoke(Native Method)", output: "System.err: 	at java.lang.reflect.Method.invoke(Native Method)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:865)", output: "System.err: 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:865)" },
+	{ input: "07-25 06:37:04.998  8141  8141 W System.err: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:755)", output: "System.err: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:755)" },
+	{ input: "07-25 06:37:05.009   739  1087 I ActivityManager: START u0 {flg=0x14008000 cmp=org.nativescript.personalalarm/com.tns.ErrorReportActivity (has extras)} from uid 10064 on display 0", output: null },
+	{ input: "07-25 06:37:05.022  8141  8141 I Process : Sending signal. PID: 8141 SIG: 9", output: null },
+	{ input: "07-25 06:37:05.056   739   775 W InputDispatcher: channel '7f802e0 org.nativescript.personalalarm/com.tns.NativeScriptActivity (server)' ~ Consumer closed input channel or an error occurred.  events=0x9", output: null },
+	{ input: "07-25 06:37:05.056   739   775 E InputDispatcher: channel '7f802e0 org.nativescript.personalalarm/com.tns.NativeScriptActivity (server)' ~ Channel is unrecoverably broken and will be disposed!", output: null },
+	{ input: "07-25 06:37:05.058   739  1212 D GraphicsStats: Buffer count: 4", output: null },
+	{ input: "07-25 06:37:05.060   739   751 I ActivityManager: Process org.nativescript.personalalarm (pid 8141) has died", output: "ActivityManager: Process org.nativescript.personalalarm (pid 8141) has died" },
+	{ input: "07-25 06:37:05.063   739  1092 I WindowManager: WIN DEATH: Window{7f802e0 u0 org.nativescript.personalalarm/com.tns.NativeScriptActivity}", output: null },
+	{ input: "07-25 06:37:05.063   739  1092 W InputDispatcher: Attempted to unregister already unregistered input channel '7f802e0 org.nativescript.personalalarm/com.tns.NativeScriptActivity (server)'", output: null },
+	{ input: "07-25 06:37:05.064   739  1092 I WindowManager: Destroying surface Surface(name=org.nativescript.personalalarm/com.tns.NativeScriptActivity) called by com.android.server.wm.WindowStateAnimator.destroySurface:2014 com.android.server.wm.WindowStateAnimator.destroySurfaceLocked:881 com.android.server.wm.WindowState.removeLocked:1449 com.android.server.wm.WindowManagerService.removeWindowInnerLocked:2478 com.android.server.wm.WindowManagerService.removeWindowLocked:2436 com.android.server.wm.WindowState$DeathRecipient.binderDied:1780 android.os.BinderProxy.sendDeathNotice:688 <bottom of call stack> ", output: null },
+	{ input: "07-25 06:37:05.084   739   751 I ActivityManager: Start proc 8244:org.nativescript.personalalarm/u0a64 for activity org.nativescript.personalalarm/com.tns.ErrorReportActivity", output: null },
+	{ input: "07-25 06:37:05.084  8244  8244 I art     : Late-enabling -Xcheck:jni", output: null },
+	{ input: "07-25 06:37:05.085  8244  8244 W art     : Unexpected CPU variant for X86 using defaults: x86", output: null },
+	{ input: "07-25 06:37:05.212  8244  8244 I TNS.Native: NativeScript Runtime Version 3.1.1, commit 253c76f850b88b0119fda04e413626872f223de5", output: null },
+	{ input: "07-25 06:37:05.213  8244  8244 D TNS.Native: JNI_ONLoad", output: null },
+	{ input: "07-25 06:37:05.213  8244  8244 D TNS.Native: JNI_ONLoad END", output: null },
+];
+
 describe("androidLogFilter", () => {
 
-	let assertFiltering = (inputData: string, expectedOutput: string, logLevel?: string) => {
+	let assertFiltering = (inputData: string, expectedOutput: string, logLevel?: string, pid?: string) => {
 		let testInjector = new Yok();
 		testInjector.register("loggingLevels", LoggingLevels);
 		let androidLogFilter = testInjector.resolve(AndroidLogFilter);
-		let filteredData = androidLogFilter.filterData(inputData, logLevel);
+		let filteredData = androidLogFilter.filterData(inputData, logLevel, pid);
 		assert.deepEqual(filteredData, expectedOutput, `The actual result '${filteredData}' did NOT match expected output '${expectedOutput}'.`);
 	};
 
@@ -131,6 +244,21 @@ describe("androidLogFilter", () => {
 			it("when API level 22 is used", () => {
 				_.each(androidApiLevel22TestData, testData => {
 					assertFiltering(testData.input, testData.output ? testData.output + EOL : testData.output, logLevel);
+				});
+			});
+
+			it("when API level 23 or later is used, and application process matches logcat pids", () => {
+				const appPid = "8141";
+				_.each(androidApiLevel23MapForPid8141, testData => {
+					assertFiltering(testData.input, testData.output ? testData.output + EOL : testData.output, logLevel, appPid);
+				});
+			});
+
+			it("when API level 23 or later is used, and application pid doesn't match any logcat pids", () => {
+				const appPid = "99999";
+				const expectedOutputMap = androidApiLevel23MapForPid8141.map(testData => ({ input: testData.input, output: null }));
+				_.each(expectedOutputMap, testData => {
+					assertFiltering(testData.input, testData.output ? testData.output + EOL : testData.output, logLevel, appPid);
 				});
 			});
 		});


### PR DESCRIPTION
### Problem
https://github.com/NativeScript/nativescript-cli/issues/2818 - When an app was started the CLI's logging filter would parse each incoming adb line and check it against a regex that either `JS:` was the tag used, or that any of the [accepted tags](https://github.com/telerik/mobile-cli-lib/compare/pete/log-by-pid-android?expand=1#diff-db4bc9bdec0f0e3438155588e7c23c1aR38)'s string was contained within the logcat line.
That would at times return incorrect, or incomplete logs.

### Proposed solution
Read the process id for the application process from adb, then filter logs by the pid.