### PR TITLE
Print message when successfully setting the tns proxy configuration

### DIFF
--- a/commands/proxy/proxy-set.ts
+++ b/commands/proxy/proxy-set.ts
@@ -18,6 +18,7 @@ export class ProxySetCommand extends ProxyCommandBase {
 		private $injector: IInjector,
 		private $prompter: IPrompter,
 		private $hostInfo: IHostInfo,
+		private $staticConfig: Config.IStaticConfig,
 		protected $analyticsService: IAnalyticsService,
 		protected $logger: ILogger,
 		protected $options: ICommonOptions,
@@ -102,6 +103,13 @@ export class ProxySetCommand extends ProxyCommandBase {
 		if (!this.$hostInfo.isWindows) {
 			this.$logger.warn(`Note that storing credentials is not supported on ${platform()} yet.`);
 		}
+
+		const clientName = this.$staticConfig.CLIENT_NAME.toLowerCase();
+		let messageNote = (clientName === "tns" ?
+			"Note that 'npm' and 'Gradle' need to be configured separately to work with a proxy." :
+			"Note that `npm` needs to be configured separately to work with a proxy.") + EOL;
+
+		this.$logger.warn(`${messageNote}Run '${clientName} proxy set --help' for more information.`);
 
 		this.$proxyService.setCache(proxyCache);
 		this.$logger.out(`Successfully setup proxy.${EOL}`);


### PR DESCRIPTION
Log a message instructing the user to run the `proxy set` help command to find out how to setup the `npm` and `Gradle` proxy configurations.

Implemented as suggested in https://github.com/NativeScript/nativescript-cli/issues/2816

Related: https://github.com/NativeScript/nativescript-cli/pull/3004