### PR TITLE
Return the real transferred files when transferDirectory of device fs is called

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -296,7 +296,7 @@ declare module Mobile {
 		putFile(localFilePath: string, deviceFilePath: string, appIdentifier: string): Promise<void>;
 		deleteFile?(deviceFilePath: string, appIdentifier: string): Promise<void>;
 		transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void>;
-		transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<void>;
+		transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<Mobile.ILocalToDevicePathData[]>;
 		transferFile?(localFilePath: string, deviceFilePath: string): Promise<void>;
 		createFileOnDevice?(deviceFilePath: string, fileContent: string): Promise<void>;
 	}

--- a/mobile/ios/device/ios-application-manager.ts
+++ b/mobile/ios/device/ios-application-manager.ts
@@ -90,7 +90,14 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 	}
 
 	public async stopApplication(appIdentifier: string, appName?: string): Promise<void> {
-		await this.$iosDeviceOperations.stop([{ deviceId: this.device.deviceInfo.identifier, ddi: this.$options.ddi, appId: appIdentifier }]);
+		const action = () => this.$iosDeviceOperations.stop([{ deviceId: this.device.deviceInfo.identifier, ddi: this.$options.ddi, appId: appIdentifier }]);
+
+		try {
+			await action();
+		} catch (err) {
+			this.$logger.trace(`Error when trying to stop application ${appIdentifier} on device ${this.device.deviceInfo.identifier}: ${err}. Retrying stop operation.`);
+			await action();
+		}
 	}
 
 	public async restartApplication(applicationId: string, appName?: string): Promise<void> {

--- a/mobile/ios/device/ios-device-file-system.ts
+++ b/mobile/ios/device/ios-device-file-system.ts
@@ -61,8 +61,9 @@ export class IOSDeviceFileSystem implements Mobile.IDeviceFileSystem {
 		}]);
 	}
 
-	public async transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<void> {
-		return this.transferFiles(deviceAppData, localToDevicePaths);
+	public async transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<Mobile.ILocalToDevicePathData[]> {
+		await this.transferFiles(deviceAppData, localToDevicePaths);
+		return localToDevicePaths;
 	}
 
 	private async uploadFilesCore(filesToUpload: IOSDeviceLib.IUploadFilesData[]): Promise<void> {

--- a/mobile/ios/simulator/ios-simulator-file-system.ts
+++ b/mobile/ios/simulator/ios-simulator-file-system.ts
@@ -30,11 +30,12 @@ export class IOSSimulatorFileSystem implements Mobile.IDeviceFileSystem {
 			));
 	}
 
-	public async transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<void> {
+	public async transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<Mobile.ILocalToDevicePathData[]> {
 		let destinationPath = await deviceAppData.getDeviceProjectRootPath();
 		this.$logger.trace(`Transferring from ${projectFilesPath} to ${destinationPath}`);
 		let sourcePath = path.join(projectFilesPath, "*");
-		return shelljs.cp("-Rf", sourcePath, destinationPath);
+		shelljs.cp("-Rf", sourcePath, destinationPath);
+		return localToDevicePaths;
 	}
 
 	public async transferFile(localFilePath: string, deviceFilePath: string): Promise<void> {


### PR DESCRIPTION
When uploading files on devices/emulators, we are executing either `transferDirectory` or `transferFiles` methods of the specific device instance.
However for Android devices, the transferDirectory method has some logic to transfer only modified files (based on shasums from previous execution). So it doesn't really transfer the directory, but just several files.
For LiveSync purposes it is important to know which are the tranferred files, so change the return type of `transferDirectory` method to return the exact files that we've sent to device.

Try-catch the stop of iOS Application as it may fail in some rare cases - in this case just retry it.
