### PR TITLE
Throw correct error on hook execution

### DIFF
--- a/services/hooks-service.ts
+++ b/services/hooks-service.ts
@@ -82,7 +82,7 @@ export class HooksService implements IHooksService {
 			}
 		} catch (err) {
 			this.$logger.trace("Failed during hook execution.");
-			this.$errors.failWithoutHelp(err.message);
+			this.$errors.failWithoutHelp(err.message || err);
 		}
 	}
 


### PR DESCRIPTION
Some plugins have hooks which `throw` strings instead of `new Error`s.
If this is the case we should display said string instead of `undefined`.


Ping @rosen-vladimirov @nadyaA @TsvetanMilanov 