### PR TITLE
use am start instead of monkey to start application

### DIFF
--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -2,6 +2,7 @@ import { EOL } from "os";
 import { ApplicationManagerBase } from "../application-manager-base";
 import { LiveSyncConstants, TARGET_FRAMEWORK_IDENTIFIERS } from "../../constants";
 import { hook } from "../../helpers";
+import { cache } from "../../decorators";
 
 export class AndroidApplicationManager extends ApplicationManagerBase {
 
@@ -61,11 +62,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		const pmDumpOutput = await this.adb.executeShellCommand(["pm", "dump", appIdentifier, "|", "grep", "-A", "1", "MAIN"]);
 		const activityMatch = this.getFullyQualifiedActivityRegex();
 		const match = activityMatch.exec(pmDumpOutput);
-		let possibleIdentifier = "";
-
-		if (match && match.length > 0) {
-			possibleIdentifier = match[0];
-		}
+		const possibleIdentifier = match && match[0];
 
 		if (possibleIdentifier) {
 			await this.adb.executeShellCommand(["am", "start", "-n", possibleIdentifier]);
@@ -128,6 +125,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		return applicationViews;
 	}
 
+	@cache()
 	private getFullyQualifiedActivityRegex(): RegExp {
 		const androidPackageName = "([A-Za-z]{1}[A-Za-z\\d_]*\\.)*[A-Za-z][A-Za-z\\d_]*";
 		const packageActivitySeparator = "\\/";

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -44,9 +44,22 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 	}
 
 	public async startApplication(appIdentifier: string): Promise<void> {
+
+		/*
+		Example "pm dump <app_identifier> | grep -A 1 MAIN" output"
+			android.intent.action.MAIN:
+			3b2df03 org.nativescript.cliapp/com.tns.NativeScriptActivity filter 50dd82e
+			Action: "android.intent.action.MAIN"
+			Category: "android.intent.category.LAUNCHER"
+			--
+			intent={act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=org.nativescript.cliapp/com.tns.NativeScriptActivity}
+			realActivity=org.nativescript.cliapp/com.tns.NativeScriptActivity
+			--
+			Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=org.nativescript.cliapp/com.tns.NativeScriptActivity }
+			frontOfTask=true task=TaskRecord{fe592ac #449 A=org.nativescript.cliapp U=0 StackId=1 sz=1}
+		*/
 		const pmDumpOutput = await this.adb.executeShellCommand(["pm", "dump", appIdentifier, "|", "grep", "-A", "1", "MAIN"]);
-		const fullActivityNameRegExp = this.getFullyQualifiedActivityRegex();
-		const activityMatch = new RegExp(fullActivityNameRegExp, "m");
+		const activityMatch = this.getFullyQualifiedActivityRegex();
 		const match = activityMatch.exec(pmDumpOutput);
 		let possibleIdentifier = "";
 
@@ -115,7 +128,11 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		return applicationViews;
 	}
 
-	public getFullyQualifiedActivityRegex(): RegExp {
-		return /([A-Za-z]{1}[A-Za-z\d_]*\.)*[A-Za-z][A-Za-z\d_]*\/([a-z][a-z_0-9]*\.)*[A-Z_$]($[A-Z_$]|[$_\w_])*/;
+	private getFullyQualifiedActivityRegex(): RegExp {
+		const androidPackageName = "([A-Za-z]{1}[A-Za-z\\d_]*\\.)*[A-Za-z][A-Za-z\\d_]*";
+		const packageActivitySeparator = "\\/";
+		const fullJavaClassName = "([a-z][a-z_0-9]*\\.)*[A-Z_$]($[A-Z_$]|[$_\\w_])*";
+
+		return new RegExp(`${androidPackageName}${packageActivitySeparator}${fullJavaClassName}`, `m`);
 	}
 }

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -50,14 +50,15 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		const match = activityMatch.exec(pmDumpOutput);
 		let possibleIdentifier = "";
 
-		if(match && match.length > 0) {
-			possibleIdentifier = match[0]
+		if (match && match.length > 0) {
+			possibleIdentifier = match[0];
 		}
 
 		if (possibleIdentifier) {
 			await this.adb.executeShellCommand(["am", "start", "-n", possibleIdentifier]);
 		} else {
-			this.$logger.trace(`Tried starting activity for: ${appIdentifier}, but failed`);
+			this.$logger.trace(`Tried starting activity for: ${appIdentifier}, using activity manager but failed.`);
+			await this.adb.executeShellCommand(["monkey", "-p", appIdentifier, "-c", "android.intent.category.LAUNCHER", "1"]);
 		}
 
 		if (!this.$options.justlaunch) {

--- a/test/unit-tests/android-application-manager.ts
+++ b/test/unit-tests/android-application-manager.ts
@@ -1,63 +1,129 @@
 import { AndroidApplicationManager } from "../../mobile/android/android-application-manager";
 import { Yok } from "../../yok";
 import { assert } from "chai";
+import { CommonLoggerStub } from "./stubs";
+const invalidIdentifier: string = "invalid.identifier";
 
-describe("android-application-manager", () => {
-
-	let testInjector: IInjector,
-		validTestInput: Array<string>,
-		expectedValidTestInput: Array<string>;
-
-	before(() => {
-		testInjector = new Yok();
-		expectedValidTestInput = [
+class AndroidDebugBridgeStub {
+	public startedWithActivityManager: Boolean = false;
+	public validIdentifierPassed: Boolean = false;
+	public static methodCallCount: number = 0;
+	private expectedValidTestInput: string[] = [
 			"org.nativescript.testApp/com.tns.TestClass",
 			"org.nativescript.testApp/com.tns.$TestClass",
 			"org.nativescript.testApp/com.tns._TestClass",
 			"org.nativescript.testApp/com.tns.$_TestClass",
-			"org.nativescript.testApp/com.tns._$TestClass"
-		],
-		validTestInput = [
+			"org.nativescript.testApp/com.tns._$TestClass",
+			"org.nativescript.testApp/com.tns.NativeScriptActivity"
+		];
+	private validTestInput: string[] = [
 			"other.stuff/ org.nativescript.testApp/com.tns.TestClass asdaas.dasdh2",
 			"other.stuff.the.regex.might.fail.on org.nativescript.testApp/com.tns.$TestClass other.stuff.the.regex.might.fail.on",
 			"/might.fail.on  org.nativescript.testApp/com.tns._TestClass /might.fail.on",
 			"might.fail.on/ org.nativescript.testApp/com.tns.$_TestClass might.fail.on//",
-			"/might.fail org.nativescript.testApp/com.tns._$TestClass something/might.fail.on/"
+			"/might.fail org.nativescript.testApp/com.tns._$TestClass something/might.fail.on/",
+			"android.intent.action.MAIN: \
+			3b2df03 org.nativescript.testApp/com.tns.NativeScriptActivity filter 50dd82e \
+			Action: \"android.intent.action.MAIN\" \
+			Category: \"android.intent.category.LAUNCHER\" \
+			-- \
+			intent={act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=org.nativescript.testApp/com.tns.NativeScriptActivity} \
+			realActivity=org.nativescript.testApp/com.tns.NativeScriptActivity \
+			-- \
+			Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=org.nativescript.testApp/com.tns.NativeScriptActivity } \
+			frontOfTask=true task=TaskRecord{fe592ac #449 A=org.nativescript.testApp U=0 StackId=1 sz=1}"
 		];
-	});
+
+	public async executeShellCommand(args: string[]): Promise<any> {
+		if (args && args.length > 0) {
+			if (args[0] === "pm") {
+				const passedIdentifier = args[2];
+				if (passedIdentifier === invalidIdentifier) {
+					return Promise.resolve("invalid output string");
+				} else {
+					const testString = this.validTestInput[AndroidDebugBridgeStub.methodCallCount];
+					return Promise.resolve(testString);
+				}
+			} else {
+				this.startedWithActivityManager = this.checkIfStartedWithActivityManager(args);
+				if (this.startedWithActivityManager) {
+					this.validIdentifierPassed = this.checkIfValidIdentifierPassed(args);
+				}
+			}
+		}
+		AndroidDebugBridgeStub.methodCallCount++;
+		Promise.resolve();
+	}
+
+	public getInputLength(): number {
+		return this.validTestInput.length;
+	}
+
+	private checkIfStartedWithActivityManager(args: string[]): Boolean {
+		const firstArgument = args[0].trim();
+		switch (firstArgument) {
+			case "am": return true;
+			case "monkey": return false;
+			default: return false;
+		}
+	}
+
+	private checkIfValidIdentifierPassed(args: string[]): Boolean {
+		if (args && args.length) {
+			const possibleIdentifier = args[args.length - 1];
+			let validTestString = this.expectedValidTestInput[AndroidDebugBridgeStub.methodCallCount];
+			if (possibleIdentifier === validTestString) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+function createTestInjector(): IInjector {
+	let testInjector = new Yok();
+	testInjector.register("androidApplicationManager", AndroidApplicationManager);
+	testInjector.register("adb", AndroidDebugBridgeStub);
+	testInjector.register('childProcess', {});
+	testInjector.register("logger", CommonLoggerStub);
+	testInjector.register("config", {});
+	testInjector.register("staticConfig", {});
+	testInjector.register("androidDebugBridgeResultHandler", {});
+	testInjector.register("options", {justlaunch: true});
+	testInjector.register("errors", {});
+	testInjector.register("identifier", {});
+	testInjector.register("logcatHelper", {});
+	testInjector.register("androidProcessService", {});
+	testInjector.register("httpClient", {});
+	testInjector.register("deviceLogProvider", {});
+	testInjector.register("hooksService", {});
+	return testInjector;
+}
+
+describe("android-application-manager", () => {
+
+	let testInjector: IInjector,
+		androidApplicationManager:AndroidApplicationManager,
+		androidDebugBridge:AndroidDebugBridgeStub;
 
 	beforeEach(() => {
-		testInjector.register("androidApplicationManager", AndroidApplicationManager);
-		testInjector.register("adb", {});
-		testInjector.register('childProcess', {});
-		testInjector.register("logger", {});
-		testInjector.register("config", {});
-		testInjector.register("staticConfig", {});
-		testInjector.register("androidDebugBridgeResultHandler", {});
-		testInjector.register("options", {});
-		testInjector.register("errors", {});
-		testInjector.register("identifier", {});
-		testInjector.register("logcatHelper", {});
-		testInjector.register("androidProcessService", {});
-		testInjector.register("httpClient", {});
-		testInjector.register("deviceLogProvider", {});
-		testInjector.register("hooksService", {});
+		testInjector = createTestInjector();
+		androidApplicationManager = testInjector.resolve("androidApplicationManager");
+		androidDebugBridge = testInjector.resolve("adb");
 	});
-	describe("tries to get fully qualified activity class name", () => {
-		it("and succeeds finding the right name", async () => {
-			let aam:AndroidApplicationManager = testInjector.resolve("androidApplicationManager");
-			const fullActivityNameRegExp:RegExp = aam.getFullyQualifiedActivityRegex();
-			const activityMatch = new RegExp(fullActivityNameRegExp, "m");
+	describe("startApplication", () => {
+		it.only("fires up the right application", async () => {
+			for (let i = 0; i < androidDebugBridge.getInputLength(); i += 1) {
+				androidDebugBridge.validIdentifierPassed = false;
 
-			for (let i = 0; i < validTestInput.length; i += 1) {
-				let validInput = validTestInput[i];
-				const match = activityMatch.exec(validInput);
-				let expectedElement = expectedValidTestInput[i];
-
-				assert.isArray(match);
-				assert.isTrue(expectedElement === match[0]);
+				await androidApplicationManager.startApplication("valid.identifier");
+				assert.isTrue(androidDebugBridge.validIdentifierPassed);
+				assert.isTrue(androidDebugBridge.startedWithActivityManager);
 			}
-			assert.isTrue(true);
+		});
+		it.only("if regex fails monkey is called to start application", async () => {
+			await androidApplicationManager.startApplication(invalidIdentifier);
+			assert.isFalse(androidDebugBridge.startedWithActivityManager);
 		});
 	});
 });

--- a/test/unit-tests/android-application-manager.ts
+++ b/test/unit-tests/android-application-manager.ts
@@ -112,7 +112,7 @@ describe("android-application-manager", () => {
 		androidDebugBridge = testInjector.resolve("adb");
 	});
 	describe("startApplication", () => {
-		it.only("fires up the right application", async () => {
+		it("fires up the right application", async () => {
 			for (let i = 0; i < androidDebugBridge.getInputLength(); i += 1) {
 				androidDebugBridge.validIdentifierPassed = false;
 
@@ -121,7 +121,7 @@ describe("android-application-manager", () => {
 				assert.isTrue(androidDebugBridge.startedWithActivityManager);
 			}
 		});
-		it.only("if regex fails monkey is called to start application", async () => {
+		it("if regex fails monkey is called to start application", async () => {
 			await androidApplicationManager.startApplication(invalidIdentifier);
 			assert.isFalse(androidDebugBridge.startedWithActivityManager);
 		});

--- a/test/unit-tests/android-application-manager.ts
+++ b/test/unit-tests/android-application-manager.ts
@@ -2,7 +2,6 @@ import { AndroidApplicationManager } from "../../mobile/android/android-applicat
 import { Yok } from "../../yok";
 import { assert } from "chai";
 
-
 describe("android-application-manager", () => {
 
 	let testInjector: IInjector,
@@ -24,8 +23,9 @@ describe("android-application-manager", () => {
 			"/might.fail.on  org.nativescript.testApp/com.tns._TestClass /might.fail.on",
 			"might.fail.on/ org.nativescript.testApp/com.tns.$_TestClass might.fail.on//",
 			"/might.fail org.nativescript.testApp/com.tns._$TestClass something/might.fail.on/"
-		]
-	})
+		];
+	});
+
 	beforeEach(() => {
 		testInjector.register("androidApplicationManager", AndroidApplicationManager);
 		testInjector.register("adb", {});
@@ -49,13 +49,13 @@ describe("android-application-manager", () => {
 			const fullActivityNameRegExp:RegExp = aam.getFullyQualifiedActivityRegex();
 			const activityMatch = new RegExp(fullActivityNameRegExp, "m");
 
-			for(let i = 0; i < validTestInput.length; i+=1) {
+			for (let i = 0; i < validTestInput.length; i += 1) {
 				let validInput = validTestInput[i];
 				const match = activityMatch.exec(validInput);
 				let expectedElement = expectedValidTestInput[i];
 
 				assert.isArray(match);
-				assert.isTrue(expectedElement == match[0]);
+				assert.isTrue(expectedElement === match[0]);
 			}
 			assert.isTrue(true);
 		});

--- a/test/unit-tests/android-application-manager.ts
+++ b/test/unit-tests/android-application-manager.ts
@@ -1,0 +1,63 @@
+import { AndroidApplicationManager } from "../../mobile/android/android-application-manager";
+import { Yok } from "../../yok";
+import { assert } from "chai";
+
+
+describe("android-application-manager", () => {
+
+	let testInjector: IInjector,
+		validTestInput: Array<string>,
+		expectedValidTestInput: Array<string>;
+
+	before(() => {
+		testInjector = new Yok();
+		expectedValidTestInput = [
+			"org.nativescript.testApp/com.tns.TestClass",
+			"org.nativescript.testApp/com.tns.$TestClass",
+			"org.nativescript.testApp/com.tns._TestClass",
+			"org.nativescript.testApp/com.tns.$_TestClass",
+			"org.nativescript.testApp/com.tns._$TestClass"
+		],
+		validTestInput = [
+			"other.stuff/ org.nativescript.testApp/com.tns.TestClass asdaas.dasdh2",
+			"other.stuff.the.regex.might.fail.on org.nativescript.testApp/com.tns.$TestClass other.stuff.the.regex.might.fail.on",
+			"/might.fail.on  org.nativescript.testApp/com.tns._TestClass /might.fail.on",
+			"might.fail.on/ org.nativescript.testApp/com.tns.$_TestClass might.fail.on//",
+			"/might.fail org.nativescript.testApp/com.tns._$TestClass something/might.fail.on/"
+		]
+	})
+	beforeEach(() => {
+		testInjector.register("androidApplicationManager", AndroidApplicationManager);
+		testInjector.register("adb", {});
+		testInjector.register('childProcess', {});
+		testInjector.register("logger", {});
+		testInjector.register("config", {});
+		testInjector.register("staticConfig", {});
+		testInjector.register("androidDebugBridgeResultHandler", {});
+		testInjector.register("options", {});
+		testInjector.register("errors", {});
+		testInjector.register("identifier", {});
+		testInjector.register("logcatHelper", {});
+		testInjector.register("androidProcessService", {});
+		testInjector.register("httpClient", {});
+		testInjector.register("deviceLogProvider", {});
+		testInjector.register("hooksService", {});
+	});
+	describe("tries to get fully qualified activity class name", () => {
+		it("and succeeds finding the right name", async () => {
+			let aam:AndroidApplicationManager = testInjector.resolve("androidApplicationManager");
+			const fullActivityNameRegExp:RegExp = aam.getFullyQualifiedActivityRegex();
+			const activityMatch = new RegExp(fullActivityNameRegExp, "m");
+
+			for(let i = 0; i < validTestInput.length; i+=1) {
+				let validInput = validTestInput[i];
+				const match = activityMatch.exec(validInput);
+				let expectedElement = expectedValidTestInput[i];
+
+				assert.isArray(match);
+				assert.isTrue(expectedElement == match[0]);
+			}
+			assert.isTrue(true);
+		});
+	});
+});

--- a/test/unit-tests/android-application-manager.ts
+++ b/test/unit-tests/android-application-manager.ts
@@ -39,10 +39,10 @@ class AndroidDebugBridgeStub {
 			if (args[0] === "pm") {
 				const passedIdentifier = args[2];
 				if (passedIdentifier === invalidIdentifier) {
-					return Promise.resolve("invalid output string");
+					return "invalid output string";
 				} else {
 					const testString = this.validTestInput[AndroidDebugBridgeStub.methodCallCount];
-					return Promise.resolve(testString);
+					return testString;
 				}
 			} else {
 				this.startedWithActivityManager = this.checkIfStartedWithActivityManager(args);

--- a/test/unit-tests/android-application-manager.ts
+++ b/test/unit-tests/android-application-manager.ts
@@ -52,7 +52,6 @@ class AndroidDebugBridgeStub {
 			}
 		}
 		AndroidDebugBridgeStub.methodCallCount++;
-		Promise.resolve();
 	}
 
 	public getInputLength(): number {
@@ -71,10 +70,9 @@ class AndroidDebugBridgeStub {
 	private checkIfValidIdentifierPassed(args: string[]): Boolean {
 		if (args && args.length) {
 			const possibleIdentifier = args[args.length - 1];
-			let validTestString = this.expectedValidTestInput[AndroidDebugBridgeStub.methodCallCount];
-			if (possibleIdentifier === validTestString) {
-				return true;
-			}
+			const validTestString = this.expectedValidTestInput[AndroidDebugBridgeStub.methodCallCount];
+
+			return possibleIdentifier === validTestString;
 		}
 		return false;
 	}
@@ -113,7 +111,7 @@ describe("android-application-manager", () => {
 	});
 	describe("startApplication", () => {
 		it("fires up the right application", async () => {
-			for (let i = 0; i < androidDebugBridge.getInputLength(); i += 1) {
+			for (let i = 0; i < androidDebugBridge.getInputLength(); i++) {
 				androidDebugBridge.validIdentifierPassed = false;
 
 				await androidApplicationManager.startApplication("valid.identifier");


### PR DESCRIPTION
_problem_
`monkey` is a tool used for testing, not for production use and we shouldn't use it since it's a tool used and built for stress testing. It has random behavior and it's not recommended for production use and therefore we are replacing `monkey` with the recommended `am` tool.
Fix Issue: https://github.com/NativeScript/NativeScript/issues/4591

_solution_
Use `am` tool instead to start the application by it's activity identifier which is a combination of the package name and the default activity. 
Example for such an identifier would be: `org.nativescript.appname/com.tns.MainActivity`