### PR TITLE
Fix the error handling in hooks execution

### DIFF
--- a/services/hooks-service.ts
+++ b/services/hooks-service.ts
@@ -132,7 +132,7 @@ export class HooksService implements IHooksService {
 						await maybePromise;
 					} catch (err) {
 						if (err && _.isBoolean(err.stopExecution) && err.errorAsWarning === true) {
-							this.$logger.warn(err.message);
+							this.$logger.warn(err.message || err);
 						} else {
 							throw err || new Error(`Failed to execute hook: ${hook.fullPath}.`);
 						}


### PR DESCRIPTION
Some hooks can reject their promises without error.
We need to check if we have an error before we try to get some information from it.