### PR TITLE
Fix infinite loop of unhandled rejections

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -466,7 +466,8 @@ declare const enum ErrorCodes {
 	UNKNOWN = 127,
 	INVALID_ARGUMENT = 128,
 	RESOURCE_PROBLEM = 129,
-	KARMA_FAIL = 130
+	KARMA_FAIL = 130,
+	UNHANDLED_REJECTION_FAILURE = 131
 }
 
 interface IFutureDispatcher {


### PR DESCRIPTION
In case the code inside our unhandled rejection handler fails, it will throw another unhandled rejection and we may end up with infinite loop.
In this case try-catch the whole code inside the unhandled rejection and in case error is arised, exit the process. We cannot console.log the error as even this operation might fail.