### PR TITLE
Safeguard against empty filePaths

### DIFF
--- a/services/project-files-provider-base.ts
+++ b/services/project-files-provider-base.ts
@@ -15,6 +15,14 @@ export abstract class ProjectFilesProviderBase implements IProjectFilesProvider 
 	}
 
 	public getProjectFileInfo(filePath: string, platform: string, projectFilesConfig?: IProjectFilesConfig): IProjectFileInfo {
+		if (!filePath) {
+			return {
+				filePath: filePath,
+				onDeviceFileName: filePath,
+				shouldIncludeFile: false
+			};
+		}
+
 		let parsed = this.parseFile(filePath, this.$mobileHelper.platformNames, platform || "");
 		let basicConfigurations = [Configurations.Debug.toLowerCase(), Configurations.Release.toLowerCase()];
 		if (!parsed) {


### PR DESCRIPTION
In case `filePath` is `false`-like we'll get an error when calling `parseFile`.
The error is `Cannot read property 'match' of null`

Ping @rosen-vladimirov @TsvetanMilanov 