### PR TITLE
Add prefer-const rule to tslint

### DIFF
--- a/appbuilder/device-emitter.ts
+++ b/appbuilder/device-emitter.ts
@@ -71,7 +71,7 @@ export class DeviceEmitter extends EventEmitter {
 	}
 
 	private checkCompanionAppChanged(device: Mobile.IDevice, applicationName: string, eventName: string): void {
-		let devicePlatform = device.deviceInfo.platform.toLowerCase();
+		const devicePlatform = device.deviceInfo.platform.toLowerCase();
 		_.each(this.companionAppIdentifiers, (platformsCompanionAppIdentifiers: IStringDictionary, framework: string) => {
 			if (applicationName === platformsCompanionAppIdentifiers[devicePlatform]) {
 				this.emit(eventName, device.deviceInfo.identifier, framework);

--- a/appbuilder/device-log-provider.ts
+++ b/appbuilder/device-log-provider.ts
@@ -7,9 +7,9 @@ export class DeviceLogProvider extends DeviceLogProviderBase {
 	}
 
 	public logData(line: string, platform: string, deviceIdentifier: string): void {
-		let logLevel = this.setDefaultLogLevelForDevice(deviceIdentifier);
+		const logLevel = this.setDefaultLogLevelForDevice(deviceIdentifier);
 
-		let applicationPid = this.getApplicationPidForDevice(deviceIdentifier),
+		const applicationPid = this.getApplicationPidForDevice(deviceIdentifier),
 			data = this.$logFilter.filterData(platform, line, applicationPid, logLevel);
 
 		if (data) {

--- a/appbuilder/mobile/appbuilder-device-app-data-base.ts
+++ b/appbuilder/mobile/appbuilder-device-app-data-base.ts
@@ -24,7 +24,7 @@ export abstract class AppBuilderDeviceAppDataBase extends DeviceAppDataBase impl
 	}
 
 	public async isLiveSyncSupported(): Promise<boolean> {
-		let isApplicationInstalled = await this.device.applicationManager.isApplicationInstalled(this.appIdentifier);
+		const isApplicationInstalled = await this.device.applicationManager.isApplicationInstalled(this.appIdentifier);
 
 		if (!isApplicationInstalled) {
 			await this.$deployHelper.deploy(this.platform.toString());

--- a/appbuilder/project/project-base.ts
+++ b/appbuilder/project/project-base.ts
@@ -51,7 +51,7 @@ export abstract class ProjectBase implements Project.IProjectBase {
 	}
 
 	public get capabilities(): Project.ICapabilities {
-		let projectData = this.projectData;
+		const projectData = this.projectData;
 		if (projectData) {
 			if (projectData.Framework && projectData.Framework.toLowerCase() === TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()) {
 				return this.$nativeScriptProjectCapabilities;
@@ -83,10 +83,10 @@ export abstract class ProjectBase implements Project.IProjectBase {
 		if (platform &&
 			platform.toLowerCase() === this.$projectConstants.ANDROID_PLATFORM_NAME.toLowerCase() &&
 			this.projectData.Framework === TARGET_FRAMEWORK_IDENTIFIERS.Cordova) {
-			let pathToAndroidResources = path.join(this.projectDir, this.$staticConfig.APP_RESOURCES_DIR_NAME, this.$projectConstants.ANDROID_PLATFORM_NAME);
+			const pathToAndroidResources = path.join(this.projectDir, this.$staticConfig.APP_RESOURCES_DIR_NAME, this.$projectConstants.ANDROID_PLATFORM_NAME);
 
-			let pathToAndroidManifest = path.join(pathToAndroidResources, ProjectBase.ANDROID_MANIFEST_NAME);
-			let appIdentifierInAndroidManifest = this.getAppIdentifierFromConfigFile(pathToAndroidManifest, /package\s*=\s*"(\S*)"/);
+			const pathToAndroidManifest = path.join(pathToAndroidResources, ProjectBase.ANDROID_MANIFEST_NAME);
+			const appIdentifierInAndroidManifest = this.getAppIdentifierFromConfigFile(pathToAndroidManifest, /package\s*=\s*"(\S*)"/);
 
 			if (appIdentifierInAndroidManifest && appIdentifierInAndroidManifest !== ProjectBase.APP_IDENTIFIER_PLACEHOLDER) {
 				platformSpecificAppIdentifier = appIdentifierInAndroidManifest;
@@ -100,19 +100,19 @@ export abstract class ProjectBase implements Project.IProjectBase {
 	protected abstract saveProjectIfNeeded(): void;
 
 	protected readProjectData(): void {
-		let projectDir = this.getProjectDir();
+		const projectDir = this.getProjectDir();
 		this.setShouldSaveProject(false);
 		if (projectDir) {
-			let projectFilePath = path.join(projectDir, this.$projectConstants.PROJECT_FILE);
+			const projectFilePath = path.join(projectDir, this.$projectConstants.PROJECT_FILE);
 			try {
 				this.projectData = this.getProjectData(projectFilePath);
 				this.validate();
 
 				_.each(this.$fs.enumerateFilesInDirectorySync(projectDir), (configProjectFile: string) => {
-					let configMatch = path.basename(configProjectFile).match(ProjectBase.CONFIGURATION_FROM_FILE_NAME_REGEX);
+					const configMatch = path.basename(configProjectFile).match(ProjectBase.CONFIGURATION_FROM_FILE_NAME_REGEX);
 					if (configMatch && configMatch.length > 1) {
-						let configurationName = configMatch[1];
-						let configProjectContent = this.$fs.readJson(configProjectFile),
+						const configurationName = configMatch[1];
+						const configProjectContent = this.$fs.readJson(configProjectFile),
 							configurationLowerCase = configurationName.toLowerCase();
 						this.configurationSpecificData[configurationLowerCase] = <any>_.merge(_.cloneDeep(this._projectData), configProjectContent);
 						this._hasBuildConfigurations = true;
@@ -134,7 +134,7 @@ export abstract class ProjectBase implements Project.IProjectBase {
 	}
 
 	private getProjectData(projectFilePath: string): Project.IData {
-		let data = this.$fs.readJson(projectFilePath);
+		const data = this.$fs.readJson(projectFilePath);
 		if (data.projectVersion && data.projectVersion.toString() !== "1") {
 			this.$errors.fail("FUTURE_PROJECT_VER");
 		}
@@ -155,9 +155,9 @@ export abstract class ProjectBase implements Project.IProjectBase {
 
 	private getAppIdentifierFromConfigFile(pathToConfigFile: string, regExp: RegExp): string {
 		if (this.$fs.exists(pathToConfigFile)) {
-			let fileContent = this.$fs.readText(pathToConfigFile);
+			const fileContent = this.$fs.readText(pathToConfigFile);
 
-			let matches = fileContent.match(regExp);
+			const matches = fileContent.match(regExp);
 
 			if (matches && matches[1]) {
 				return matches[1];

--- a/appbuilder/proton-static-config.ts
+++ b/appbuilder/proton-static-config.ts
@@ -7,7 +7,7 @@ export class ProtonStaticConfig extends StaticConfigBase {
 	}
 
 	public async getAdbFilePath(): Promise<string> {
-		let value = await super.getAdbFilePath();
+		const value = await super.getAdbFilePath();
 		return value.replace("app.asar", "app.asar.unpacked");
 	}
 

--- a/appbuilder/providers/device-app-data-provider.ts
+++ b/appbuilder/providers/device-app-data-provider.ts
@@ -19,7 +19,7 @@ export class AndroidAppIdentifier extends AppBuilderDeviceAppDataBase implements
 	public async getDeviceProjectRootPath(): Promise<string> {
 		let deviceTmpDirFormat = "";
 
-		let version = await this.getLiveSyncVersion();
+		const version = await this.getLiveSyncVersion();
 		if (version === 2) {
 			deviceTmpDirFormat = LiveSyncConstants.DEVICE_TMP_DIR_FORMAT_V2;
 		} else if (version === 3) {
@@ -102,7 +102,7 @@ export class IOSAppIdentifier extends AppBuilderDeviceAppDataBase implements ILi
 	@cache()
 	public async getDeviceProjectRootPath(): Promise<string> {
 		if (this.device.isEmulator) {
-			let applicationPath = this.$iOSSimResolver.iOSSim.getApplicationPath(this.device.deviceInfo.identifier, this.appIdentifier);
+			const applicationPath = this.$iOSSimResolver.iOSSim.getApplicationPath(this.device.deviceInfo.identifier, this.appIdentifier);
 			return path.join(applicationPath, "www");
 		}
 
@@ -127,7 +127,7 @@ export class IOSNativeScriptAppIdentifier extends AppBuilderDeviceAppDataBase im
 	@cache()
 	public async getDeviceProjectRootPath(): Promise<string> {
 		if (this.device.isEmulator) {
-			let applicationPath = this.$iOSSimResolver.iOSSim.getApplicationPath(this.device.deviceInfo.identifier, this.appIdentifier);
+			const applicationPath = this.$iOSSimResolver.iOSSim.getApplicationPath(this.device.deviceInfo.identifier, this.appIdentifier);
 			return applicationPath;
 		}
 
@@ -217,7 +217,7 @@ export class DeviceAppDataProvider implements Mobile.IDeviceAppDataProvider {
 	constructor(private $project: any) { }
 
 	public createFactoryRules(): IDictionary<Mobile.IDeviceAppDataFactoryRule> {
-		let rules: IDictionary<IDictionary<Mobile.IDeviceAppDataFactoryRule>> = {
+		const rules: IDictionary<IDictionary<Mobile.IDeviceAppDataFactoryRule>> = {
 			Cordova: {
 				Android: {
 					vanilla: AndroidAppIdentifier,

--- a/appbuilder/providers/project-files-provider.ts
+++ b/appbuilder/providers/project-files-provider.ts
@@ -7,7 +7,7 @@ export class ProjectFilesProvider extends ProjectFilesProviderBase {
 	private _projectDir: string = null;
 	private get projectDir(): string {
 		if (!this._projectDir) {
-			let project = this.$injector.resolve("project");
+			const project = this.$injector.resolve("project");
 			this._projectDir = project.getProjectDir();
 		}
 
@@ -23,7 +23,7 @@ export class ProjectFilesProvider extends ProjectFilesProviderBase {
 	}
 
 	public isFileExcluded(filePath: string): boolean {
-		let exclusionList = ProjectFilesProvider.INTERNAL_NONPROJECT_FILES.concat(this.getIgnoreFilesRules());
+		const exclusionList = ProjectFilesProvider.INTERNAL_NONPROJECT_FILES.concat(this.getIgnoreFilesRules());
 		return this.$pathFilteringService.isFileExcluded(filePath, exclusionList, this.projectDir);
 	}
 
@@ -43,9 +43,9 @@ export class ProjectFilesProvider extends ProjectFilesProviderBase {
 	}
 
 	private get ignoreFilesConfigurations(): string[] {
-		let configurations: string[] = [ProjectFilesProvider.IGNORE_FILE];
+		const configurations: string[] = [ProjectFilesProvider.IGNORE_FILE];
 		// unless release is explicitly set, we use debug config
-		let configFileName = "." +
+		const configFileName = "." +
 			(this.$options.release ? this.$projectConstants.RELEASE_CONFIGURATION_NAME : this.$projectConstants.DEBUG_CONFIGURATION_NAME) +
 			ProjectFilesProvider.IGNORE_FILE;
 		configurations.push(configFileName);

--- a/appbuilder/services/livesync/android-livesync-service.ts
+++ b/appbuilder/services/livesync/android-livesync-service.ts
@@ -11,7 +11,7 @@ export class AppBuilderAndroidLiveSyncService extends AndroidLiveSyncService imp
 	}
 
 	public async refreshApplication(deviceAppData: Mobile.IDeviceAppData): Promise<void> {
-		let commands = [this.liveSyncCommands.SyncFilesCommand()];
+		const commands = [this.liveSyncCommands.SyncFilesCommand()];
 		if (this.$options.watch || this.$options.file) {
 			commands.push(this.liveSyncCommands.RefreshCurrentViewCommand());
 		} else {
@@ -23,10 +23,10 @@ export class AppBuilderAndroidLiveSyncService extends AndroidLiveSyncService imp
 
 	public async removeFiles(appIdentifier: string, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void> {
 		if (localToDevicePaths && localToDevicePaths.length) {
-			let deviceProjectRootPath = localToDevicePaths[0].deviceProjectRootPath;
-			let commands = _.map(localToDevicePaths, ldp => {
+			const deviceProjectRootPath = localToDevicePaths[0].deviceProjectRootPath;
+			const commands = _.map(localToDevicePaths, ldp => {
 
-				let relativePath = path.relative(deviceProjectRootPath, ldp.getDevicePath()),
+				const relativePath = path.relative(deviceProjectRootPath, ldp.getDevicePath()),
 					unixPath = helpers.fromWindowsRelativePathToUnix(relativePath);
 
 				return this.liveSyncCommands.DeleteFile(unixPath);

--- a/appbuilder/services/livesync/companion-apps-service.ts
+++ b/appbuilder/services/livesync/companion-apps-service.ts
@@ -12,8 +12,8 @@ export class CompanionAppsService implements ICompanionAppsService {
 
 	@exported("companionAppsService")
 	public getCompanionAppIdentifier(framework: string, platform: string): string {
-		let lowerCasedFramework = (framework || "").toLowerCase();
-		let lowerCasedPlatform = (platform || "").toLowerCase();
+		const lowerCasedFramework = (framework || "").toLowerCase();
+		const lowerCasedPlatform = (platform || "").toLowerCase();
 
 		if (lowerCasedFramework === TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()) {
 			if (this.$mobileHelper.isAndroidPlatform(lowerCasedPlatform)) {
@@ -34,23 +34,23 @@ export class CompanionAppsService implements ICompanionAppsService {
 
 	@exported("companionAppsService")
 	public getAllCompanionAppIdentifiers(): IDictionary<IStringDictionary> {
-		let platforms = [
+		const platforms = [
 			this.$devicePlatformsConstants.Android,
 			this.$devicePlatformsConstants.iOS,
 			this.$devicePlatformsConstants.WP8
 		];
 
-		let frameworks = [
+		const frameworks = [
 			TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase(),
 			TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()
 		];
 
-		let companionAppIdentifiers: IDictionary<IStringDictionary> = {};
+		const companionAppIdentifiers: IDictionary<IStringDictionary> = {};
 		_.each(frameworks, framework => {
-			let lowerCasedFramework = framework.toLowerCase();
+			const lowerCasedFramework = framework.toLowerCase();
 			companionAppIdentifiers[lowerCasedFramework] = companionAppIdentifiers[lowerCasedFramework] || {};
 			_.each(platforms, platform => {
-				let lowerCasedPlatform = platform.toLowerCase();
+				const lowerCasedPlatform = platform.toLowerCase();
 				companionAppIdentifiers[lowerCasedFramework][lowerCasedPlatform] = this.getCompanionAppIdentifier(lowerCasedFramework, lowerCasedPlatform);
 			});
 		});

--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as shell from "shelljs";
-let osenv = require("osenv");
+const osenv = require("osenv");
 import * as constants from "../../../constants";
 
 export class IOSLiveSyncService implements IDeviceLiveSyncService {
@@ -25,15 +25,15 @@ export class IOSLiveSyncService implements IDeviceLiveSyncService {
 
 	public async refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void> {
 		if (this.device.isEmulator) {
-			let simulatorLogFilePath = path.join(osenv.home(), `/Library/Developer/CoreSimulator/Devices/${this.device.deviceInfo.identifier}/data/Library/Logs/system.log`);
-			let simulatorLogFileContent = this.$fs.readText(simulatorLogFilePath) || "";
+			const simulatorLogFilePath = path.join(osenv.home(), `/Library/Developer/CoreSimulator/Devices/${this.device.deviceInfo.identifier}/data/Library/Logs/system.log`);
+			const simulatorLogFileContent = this.$fs.readText(simulatorLogFilePath) || "";
 
-			let simulatorCachePath = path.join(osenv.home(), `/Library/Developer/CoreSimulator/Devices/${this.device.deviceInfo.identifier}/data/Containers/Data/Application/`);
-			let regex = new RegExp(`^(?:.*?)${deviceAppData.appIdentifier}(?:.*?)${simulatorCachePath}(.*?)$`, "gm");
+			const simulatorCachePath = path.join(osenv.home(), `/Library/Developer/CoreSimulator/Devices/${this.device.deviceInfo.identifier}/data/Containers/Data/Application/`);
+			const regex = new RegExp(`^(?:.*?)${deviceAppData.appIdentifier}(?:.*?)${simulatorCachePath}(.*?)$`, "gm");
 
 			let guid = "";
 			while (true) {
-				let parsed = regex.exec(simulatorLogFileContent);
+				const parsed = regex.exec(simulatorLogFileContent);
 				if (!parsed) {
 					break;
 				}
@@ -45,8 +45,8 @@ export class IOSLiveSyncService implements IDeviceLiveSyncService {
 				this.$errors.failWithoutHelp(`Unable to find application GUID for application ${deviceAppData.appIdentifier}. Make sure application is installed on Simulator.`);
 			}
 
-			let sourcePath = await deviceAppData.getDeviceProjectRootPath();
-			let destinationPath = path.join(simulatorCachePath, guid, constants.LiveSyncConstants.IOS_PROJECT_PATH);
+			const sourcePath = await deviceAppData.getDeviceProjectRootPath();
+			const destinationPath = path.join(simulatorCachePath, guid, constants.LiveSyncConstants.IOS_PROJECT_PATH);
 
 			this.$logger.trace(`Transferring from ${sourcePath} to ${destinationPath}`);
 			shell.cp("-Rf", path.join(sourcePath, "*"), destinationPath);
@@ -54,7 +54,7 @@ export class IOSLiveSyncService implements IDeviceLiveSyncService {
 			await this.device.applicationManager.restartApplication(deviceAppData.appIdentifier);
 		} else {
 			await this.device.fileSystem.deleteFile("/Documents/AppBuilder/ServerInfo.plist", deviceAppData.appIdentifier);
-			let notification = this.$project.projectData.Framework === constants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript ? "com.telerik.app.refreshApp" : "com.telerik.app.refreshWebView";
+			const notification = this.$project.projectData.Framework === constants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript ? "com.telerik.app.refreshApp" : "com.telerik.app.refreshWebView";
 			const notificationData = {
 				deviceId: this.device.deviceInfo.identifier,
 				notificationName: notification,
@@ -67,7 +67,7 @@ export class IOSLiveSyncService implements IDeviceLiveSyncService {
 	public async removeFiles(appIdentifier: string, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void> {
 		const devicePaths = localToDevicePaths.map(localToDevicePath => localToDevicePath.getDevicePath());
 
-		for (let deviceFilePath of devicePaths) {
+		for (const deviceFilePath of devicePaths) {
 			await this.device.fileSystem.deleteFile(deviceFilePath, appIdentifier);
 		}
 	}

--- a/appbuilder/services/livesync/livesync-service.ts
+++ b/appbuilder/services/livesync/livesync-service.ts
@@ -29,13 +29,13 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 	}
 
 	private async liveSyncOnDevice(deviceDescriptor: IDeviceLiveSyncInfo, filePaths: string[], liveSyncOptions?: ILiveSyncDeletionOptions): Promise<IDeviceLiveSyncResult> {
-		let isForDeletedFiles = liveSyncOptions && liveSyncOptions.isForDeletedFiles;
+		const isForDeletedFiles = liveSyncOptions && liveSyncOptions.isForDeletedFiles;
 
-		let result: IDeviceLiveSyncResult = {
+		const result: IDeviceLiveSyncResult = {
 			deviceIdentifier: deviceDescriptor.deviceIdentifier
 		};
 
-		let device = _.find(this.$devicesService.getDeviceInstances(), d => d.deviceInfo.identifier === deviceDescriptor.deviceIdentifier);
+		const device = _.find(this.$devicesService.getDeviceInstances(), d => d.deviceInfo.identifier === deviceDescriptor.deviceIdentifier);
 		if (!device) {
 			result.liveSyncToApp = result.liveSyncToCompanion = {
 				isResolved: false,
@@ -55,7 +55,7 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 		}
 
 		if (!isForDeletedFiles && filePaths && filePaths.length) {
-			let missingFiles = filePaths.filter(filePath => !this.$fs.exists(filePath));
+			const missingFiles = filePaths.filter(filePath => !this.$fs.exists(filePath));
 			if (missingFiles && missingFiles.length) {
 				result.liveSyncToApp = result.liveSyncToCompanion = {
 					isResolved: false,
@@ -66,7 +66,7 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 			}
 		}
 
-		let appIdentifier = await this.$project.getAppIdentifierForPlatform(this.$devicesService.platform),
+		const appIdentifier = await this.$project.getAppIdentifierForPlatform(this.$devicesService.platform),
 			canExecute = (d: Mobile.IDevice) => d.deviceInfo.identifier === device.deviceInfo.identifier,
 			livesyncData: ILiveSyncData = {
 				platform: device.deviceInfo.platform,
@@ -76,7 +76,7 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 				excludedProjectDirsAndFiles: this.excludedProjectDirsAndFiles,
 			};
 
-		let canExecuteAction = await this.$liveSyncServiceBase.getCanExecuteAction(device.deviceInfo.platform, appIdentifier, canExecute);
+		const canExecuteAction = await this.$liveSyncServiceBase.getCanExecuteAction(device.deviceInfo.platform, appIdentifier, canExecute);
 
 		if (deviceDescriptor.syncToApp) {
 			result.liveSyncToApp = await this.liveSyncCore(livesyncData, device, appIdentifier, canExecuteAction, { isForCompanionApp: false, isForDeletedFiles: isForDeletedFiles }, filePaths);
@@ -90,7 +90,7 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 	}
 
 	private async liveSyncCore(livesyncData: ILiveSyncData, device: Mobile.IDevice, appIdentifier: string, canExecuteAction: (dev: Mobile.IDevice) => boolean, liveSyncOptions: ILiveSyncOptions, filePaths: string[]): Promise<ILiveSyncOperationResult> {
-		let liveSyncOperationResult: ILiveSyncOperationResult = {
+		const liveSyncOperationResult: ILiveSyncOperationResult = {
 			isResolved: false
 		};
 
@@ -101,8 +101,8 @@ export class ProtonLiveSyncService implements IProtonLiveSyncService {
 
 		if (await device.applicationManager.isApplicationInstalled(appIdentifier)) {
 
-			let deletedFilesAction: any = liveSyncOptions && liveSyncOptions.isForDeletedFiles ? this.$liveSyncServiceBase.getSyncRemovedFilesAction(livesyncData) : null;
-			let action: any = this.$liveSyncServiceBase.getSyncAction(livesyncData, filePaths, deletedFilesAction, liveSyncOptions);
+			const deletedFilesAction: any = liveSyncOptions && liveSyncOptions.isForDeletedFiles ? this.$liveSyncServiceBase.getSyncRemovedFilesAction(livesyncData) : null;
+			const action: any = this.$liveSyncServiceBase.getSyncAction(livesyncData, filePaths, deletedFilesAction, liveSyncOptions);
 			try {
 				await this.$devicesService.execute(action, canExecuteAction);
 				liveSyncOperationResult.isResolved = true;

--- a/appbuilder/services/npm-service.ts
+++ b/appbuilder/services/npm-service.ts
@@ -39,7 +39,7 @@ export class NpmService implements INpmService {
 
 	@exported("npmService")
 	public async install(projectDir: string, dependencyToInstall?: INpmDependency): Promise<INpmInstallResult> {
-		let npmInstallResult: INpmInstallResult = {};
+		const npmInstallResult: INpmInstallResult = {};
 
 		if (dependencyToInstall) {
 			npmInstallResult.result = {
@@ -78,7 +78,7 @@ export class NpmService implements INpmService {
 
 	@exported("npmService")
 	public async uninstall(projectDir: string, dependency: string): Promise<void> {
-		let packageJsonContent = this.getPackageJsonContent(projectDir);
+		const packageJsonContent = this.getPackageJsonContent(projectDir);
 
 		if (packageJsonContent && packageJsonContent.dependencies && packageJsonContent.dependencies[dependency]) {
 			await this.npmUninstall(projectDir, dependency, ["--save"]);
@@ -93,12 +93,12 @@ export class NpmService implements INpmService {
 
 	public async search(projectDir: string, keywords: string[], args?: string[]): Promise<IBasicPluginInformation[]> {
 		args = args === undefined ? [] : args;
-		let result: IBasicPluginInformation[] = [];
-		let commandArguments = _.concat(["search"], args, keywords);
-		let spawnResult = await this.executeNpmCommandCore(projectDir, commandArguments);
+		const result: IBasicPluginInformation[] = [];
+		const commandArguments = _.concat(["search"], args, keywords);
+		const spawnResult = await this.executeNpmCommandCore(projectDir, commandArguments);
 		if (spawnResult.stderr) {
 			// npm will write "npm WARN Building the local index for the first time, please be patient" to the stderr and if it is the only message on the stderr we should ignore it.
-			let splitError = spawnResult.stderr.trim().split("\n");
+			const splitError = spawnResult.stderr.trim().split("\n");
 			if (splitError.length > 1 || splitError[0].indexOf("Building the local index for the first time") === -1) {
 				this.$errors.failWithoutHelp(spawnResult.stderr);
 			}
@@ -108,21 +108,21 @@ export class NpmService implements INpmService {
 		// Sample output:
 		// NAME                    DESCRIPTION             AUTHOR        DATE       VERSION  KEYWORDS
 		// cordova-plugin-console  Cordova Console Plugin  =csantanapr…  2016-04-20 1.0.3    cordova console ecosystem:cordova cordova-ios
-		let pluginsRows: string[] = spawnResult.stdout.split("\n");
+		const pluginsRows: string[] = spawnResult.stdout.split("\n");
 
 		// Remove the table headers row.
 		pluginsRows.shift();
 
-		let npmNameGroup = "(\\S+)";
-		let npmDateGroup = "(\\d+-\\d+-\\d+)\\s";
-		let npmFreeTextGroup = "([^=]+)";
-		let npmAuthorsGroup = "((?:=\\S+\\s?)+)\\s+";
+		const npmNameGroup = "(\\S+)";
+		const npmDateGroup = "(\\d+-\\d+-\\d+)\\s";
+		const npmFreeTextGroup = "([^=]+)";
+		const npmAuthorsGroup = "((?:=\\S+\\s?)+)\\s+";
 
 		// Should look like this /(\S+)\s+([^=]+)((?:=\S+\s?)+)\s+(\d+-\d+-\d+)\s(\S+)(\s+([^=]+))?/
-		let pluginRowRegExp = new RegExp(`${npmNameGroup}\\s+${npmFreeTextGroup}${npmAuthorsGroup}${npmDateGroup}${npmNameGroup}(\\s+${npmFreeTextGroup})?`);
+		const pluginRowRegExp = new RegExp(`${npmNameGroup}\\s+${npmFreeTextGroup}${npmAuthorsGroup}${npmDateGroup}${npmNameGroup}(\\s+${npmFreeTextGroup})?`);
 
 		_.each(pluginsRows, (pluginRow: string) => {
-			let matches = pluginRowRegExp.exec(pluginRow.trim());
+			const matches = pluginRowRegExp.exec(pluginRow.trim());
 
 			if (!matches || !matches[0]) {
 				return;
@@ -172,14 +172,14 @@ export class NpmService implements INpmService {
 	}
 
 	public isScopedDependency(dependency: string): boolean {
-		let matches = dependency.match(NpmService.SCOPED_DEPENDENCY_REGEXP);
+		const matches = dependency.match(NpmService.SCOPED_DEPENDENCY_REGEXP);
 
 		return !!(matches && matches[0]);
 	}
 
 	public getDependencyInformation(dependency: string): IDependencyInformation {
-		let regExp = this.isScopedDependency(dependency) ? NpmService.SCOPED_DEPENDENCY_REGEXP : NpmService.DEPENDENCY_REGEXP;
-		let matches = dependency.match(regExp);
+		const regExp = this.isScopedDependency(dependency) ? NpmService.SCOPED_DEPENDENCY_REGEXP : NpmService.DEPENDENCY_REGEXP;
+		const matches = dependency.match(regExp);
 
 		return {
 			name: matches[1],
@@ -219,7 +219,7 @@ export class NpmService implements INpmService {
 	}
 
 	private getPackageJsonContent(projectDir: string): any {
-		let pathToPackageJson = this.getPathToPackageJson(projectDir);
+		const pathToPackageJson = this.getPathToPackageJson(projectDir);
 
 		try {
 			return this.$fs.readJson(pathToPackageJson);
@@ -245,13 +245,13 @@ export class NpmService implements INpmService {
 	}
 
 	private generateReferencesFile(projectDir: string): void {
-		let packageJsonContent = this.getPackageJsonContent(projectDir);
+		const packageJsonContent = this.getPackageJsonContent(projectDir);
 
-		let pathToReferenceFile = this.getPathToReferencesFile(projectDir),
-			lines: string[] = [];
+		const pathToReferenceFile = this.getPathToReferencesFile(projectDir);
+		let lines: string[] = [];
 
 		if (packageJsonContent && packageJsonContent.dependencies && packageJsonContent.dependencies[constants.TNS_CORE_MODULES]) {
-			let relativePathToTnsCoreModulesDts = `./${constants.NODE_MODULES_DIR_NAME}/${constants.TNS_CORE_MODULES}/${NpmService.TNS_CORE_MODULES_DEFINITION_FILE_NAME}`;
+			const relativePathToTnsCoreModulesDts = `./${constants.NODE_MODULES_DIR_NAME}/${constants.TNS_CORE_MODULES}/${NpmService.TNS_CORE_MODULES_DEFINITION_FILE_NAME}`;
 
 			if (this.$fs.exists(path.join(projectDir, relativePathToTnsCoreModulesDts))) {
 				lines.push(this.getReferenceLine(relativePathToTnsCoreModulesDts));
@@ -262,11 +262,11 @@ export class NpmService implements INpmService {
 			.keys()
 			.each(devDependency => {
 				if (this.isFromTypesRepo(devDependency)) {
-					let nodeModulesDirectory = path.join(projectDir, constants.NODE_MODULES_DIR_NAME);
-					let definitionFiles = this.$fs.enumerateFilesInDirectorySync(path.join(nodeModulesDirectory, devDependency),
+					const nodeModulesDirectory = path.join(projectDir, constants.NODE_MODULES_DIR_NAME);
+					const definitionFiles = this.$fs.enumerateFilesInDirectorySync(path.join(nodeModulesDirectory, devDependency),
 						(file, stat) => _.endsWith(file, constants.FileExtensions.TYPESCRIPT_DEFINITION_FILE) || stat.isDirectory(), { enumerateDirectories: false });
 
-					let defs = _.map(definitionFiles, def => this.getReferenceLine(fromWindowsRelativePathToUnix(path.relative(projectDir, def))));
+					const defs = _.map(definitionFiles, def => this.getReferenceLine(fromWindowsRelativePathToUnix(path.relative(projectDir, def))));
 
 					this.$logger.trace(`Adding lines for definition files: ${definitionFiles.join(", ")}`);
 					lines = lines.concat(defs);

--- a/appbuilder/services/path-filtering.ts
+++ b/appbuilder/services/path-filtering.ts
@@ -5,11 +5,11 @@ export class PathFilteringService implements IPathFilteringService {
 	constructor(private $fs: IFileSystem) { }
 
 	public getRulesFromFile(fullFilePath: string): string[] {
-		let COMMENT_START = '#';
+		const COMMENT_START = '#';
 		let rules: string[] = [];
 
 		try {
-			let fileContent = this.$fs.readText(fullFilePath);
+			const fileContent = this.$fs.readText(fullFilePath);
 			rules = _.reject(fileContent.split(/[\n\r]/),
 				(line: string) => line.length === 0 || line[0] === COMMENT_START);
 
@@ -33,20 +33,20 @@ export class PathFilteringService implements IPathFilteringService {
 			// minimatch treats starting '!' as pattern negation
 			// but we want the pattern matched and then do something else with the file
 			// therefore, we manually handle leading ! and \! and hide them from minimatch
-			let shouldInclude = rule[0] === '!';
+			const shouldInclude = rule[0] === '!';
 			if (shouldInclude) {
 				rule = rule.substr(1);
-				let ruleMatched = minimatch(file, rule, { nocase: true, dot: true });
+				const ruleMatched = minimatch(file, rule, { nocase: true, dot: true });
 				if (ruleMatched) {
 					fileMatched = true;
 				}
 			} else {
-				let options = { nocase: true, nonegate: false, dot: true };
+				const options = { nocase: true, nonegate: false, dot: true };
 				if (rule[0] === '\\' && rule[1] === '!') {
 					rule = rule.substr(1);
 					options.nonegate = true;
 				}
-				let ruleMatched = minimatch(file, rule, options);
+				const ruleMatched = minimatch(file, rule, options);
 				fileMatched = fileMatched && !ruleMatched;
 			}
 		});

--- a/child-process.ts
+++ b/child-process.ts
@@ -9,13 +9,13 @@ export class ChildProcess extends EventEmitter implements IChildProcess {
 
 	public async exec(command: string, options?: any, execOptions?: IExecOptions): Promise<any> {
 		return new Promise<any>((resolve, reject) => {
-			let callback = (error: Error, stdout: NodeBuffer, stderr: NodeBuffer) => {
+			const callback = (error: Error, stdout: NodeBuffer, stderr: NodeBuffer) => {
 				this.$logger.trace("Exec %s \n stdout: %s \n stderr: %s", command, stdout.toString(), stderr.toString());
 
 				if (error) {
 					reject(error);
 				} else {
-					let output = execOptions && execOptions.showStderr ? { stdout, stderr } : stdout;
+					const output = execOptions && execOptions.showStderr ? { stdout, stderr } : stdout;
 					resolve(output);
 				}
 			};
@@ -58,7 +58,7 @@ export class ChildProcess extends EventEmitter implements IChildProcess {
 		options?: any, spawnFromEventOptions?: ISpawnFromEventOptions): Promise<ISpawnResult> { // event should be exit or close
 
 		return new Promise<ISpawnResult>((resolve, reject) => {
-			let childProcess = this.spawn(command, args, options);
+			const childProcess = this.spawn(command, args, options);
 			let isResolved = false;
 			let capturedOut = "";
 			let capturedErr = "";
@@ -84,8 +84,8 @@ export class ChildProcess extends EventEmitter implements IChildProcess {
 			}
 
 			childProcess.on(event, (arg: any) => {
-				let exitCode = typeof arg === "number" ? arg : arg && arg.code;
-				let result = {
+				const exitCode = typeof arg === "number" ? arg : arg && arg.code;
+				const result = {
 					stdout: capturedOut,
 					stderr: capturedErr,
 					exitCode: exitCode
@@ -119,7 +119,7 @@ export class ChildProcess extends EventEmitter implements IChildProcess {
 			childProcess.once("error", (err: Error) => {
 				if (!isResolved) {
 					if (spawnFromEventOptions && spawnFromEventOptions.throwError === false) {
-						let result = {
+						const result = {
 							stdout: capturedOut,
 							stderr: err.message,
 							exitCode: (<any>err).code
@@ -138,7 +138,7 @@ export class ChildProcess extends EventEmitter implements IChildProcess {
 
 	public async tryExecuteApplication(command: string, args: string[], event: string,
 		errorMessage: string, condition: (_childProcess: any) => boolean): Promise<any> {
-		let childProcess = await this.tryExecuteApplicationCore(command, args, event, errorMessage);
+		const childProcess = await this.tryExecuteApplicationCore(command, args, event, errorMessage);
 
 		if (condition && condition(childProcess)) {
 			this.$errors.fail(errorMessage);
@@ -149,7 +149,7 @@ export class ChildProcess extends EventEmitter implements IChildProcess {
 		try {
 			return this.spawnFromEvent(command, args, event, undefined, { throwError: false });
 		} catch (e) {
-			let message = (e.code === "ENOENT") ? errorMessage : e.message;
+			const message = (e.code === "ENOENT") ? errorMessage : e.message;
 			this.$errors.failWithoutHelp(message);
 		}
 	}

--- a/codeGeneration/code-entity.ts
+++ b/codeGeneration/code-entity.ts
@@ -47,7 +47,7 @@ export class Block implements CodeGeneration.IBlock {
 	}
 
 	public writeLine(content: string): void {
-		let line = Line.create(content);
+		const line = Line.create(content);
 		this.codeEntities.push(line);
 	}
 }

--- a/command-params.ts
+++ b/command-params.ts
@@ -22,7 +22,7 @@ export class StringParameterBuilder implements IStringParameterBuilder {
 	constructor(private $injector: IInjector) { }
 
 	public createMandatoryParameter(errorMsg: string): ICommandParameter {
-		let commandParameter = new StringCommandParameter(this.$injector);
+		const commandParameter = new StringCommandParameter(this.$injector);
 		commandParameter.mandatory = true;
 		commandParameter.errorMessage = errorMsg;
 

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -2,7 +2,7 @@ export class AnalyticsCommandParameter implements ICommandParameter {
 	constructor(private $errors: IErrors) { }
 	mandatory = false;
 	async validate(validationValue: string): Promise<boolean> {
-		let val = validationValue || "";
+		const val = validationValue || "";
 		switch (val.toLowerCase()) {
 			case "enable":
 			case "disable":
@@ -27,7 +27,7 @@ class AnalyticsCommand implements ICommand {
 	public disableAnalytics = true;
 
 	public async execute(args: string[]): Promise<void> {
-		let arg = args[0] || "";
+		const arg = args[0] || "";
 		switch (arg.toLowerCase()) {
 			case "enable":
 				await this.$analyticsService.setStatus(this.settingName, true);

--- a/commands/autocompletion.ts
+++ b/commands/autocompletion.ts
@@ -20,9 +20,9 @@ export class AutoCompleteCommand implements ICommand {
 				}
 			} else {
 				this.$logger.out("If you are using bash or zsh, you can enable command-line completion.");
-				let message = "Do you want to enable it now?";
+				const message = "Do you want to enable it now?";
 
-				let autoCompetionStatus = await this.$prompter.confirm(message, () => true);
+				const autoCompetionStatus = await this.$prompter.confirm(message, () => true);
 				if (autoCompetionStatus) {
 					await this.$autoCompletionService.enableAutoCompletion();
 				} else {

--- a/commands/device/device-log-stream.ts
+++ b/commands/device/device-log-stream.ts
@@ -20,7 +20,7 @@ export class OpenDeviceLogStreamCommand implements ICommand {
 			this.$errors.fail(OpenDeviceLogStreamCommand.NOT_SPECIFIED_DEVICE_ERROR_MESSAGE);
 		}
 
-		let action = (device: Mobile.IDevice) => device.openDeviceLogStream();
+		const action = (device: Mobile.IDevice) => device.openDeviceLogStream();
 		await this.$devicesService.execute(action);
 	}
 }

--- a/commands/device/get-file.ts
+++ b/commands/device/get-file.ts
@@ -17,7 +17,7 @@ export class GetFileCommand implements ICommand {
 
 		appIdentifier = appIdentifier || this.$project.projectData.AppIdentifier;
 
-		let action = (device: Mobile.IDevice) => device.fileSystem.getFile(args[0], appIdentifier, this.$options.file);
+		const action = (device: Mobile.IDevice) => device.fileSystem.getFile(args[0], appIdentifier, this.$options.file);
 		await this.$devicesService.execute(action);
 	}
 }

--- a/commands/device/list-applications.ts
+++ b/commands/device/list-applications.ts
@@ -10,10 +10,10 @@ export class ListApplicationsCommand implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		await this.$devicesService.initialize({ deviceId: this.$options.device, skipInferPlatform: true });
-		let output: string[] = [];
+		const output: string[] = [];
 
-		let action = async (device: Mobile.IDevice) => {
-			let applications = await device.applicationManager.getInstalledApplications();
+		const action = async (device: Mobile.IDevice) => {
+			const applications = await device.applicationManager.getInstalledApplications();
 			output.push(util.format("%s=====Installed applications on device with UDID '%s' are:", EOL, device.deviceInfo.identifier));
 			_.each(applications, (applicationId: string) => output.push(applicationId));
 		};

--- a/commands/device/list-devices.ts
+++ b/commands/device/list-devices.ts
@@ -19,7 +19,7 @@ export class ListDevicesCommand implements ICommand {
 		let index = 1;
 		await this.$devicesService.initialize({ platform: args[0], deviceId: null, skipInferPlatform: true, skipDeviceDetectionInterval: true, skipEmulatorStart: true });
 
-		let table: any = createTable(["#", "Device Name", "Platform", "Device Identifier", "Type", "Status"], []);
+		const table: any = createTable(["#", "Device Name", "Platform", "Device Identifier", "Type", "Status"], []);
 		let action: (_device: Mobile.IDevice) => Promise<void>;
 		if (this.$options.json) {
 			this.$logger.setLevel("ERROR");
@@ -51,8 +51,8 @@ class ListAndroidDevicesCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
-		let listDevicesCommand: ICommand = this.$injector.resolve(ListDevicesCommand);
-		let platform = this.$devicePlatformsConstants.Android;
+		const listDevicesCommand: ICommand = this.$injector.resolve(ListDevicesCommand);
+		const platform = this.$devicePlatformsConstants.Android;
 		await listDevicesCommand.execute([platform]);
 	}
 }
@@ -66,8 +66,8 @@ class ListiOSDevicesCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
-		let listDevicesCommand: ICommand = this.$injector.resolve(ListDevicesCommand);
-		let platform = this.$devicePlatformsConstants.iOS;
+		const listDevicesCommand: ICommand = this.$injector.resolve(ListDevicesCommand);
+		const platform = this.$devicePlatformsConstants.iOS;
 		await listDevicesCommand.execute([platform]);
 	}
 }

--- a/commands/device/list-files.ts
+++ b/commands/device/list-files.ts
@@ -18,7 +18,7 @@ export class ListFilesCommand implements ICommand {
 
 		appIdentifier = appIdentifier || this.$project.projectData.AppIdentifier;
 
-		let action = (device: Mobile.IDevice) => device.fileSystem.listFiles(pathToList, appIdentifier);
+		const action = (device: Mobile.IDevice) => device.fileSystem.listFiles(pathToList, appIdentifier);
 		await this.$devicesService.execute(action);
 	}
 }

--- a/commands/device/put-file.ts
+++ b/commands/device/put-file.ts
@@ -16,7 +16,7 @@ export class PutFileCommand implements ICommand {
 		}
 
 		appIdentifier = appIdentifier || this.$project.projectData.AppIdentifier;
-		let action = (device: Mobile.IDevice) => device.fileSystem.putFile(args[0], args[1], appIdentifier);
+		const action = (device: Mobile.IDevice) => device.fileSystem.putFile(args[0], args[1], appIdentifier);
 		await this.$devicesService.execute(action);
 	}
 }

--- a/commands/device/stop-application.ts
+++ b/commands/device/stop-application.ts
@@ -9,7 +9,7 @@ export class StopApplicationOnDeviceCommand implements ICommand {
 	public async execute(args: string[]): Promise<void> {
 		await this.$devicesService.initialize({ deviceId: this.$options.device, skipInferPlatform: true, platform: args[1] });
 
-		let action = (device: Mobile.IDevice) => device.applicationManager.stopApplication(args[0]);
+		const action = (device: Mobile.IDevice) => device.applicationManager.stopApplication(args[0]);
 		await this.$devicesService.execute(action);
 	}
 }

--- a/commands/device/uninstall-application.ts
+++ b/commands/device/uninstall-application.ts
@@ -8,7 +8,7 @@ export class UninstallApplicationCommand implements ICommand {
 	public async execute(args: string[]): Promise<void> {
 		await this.$devicesService.initialize({ deviceId: this.$options.device, skipInferPlatform: true });
 
-		let action = (device: Mobile.IDevice) => device.applicationManager.uninstallApplication(args[0]);
+		const action = (device: Mobile.IDevice) => device.applicationManager.uninstallApplication(args[0]);
 		await this.$devicesService.execute(action);
 	}
 }

--- a/commands/doctor.ts
+++ b/commands/doctor.ts
@@ -13,9 +13,9 @@ export class DoctorCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
-		let warningsPrinted = await this.$doctorService.printWarnings();
+		const warningsPrinted = await this.$doctorService.printWarnings();
 		if (warningsPrinted) {
-			let client = this.$staticConfig.CLIENT_NAME_ALIAS || this.$staticConfig.CLIENT_NAME;
+			const client = this.$staticConfig.CLIENT_NAME_ALIAS || this.$staticConfig.CLIENT_NAME;
 			this.$logger.out(`When you file an issue, these warnings will help the ${client} team to investigate, identify, and resolve the report.`.bold
 				+ EOL + `Please, ignore them if you are not experiencing any issues with ${client}.`.bold + EOL);
 		} else {

--- a/commands/generate-messages.ts
+++ b/commands/generate-messages.ts
@@ -12,11 +12,11 @@ export class GenerateMessages implements ICommand {
 	allowedParameters: ICommandParameter[] = [];
 
 	async execute(args: string[]): Promise<void> {
-		let result = await this.$messageContractGenerator.generate(),
-			innerMessagesDirectory = path.join(__dirname, "../messages"),
-			outerMessagesDirectory = path.join(__dirname, "../.."),
-			interfaceFilePath: string,
-			implementationFilePath: string;
+		const result = await this.$messageContractGenerator.generate();
+		const innerMessagesDirectory = path.join(__dirname, "../messages");
+		const outerMessagesDirectory = path.join(__dirname, "../..");
+		let interfaceFilePath: string;
+		let implementationFilePath: string;
 
 		if (this.$options.default) {
 			interfaceFilePath = path.join(innerMessagesDirectory, GenerateMessages.MESSAGES_DEFINITIONS_FILE_NAME);

--- a/commands/help.ts
+++ b/commands/help.ts
@@ -16,13 +16,13 @@ export class HelpCommand implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		let topic = (args[0] || "").toLowerCase();
-		let hierarchicalCommand = this.$injector.buildHierarchicalCommand(args[0], _.tail(args));
+		const hierarchicalCommand = this.$injector.buildHierarchicalCommand(args[0], _.tail(args));
 		if (hierarchicalCommand) {
 			topic = hierarchicalCommand.commandName;
 		}
 
 		if (this.$options.help) {
-			let help = await this.$htmlHelpService.getCommandLineHelpForCommand(topic);
+			const help = await this.$htmlHelpService.getCommandLineHelpForCommand(topic);
 			if (this.$staticConfig.FULL_CLIENT_NAME) {
 				this.$logger.info(this.$staticConfig.FULL_CLIENT_NAME.green.bold + EOL);
 			}

--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -24,7 +24,7 @@ export class PostInstallCommand implements ICommand {
 
 		await this.$htmlHelpService.generateHtmlPages();
 
-		let doctorResult = await this.$doctorService.printWarnings({ trackResult: false });
+		const doctorResult = await this.$doctorService.printWarnings({ trackResult: false });
 		// Explicitly ask for confirmation of usage-reporting:
 		await this.$analyticsService.checkConsent();
 

--- a/commands/proxy/proxy-set.ts
+++ b/commands/proxy/proxy-set.ts
@@ -27,9 +27,9 @@ export class ProxySetCommand extends ProxyCommandBase {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		let urlString = args[0],
-			username = args[1],
-			password = args[2];
+		let urlString = args[0];
+		let username = args[1];
+		let password = args[2];
 
 		const noUrl = !urlString;
 		if (noUrl) {
@@ -105,7 +105,7 @@ export class ProxySetCommand extends ProxyCommandBase {
 		}
 
 		const clientName = this.$staticConfig.CLIENT_NAME.toLowerCase();
-		let messageNote = (clientName === "tns" ?
+		const messageNote = (clientName === "tns" ?
 			"Note that 'npm' and 'Gradle' need to be configured separately to work with a proxy." :
 			"Note that `npm` needs to be configured separately to work with a proxy.") + EOL;
 

--- a/config-base.ts
+++ b/config-base.ts
@@ -6,7 +6,7 @@ export class ConfigBase implements Config.IConfig {
 	constructor(protected $fs: IFileSystem) { }
 
 	protected loadConfig(name: string): any {
-		let configFileName = this.getConfigPath(name);
+		const configFileName = this.getConfigPath(name);
 		return this.$fs.readJson(configFileName);
 	}
 

--- a/decorators.ts
+++ b/decorators.ts
@@ -27,12 +27,12 @@
 export function cache(): any {
 	return (target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>): TypedPropertyDescriptor<any> => {
 		let result: any;
-		let propName: string = descriptor.value ? "value" : "get";
+		const propName: string = descriptor.value ? "value" : "get";
 
 		const originalValue = (<any>descriptor)[propName];
 
 		(<any>descriptor)[propName] = function (...args: any[]) {
-			let propertyName = `__isCalled_${propertyKey}__`;
+			const propertyName = `__isCalled_${propertyKey}__`;
 			if (this && !this[propertyName]) {
 				this[propertyName] = true;
 				result = originalValue.apply(this, args);
@@ -73,7 +73,7 @@ export function exported(moduleName: string): any {
 	return (target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>): TypedPropertyDescriptor<any> => {
 		$injector.publicApi.__modules__[moduleName] = $injector.publicApi.__modules__[moduleName] || {};
 		$injector.publicApi.__modules__[moduleName][propertyKey] = (...args: any[]): any => {
-			let originalModule = $injector.resolve(moduleName),
+			const originalModule = $injector.resolve(moduleName),
 				originalMethod: any = originalModule[propertyKey],
 				result = originalMethod.apply(originalModule, args);
 

--- a/dispatchers.ts
+++ b/dispatchers.ts
@@ -17,14 +17,14 @@ export class CommandDispatcher implements ICommandDispatcher {
 
 		if (this.$logger.getLevel() === "TRACE") {
 			// CommandDispatcher is called from external CLI's only, so pass the path to their package.json
-			let sysInfo = await this.$sysInfo.getSysInfo(path.join(__dirname, "..", "..", "package.json"));
+			const sysInfo = await this.$sysInfo.getSysInfo(path.join(__dirname, "..", "..", "package.json"));
 			this.$logger.trace("System information:");
 			this.$logger.trace(sysInfo);
 		}
 
 		let commandName = this.getCommandName();
-		let commandArguments = this.$options.argv._.slice(1);
-		let lastArgument: string = _.last(commandArguments);
+		const commandArguments = this.$options.argv._.slice(1);
+		const lastArgument: string = _.last(commandArguments);
 
 		if (this.$options.help) {
 			commandArguments.unshift(commandName);
@@ -45,7 +45,7 @@ export class CommandDispatcher implements ICommandDispatcher {
 	}
 
 	private getCommandName(): string {
-		let remaining: string[] = this.$options.argv._;
+		const remaining: string[] = this.$options.argv._;
 		if (remaining.length > 0) {
 			return remaining[0].toString().toLowerCase();
 		}
@@ -57,7 +57,7 @@ export class CommandDispatcher implements ICommandDispatcher {
 	private printVersion(): void {
 		let version = this.$staticConfig.version;
 
-		let json = this.$fs.readJson(this.$staticConfig.pathToPackageJson);
+		const json = this.$fs.readJson(this.$staticConfig.pathToPackageJson);
 		if (json && json.buildVersion) {
 			version = `${version}-${json.buildVersion}`;
 		}
@@ -78,7 +78,7 @@ class FutureDispatcher implements IFutureDispatcher {
 		this.actions = new queue.Queue<any>();
 
 		while (true) {
-			let action = await this.actions.dequeue();
+			const action = await this.actions.dequeue();
 			await action();
 		}
 	}

--- a/errors.ts
+++ b/errors.ts
@@ -10,8 +10,8 @@ function Exception() {
 Exception.prototype = new Error();
 
 function resolveCallStack(error: Error): string {
-	let stackLines: string[] = error.stack.split("\n");
-	let parsed = _.map(stackLines, (line: string): any => {
+	const stackLines: string[] = error.stack.split("\n");
+	const parsed = _.map(stackLines, (line: string): any => {
 		let match = line.match(/^\s*at ([^(]*) \((.*?):([0-9]+):([0-9]+)\)$/);
 		if (match) {
 			return match;
@@ -26,29 +26,29 @@ function resolveCallStack(error: Error): string {
 		return line;
 	});
 
-	let fs = require("fs");
+	const fs = require("fs");
 
-	let remapped = _.map(parsed, (parsedLine) => {
+	const remapped = _.map(parsed, (parsedLine) => {
 		if (_.isString(parsedLine)) {
 			return parsedLine;
 		}
 
-		let functionName = parsedLine[1];
-		let fileName = parsedLine[2];
-		let line = +parsedLine[3];
-		let column = +parsedLine[4];
+		const functionName = parsedLine[1];
+		const fileName = parsedLine[2];
+		const line = +parsedLine[3];
+		const column = +parsedLine[4];
 
-		let mapFileName = fileName + ".map";
+		const mapFileName = fileName + ".map";
 		if (!fs.existsSync(mapFileName)) {
 			return parsedLine.input;
 		}
 
-		let mapData = JSON.parse(fs.readFileSync(mapFileName).toString());
+		const mapData = JSON.parse(fs.readFileSync(mapFileName).toString());
 
-		let consumer = new SourceMapConsumer(mapData);
-		let sourcePos = consumer.originalPositionFor({ line: line, column: column });
+		const consumer = new SourceMapConsumer(mapData);
+		const sourcePos = consumer.originalPositionFor({ line: line, column: column });
 		if (sourcePos && sourcePos.source) {
-			let source = path.join(path.dirname(fileName), sourcePos.source);
+			const source = path.join(path.dirname(fileName), sourcePos.source);
 			return util.format("    at %s (%s:%s:%s)", functionName, source, sourcePos.line, sourcePos.column);
 		}
 
@@ -66,7 +66,7 @@ function resolveCallStack(error: Error): string {
 }
 
 export function installUncaughtExceptionListener(actionOnException?: () => void): void {
-	let handler = async (err: Error) => {
+	const handler = async (err: Error) => {
 		try {
 			let callstack = err.stack;
 			if (callstack) {
@@ -107,7 +107,7 @@ async function tryTrackException(error: Error, injector: IInjector): Promise<voi
 
 	if (!disableAnalytics) {
 		try {
-			let analyticsService = injector.resolve("analyticsService");
+			const analyticsService = injector.resolve("analyticsService");
 			await analyticsService.trackException(error, error.message);
 		} catch (e) {
 			// Do not replace with logger due to cyclic dependency
@@ -130,7 +130,7 @@ export class Errors implements IErrors {
 			opts = { formatStr: opts };
 		}
 
-		let exception: any = new (<any>Exception)();
+		const exception: any = new (<any>Exception)();
 		exception.name = opts.name || "Exception";
 		exception.message = util.format.apply(null, [opts.formatStr].concat(argsArray));
 		try {
@@ -155,8 +155,8 @@ export class Errors implements IErrors {
 		try {
 			return await action();
 		} catch (ex) {
-			let loggerLevel: string = $injector.resolve("logger").getLevel().toUpperCase();
-			let printCallStack = this.printCallStack || loggerLevel === "TRACE" || loggerLevel === "DEBUG";
+			const loggerLevel: string = $injector.resolve("logger").getLevel().toUpperCase();
+			const printCallStack = this.printCallStack || loggerLevel === "TRACE" || loggerLevel === "DEBUG";
 			console.error(printCallStack
 				? resolveCallStack(ex)
 				: "\x1B[31;1m" + ex.message + "\x1B[0m");

--- a/file-system.ts
+++ b/file-system.ts
@@ -18,20 +18,20 @@ export class FileSystem implements IFileSystem {
 	//TODO: try 'archiver' module for zipping
 	public async zipFiles(zipFile: string, files: string[], zipPathCallback: (path: string) => string): Promise<void> {
 		//we are resolving it here instead of in the constructor, because config has dependency on file system and config shouldn't require logger
-		let $logger = this.$injector.resolve("logger");
-		let zipstream = require("zipstream");
-		let zip = zipstream.createZip({ level: 9 });
-		let outFile = fs.createWriteStream(zipFile);
+		const $logger = this.$injector.resolve("logger");
+		const zipstream = require("zipstream");
+		const zip = zipstream.createZip({ level: 9 });
+		const outFile = fs.createWriteStream(zipFile);
 		zip.pipe(outFile);
 
 		return new Promise<void>((resolve, reject) => {
 			outFile.on("error", (err: Error) => reject(err));
 
 			let fileIdx = -1;
-			let zipCallback = () => {
+			const zipCallback = () => {
 				fileIdx++;
 				if (fileIdx < files.length) {
-					let file = files[fileIdx];
+					const file = files[fileIdx];
 
 					let relativePath = zipPathCallback(file);
 					relativePath = relativePath.replace(/\\/g, "/");
@@ -61,9 +61,9 @@ export class FileSystem implements IFileSystem {
 
 	public async unzip(zipFile: string, destinationDir: string, options?: { overwriteExisitingFiles?: boolean; caseSensitive?: boolean },
 		fileFilters?: string[]): Promise<void> {
-		let shouldOverwriteFiles = !(options && options.overwriteExisitingFiles === false);
-		let isCaseSensitive = !(options && options.caseSensitive === false);
-		let $hostInfo = this.$injector.resolve("$hostInfo");
+		const shouldOverwriteFiles = !(options && options.overwriteExisitingFiles === false);
+		const isCaseSensitive = !(options && options.caseSensitive === false);
+		const $hostInfo = this.$injector.resolve("$hostInfo");
 
 		this.createDirectory(destinationDir);
 
@@ -80,7 +80,7 @@ export class FileSystem implements IFileSystem {
 			zipFile = this.findFileCaseInsensitive(zipFile);
 		}
 
-		let args = _.flatten<string>(["-b",
+		const args = _.flatten<string>(["-b",
 			shouldOverwriteFiles ? "-o" : "-n",
 			isCaseSensitive ? [] : "-C",
 			zipFile,
@@ -88,16 +88,16 @@ export class FileSystem implements IFileSystem {
 			"-d",
 			destinationDir]);
 
-		let $childProcess = this.$injector.resolve("childProcess");
+		const $childProcess = this.$injector.resolve("childProcess");
 		await $childProcess.spawnFromEvent(proc, args, "close", { stdio: "ignore", detached: true });
 	}
 
 	private findFileCaseInsensitive(file: string): string {
-		let dir = path.dirname(file);
-		let basename = path.basename(file);
-		let entries = this.readDirectory(dir);
-		let match = minimatch.match(entries, basename, { nocase: true, nonegate: true, nonull: true })[0];
-		let result = path.join(dir, match);
+		const dir = path.dirname(file);
+		const basename = path.basename(file);
+		const entries = this.readDirectory(dir);
+		const match = minimatch.match(entries, basename, { nocase: true, nonegate: true, nonull: true })[0];
+		const result = path.join(dir, match);
 		return result;
 	}
 
@@ -126,17 +126,17 @@ export class FileSystem implements IFileSystem {
 	}
 
 	public getFileSize(path: string): number {
-		let stat = this.getFsStats(path);
+		const stat = this.getFsStats(path);
 		return stat.size;
 	}
 
 	public async futureFromEvent(eventEmitter: any, event: string): Promise<any> {
 		return new Promise((resolve, reject) => {
 			eventEmitter.once(event, function () {
-				let args = _.toArray(arguments);
+				const args = _.toArray(arguments);
 
 				if (event === "error") {
-					let err = <Error>args[0];
+					const err = <Error>args[0];
 					reject(err);
 					return;
 				}
@@ -183,7 +183,7 @@ export class FileSystem implements IFileSystem {
 	}
 
 	public readJson(filename: string, encoding?: string): any {
-		let data = this.readText(filename, encoding);
+		const data = this.readText(filename, encoding);
 		if (data) {
 			// Replace BOM from the header of the file if it exists
 			return JSON.parse(data.replace(/^\uFEFF/, ""));
@@ -260,11 +260,11 @@ export class FileSystem implements IFileSystem {
 		if (!this.exists(baseName)) {
 			return baseName;
 		}
-		let extension = path.extname(baseName);
-		let prefix = path.basename(baseName, extension);
+		const extension = path.extname(baseName);
+		const prefix = path.basename(baseName, extension);
 
 		for (let i = 2; ; ++i) {
-			let numberedName = prefix + i + extension;
+			const numberedName = prefix + i + extension;
 			if (!this.exists(numberedName)) {
 				return numberedName;
 			}
@@ -272,13 +272,13 @@ export class FileSystem implements IFileSystem {
 	}
 
 	public isEmptyDir(directoryPath: string): boolean {
-		let directoryContent = this.readDirectory(directoryPath);
+		const directoryContent = this.readDirectory(directoryPath);
 		return directoryContent.length === 0;
 	}
 
 	public isRelativePath(p: string): boolean {
-		let normal = path.normalize(p);
-		let absolute = path.resolve(p);
+		const normal = path.normalize(p);
+		const absolute = path.resolve(p);
 		return normal !== absolute;
 	}
 
@@ -309,10 +309,10 @@ export class FileSystem implements IFileSystem {
 	}
 
 	public async setCurrentUserAsOwner(path: string, owner: string): Promise<void> {
-		let $childProcess = this.$injector.resolve("childProcess");
+		const $childProcess = this.$injector.resolve("childProcess");
 
 		if (!this.$injector.resolve("$hostInfo").isWindows) {
-			let chown = $childProcess.spawn("chown", ["-R", owner, path],
+			const chown = $childProcess.spawn("chown", ["-R", owner, path],
 				{ stdio: "ignore", detached: true });
 			await this.futureFromEvent(chown, "close");
 		}
@@ -326,15 +326,15 @@ export class FileSystem implements IFileSystem {
 		foundFiles = foundFiles || [];
 
 		if (!this.exists(directoryPath)) {
-			let $logger = this.$injector.resolve("logger");
+			const $logger = this.$injector.resolve("logger");
 			$logger.warn('Could not find folder: ' + directoryPath);
 			return foundFiles;
 		}
 
-		let contents = this.readDirectory(directoryPath);
+		const contents = this.readDirectory(directoryPath);
 		for (let i = 0; i < contents.length; ++i) {
-			let file = path.join(directoryPath, contents[i]);
-			let stat = this.getFsStats(file);
+			const file = path.join(directoryPath, contents[i]);
+			const stat = this.getFsStats(file);
 			if (filterCallback && !filterCallback(file, stat)) {
 				continue;
 			}
@@ -357,17 +357,17 @@ export class FileSystem implements IFileSystem {
 
 	public async getFileShasum(fileName: string, options?: { algorithm?: string, encoding?: crypto.HexBase64Latin1Encoding }): Promise<string> {
 		return new Promise<string>((resolve, reject) => {
-			let algorithm = (options && options.algorithm) || "sha1";
-			let encoding = (options && options.encoding) || "hex";
-			let logger: ILogger = this.$injector.resolve("$logger");
-			let shasumData = crypto.createHash(algorithm);
-			let fileStream = this.createReadStream(fileName);
+			const algorithm = (options && options.algorithm) || "sha1";
+			const encoding = (options && options.encoding) || "hex";
+			const logger: ILogger = this.$injector.resolve("$logger");
+			const shasumData = crypto.createHash(algorithm);
+			const fileStream = this.createReadStream(fileName);
 			fileStream.on("data", (data: NodeBuffer | string) => {
 				shasumData.update(data);
 			});
 
 			fileStream.on("end", () => {
-				let shasum: string = shasumData.digest(encoding);
+				const shasum: string = shasumData.digest(encoding);
 				logger.trace(`Shasum of file ${fileName} is ${shasum}`);
 				resolve(shasum);
 			});
@@ -409,14 +409,14 @@ export class FileSystem implements IFileSystem {
 			return FileSystem.DEFAULT_INDENTATION_CHARACTER;
 		}
 
-		let fileContent = this.readText(filePath).trim();
-		let matches = fileContent.match(FileSystem.JSON_OBJECT_REGEXP);
+		const fileContent = this.readText(filePath).trim();
+		const matches = fileContent.match(FileSystem.JSON_OBJECT_REGEXP);
 
 		if (!matches || !matches[1]) {
 			return FileSystem.DEFAULT_INDENTATION_CHARACTER;
 		}
 
-		let indentation = matches[1];
+		const indentation = matches[1];
 
 		return indentation[0] === " " ? indentation : FileSystem.DEFAULT_INDENTATION_CHARACTER;
 	}

--- a/helpers.ts
+++ b/helpers.ts
@@ -1,11 +1,12 @@
 import * as uuid from "uuid";
 import * as net from "net";
-let Table = require("cli-table");
 import { platform, EOL } from "os";
 import { ReadStream } from "tty";
 import { Configurations } from "./constants";
 import { EventEmitter } from "events";
 import * as crypto from "crypto";
+
+const Table = require("cli-table");
 
 export function deferPromise<T>(): IDeferPromise<T> {
 	let resolve: (value?: T | PromiseLike<T>) => void;
@@ -47,9 +48,9 @@ export function deferPromise<T>(): IDeferPromise<T> {
  */
 export function settlePromises<T>(promises: Promise<T>[]): Promise<T[]> {
 	return new Promise((resolve, reject) => {
-		let settledPromisesCount = 0,
-			results: T[] = [],
-			errors: Error[] = [];
+		let settledPromisesCount = 0;
+		const results: T[] = [];
+		const errors: Error[] = [];
 
 		const length = promises.length;
 
@@ -79,7 +80,7 @@ export function settlePromises<T>(promises: Promise<T>[]): Promise<T[]> {
 
 export function getPropertyName(func: Function): string {
 	if (func) {
-		let match = func.toString().match(/(?:return\s+?.*\.(.+);)|(?:=>\s*?.*\.(.+)\b)/);
+		const match = func.toString().match(/(?:return\s+?.*\.(.+);)|(?:=>\s*?.*\.(.+)\b)/);
 		if (match) {
 			return (match[1] || match[2]).trim();
 		}
@@ -148,17 +149,17 @@ export function formatListOfNames(names: string[], conjunction?: string): string
 }
 
 export function getRelativeToRootPath(rootPath: string, filePath: string): string {
-	let relativeToRootPath = filePath.substr(rootPath.length);
+	const relativeToRootPath = filePath.substr(rootPath.length);
 	return relativeToRootPath;
 }
 
 function getVersionArray(version: string | IVersionData): number[] {
-	let result: number[] = [],
-		parseLambda = (x: string) => parseInt(x, 10),
-		filterLambda = (x: number) => !isNaN(x);
+	let result: number[] = [];
+	const parseLambda = (x: string) => parseInt(x, 10);
+	const filterLambda = (x: number) => !isNaN(x);
 
 	if (typeof version === "string") {
-		let versionString = <string>version.split("-")[0];
+		const versionString = <string>version.split("-")[0];
 		result = _.map(versionString.split("."), parseLambda);
 	} else {
 		result = _(version).map(parseLambda).filter(filterLambda).value();
@@ -168,7 +169,7 @@ function getVersionArray(version: string | IVersionData): number[] {
 }
 
 export function versionCompare(version1: string | IVersionData, version2: string | IVersionData): number {
-	let v1array = getVersionArray(version1),
+	const v1array = getVersionArray(version1),
 		v2array = getVersionArray(version2);
 
 	if (v1array.length !== v2array.length) {
@@ -219,7 +220,7 @@ export function isNullOrWhitespace(input: any): boolean {
 }
 
 export function getCurrentEpochTime(): number {
-	let dateTime = new Date();
+	const dateTime = new Date();
 	return dateTime.getTime();
 }
 
@@ -230,7 +231,7 @@ export async function sleep(ms: number): Promise<void> {
 }
 
 export function createTable(headers: string[], data: string[][]): any {
-	let table = new Table({
+	const table = new Table({
 		head: headers,
 		chars: { "mid": "", "left-mid": "", "mid-mid": "", "right-mid": "" }
 	});
@@ -241,7 +242,7 @@ export function createTable(headers: string[], data: string[][]): any {
 
 export function remove<T>(array: T[], predicate: (element: T) => boolean, numberOfElements?: number): T[] {
 	numberOfElements = numberOfElements || 1;
-	let index = _.findIndex(array, predicate);
+	const index = _.findIndex(array, predicate);
 	if (index === -1) {
 		return new Array<T>();
 	}
@@ -272,7 +273,7 @@ export async function getFuturesResults<T>(promises: Promise<T | T[]>[], predica
 }
 
 export function appendZeroesToVersion(version: string, requiredVersionLength: number): string {
-	let zeroesToAppend = requiredVersionLength - version.split(".").length;
+	const zeroesToAppend = requiredVersionLength - version.split(".").length;
 	for (let index = 0; index < zeroesToAppend; index++) {
 		version += ".0";
 	}
@@ -282,12 +283,12 @@ export function appendZeroesToVersion(version: string, requiredVersionLength: nu
 
 export function decorateMethod(before: (method1: any, self1: any, args1: any[]) => Promise<void>, after: (method2: any, self2: any, result2: any, args2: any[]) => Promise<any>) {
 	return (target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<Function>) => {
-		let sink = descriptor.value;
+		const sink = descriptor.value;
 		descriptor.value = async function (...args: any[]): Promise<any> {
 			if (before) {
 				await before(sink, this, args);
 			}
-			let result = sink.apply(this, args);
+			const result = sink.apply(this, args);
 			if (after) {
 				return await after(sink, this, result, args);
 			}
@@ -301,7 +302,7 @@ export function hook(commandName: string) {
 	function getHooksService(self: any): IHooksService {
 		let hooksService: IHooksService = self.$hooksService;
 		if (!hooksService) {
-			let injector = self.$injector;
+			const injector = self.$injector;
 			if (!injector) {
 				throw Error('Type with hooks needs to have either $hooksService or $injector injected.');
 			}
@@ -312,12 +313,12 @@ export function hook(commandName: string) {
 
 	function prepareArguments(method: any, args: any[], hooksService: IHooksService): { [key: string]: any } {
 		annotate(method);
-		let argHash: any = {};
+		const argHash: any = {};
 		for (let i = 0; i < method.$inject.args.length; ++i) {
 			argHash[method.$inject.args[i]] = args[i];
 		}
 		argHash.$arguments = args;
-		let result: any = {};
+		const result: any = {};
 		result[hooksService.hookArgsName] = argHash;
 
 		return result;
@@ -325,12 +326,12 @@ export function hook(commandName: string) {
 
 	return decorateMethod(
 		async (method: any, self: any, args: any[]) => {
-			let hooksService = getHooksService(self);
+			const hooksService = getHooksService(self);
 			await hooksService.executeBeforeHooks(commandName, prepareArguments(method, args, hooksService));
 		},
 		async (method: any, self: any, resultPromise: any, args: any[]) => {
-			let result = await resultPromise;
-			let hooksService = getHooksService(self);
+			const result = await resultPromise;
+			const hooksService = getHooksService(self);
 			await hooksService.executeAfterHooks(commandName, prepareArguments(method, args, hooksService));
 			return Promise.resolve(result);
 		});
@@ -352,9 +353,9 @@ export async function attachAwaitDetach(eventName: string, eventEmitter: EventEm
 
 export async function connectEventually(factory: () => Promise<net.Socket>, handler: (_socket: net.Socket) => void): Promise<void> {
 	async function tryConnect() {
-		let tryConnectAfterTimeout = setTimeout.bind(undefined, tryConnect, 1000);
+		const tryConnectAfterTimeout = setTimeout.bind(undefined, tryConnect, 1000);
 
-		let socket = await factory();
+		const socket = await factory();
 		socket.on("connect", () => {
 			socket.removeListener("error", tryConnectAfterTimeout);
 			handler(socket);
@@ -383,7 +384,7 @@ export async function connectEventuallyUntilTimeout(factory: () => net.Socket, t
 		}, timeout);
 
 		function tryConnect() {
-			let tryConnectAfterTimeout = (error: Error) => {
+			const tryConnectAfterTimeout = (error: Error) => {
 				if (isResolved) {
 					return;
 				}
@@ -392,7 +393,7 @@ export async function connectEventuallyUntilTimeout(factory: () => net.Socket, t
 				setTimeout(tryConnect, 1000);
 			};
 
-			let socket = factory();
+			const socket = factory();
 			socket.on("connect", () => {
 				socket.removeListener("error", tryConnectAfterTimeout);
 				isResolved = true;

--- a/host-info.ts
+++ b/host-info.ts
@@ -34,8 +34,8 @@ export class HostInfo implements IHostInfo {
 	public dotNetVersion(): Promise<string> {
 		if (this.isWindows) {
 			return new Promise<string>((resolve, reject) => {
-				let Winreg = require("winreg");
-				let regKey = new Winreg({
+				const Winreg = require("winreg");
+				const regKey = new Winreg({
 					hive: Winreg.HKLM,
 					key: HostInfo.DOT_NET_REGISTRY_PATH
 				});

--- a/http-client.ts
+++ b/http-client.ts
@@ -25,10 +25,10 @@ export class HttpClient implements Server.IHttpClient {
 			};
 		}
 
-		let unmodifiedOptions = _.clone(options);
+		const unmodifiedOptions = _.clone(options);
 
 		if (options.url) {
-			let urlParts = url.parse(options.url);
+			const urlParts = url.parse(options.url);
 			if (urlParts.protocol) {
 				options.proto = urlParts.protocol.slice(0, -1);
 			}
@@ -37,8 +37,8 @@ export class HttpClient implements Server.IHttpClient {
 			options.path = urlParts.path;
 		}
 
-		let requestProto = options.proto || "http";
-		let body = options.body;
+		const requestProto = options.proto || "http";
+		const body = options.body;
 		delete options.body;
 		let pipeTo = options.pipeTo;
 		delete options.pipeTo;
@@ -46,7 +46,7 @@ export class HttpClient implements Server.IHttpClient {
 		const proxyCache = this.$proxyService.getCache();
 
 		options.headers = options.headers || {};
-		let headers = options.headers;
+		const headers = options.headers;
 
 		await this.useProxySettings(proxySettings, proxyCache, options, headers, requestProto);
 
@@ -73,10 +73,10 @@ export class HttpClient implements Server.IHttpClient {
 			headers["Accept-Encoding"] = "gzip,deflate";
 		}
 
-		let result = new Promise<Server.IResponse>((resolve, reject) => {
+		const result = new Promise<Server.IResponse>((resolve, reject) => {
 			let timerId: number;
 
-			let promiseActions: IPromiseActions<Server.IResponse> = {
+			const promiseActions: IPromiseActions<Server.IResponse> = {
 				resolve,
 				reject,
 				isResolved: () => false
@@ -106,12 +106,12 @@ export class HttpClient implements Server.IHttpClient {
 					// in case there is a better way to obtain status code in future version do not hesitate to remove this code
 					const errorMessageMatch = err.message.match(HttpClient.STATUS_CODE_REGEX);
 					const errorMessageStatusCode = errorMessageMatch && errorMessageMatch[1] && +errorMessageMatch[1];
-					let errorMessage = this.getErrorMessage(errorMessageStatusCode, null);
+					const errorMessage = this.getErrorMessage(errorMessageStatusCode, null);
 					err.message = errorMessage || err.message;
 					this.setResponseResult(promiseActions, timerId, { err });
 				})
 				.on("response", (response: Server.IRequestResponseData) => {
-					let successful = helpers.isRequestSuccessful(response);
+					const successful = helpers.isRequestSuccessful(response);
 					if (!successful) {
 						pipeTo = undefined;
 					}
@@ -136,7 +136,7 @@ export class HttpClient implements Server.IHttpClient {
 
 						responseStream.pipe(pipeTo);
 					} else {
-						let data: string[] = [];
+						const data: string[] = [];
 
 						responseStream.on("data", (chunk: string) => {
 							data.push(chunk);
@@ -150,7 +150,7 @@ export class HttpClient implements Server.IHttpClient {
 								this.setResponseResult(promiseActions, timerId, { body: responseBody, response });
 							} else {
 								const errorMessage = this.getErrorMessage(response.statusCode, responseBody);
-								let err: any = new Error(errorMessage);
+								const err: any = new Error(errorMessage);
 								err.response = response;
 								err.body = responseBody;
 								this.setResponseResult(promiseActions, timerId, { err });
@@ -169,7 +169,7 @@ export class HttpClient implements Server.IHttpClient {
 			}
 		});
 
-		let response = await result;
+		const response = await result;
 
 		if (helpers.isResponseRedirect(response.response)) {
 			if (response.response.statusCode === HttpStatusCodes.SEE_OTHER) {
@@ -196,7 +196,7 @@ export class HttpClient implements Server.IHttpClient {
 				return result.reject(resultData.err);
 			}
 
-			let finalResult: any = resultData;
+			const finalResult: any = resultData;
 			finalResult.headers = resultData.response.headers;
 
 			result.resolve(finalResult);
@@ -205,17 +205,17 @@ export class HttpClient implements Server.IHttpClient {
 
 	private trackDownloadProgress(pipeTo: NodeJS.WritableStream): NodeJS.ReadableStream {
 		// \r for carriage return doesn't work on windows in node for some reason so we have to use it's hex representation \x1B[0G
-		let lastMessageSize = 0,
-			carriageReturn = "\x1B[0G",
-			timeElapsed = 0;
+		let lastMessageSize = 0;
+		const carriageReturn = "\x1B[0G";
+		let timeElapsed = 0;
 
-		let progressStream = progress({ time: 1000 }, (progress: any) => {
+		const progressStream = progress({ time: 1000 }, (progress: any) => {
 			timeElapsed = progress.runtime;
 
 			if (timeElapsed >= 1) {
 				this.$logger.write("%s%s", carriageReturn, Array(lastMessageSize + 1).join(" "));
 
-				let message = util.format("%sDownload progress ... %s | %s | %s/s",
+				const message = util.format("%sDownload progress ... %s | %s | %s/s",
 					carriageReturn,
 					Math.floor(progress.percentage) + "%",
 					filesize(progress.transferred),
@@ -241,13 +241,13 @@ export class HttpClient implements Server.IHttpClient {
 			const clientNameLowerCase = this.$staticConfig.CLIENT_NAME.toLowerCase();
 			return `Your proxy requires authentication. You can run ${EOL}\t${clientNameLowerCase} proxy set <url> <username> <password>.${EOL}In order to supply ${clientNameLowerCase} with the credentials needed.`;
 		} else if (statusCode === HttpStatusCodes.PAYMENT_REQUIRED) {
-			let subscriptionUrl = util.format("%s://%s/appbuilder/account/subscription", this.$config.AB_SERVER_PROTO, this.$config.AB_SERVER);
+			const subscriptionUrl = util.format("%s://%s/appbuilder/account/subscription", this.$config.AB_SERVER_PROTO, this.$config.AB_SERVER);
 			return util.format("Your subscription has expired. Go to %s to manage your subscription. Note: After you renew your subscription, " +
 				"log out and log back in for the changes to take effect.", subscriptionUrl);
 		} else {
 			this.$logger.trace("Request was unsuccessful. Server returned: ", body);
 			try {
-				let err = JSON.parse(body);
+				const err = JSON.parse(body);
 
 				if (_.isString(err)) {
 					return err;

--- a/logger.ts
+++ b/logger.ts
@@ -2,8 +2,8 @@ import * as log4js from "log4js";
 import * as util from "util";
 import * as stream from "stream";
 import * as marked from "marked";
-let TerminalRenderer = require("marked-terminal");
-let chalk = require("chalk");
+const TerminalRenderer = require("marked-terminal");
+const chalk = require("chalk");
 
 export class Logger implements ILogger {
 	private log4jsLogger: log4js.ILogger = null;
@@ -17,7 +17,7 @@ export class Logger implements ILogger {
 
 	constructor($config: Config.IConfig,
 		private $options: ICommonOptions) {
-		let appenders: log4js.IAppender[] = [];
+		const appenders: log4js.IAppender[] = [];
 
 		if (!$config.CI_LOGGER) {
 			appenders.push({
@@ -52,21 +52,21 @@ export class Logger implements ILogger {
 	}
 
 	error(...args: string[]): void {
-		let message = util.format.apply(null, args);
-		let colorizedMessage = message.red;
+		const message = util.format.apply(null, args);
+		const colorizedMessage = message.red;
 
 		this.log4jsLogger.error.apply(this.log4jsLogger, [colorizedMessage]);
 	}
 
 	warn(...args: string[]): void {
-		let message = util.format.apply(null, args);
-		let colorizedMessage = message.yellow;
+		const message = util.format.apply(null, args);
+		const colorizedMessage = message.yellow;
 
 		this.log4jsLogger.warn.apply(this.log4jsLogger, [colorizedMessage]);
 	}
 
 	warnWithLabel(...args: string[]): void {
-		let message = util.format.apply(null, args);
+		const message = util.format.apply(null, args);
 		this.warn(`${Logger.LABEL} ${message}`);
 	}
 
@@ -75,12 +75,12 @@ export class Logger implements ILogger {
 	}
 
 	debug(...args: string[]): void {
-		let encodedArgs: string[] = this.getPasswordEncodedArguments(args);
+		const encodedArgs: string[] = this.getPasswordEncodedArguments(args);
 		this.log4jsLogger.debug.apply(this.log4jsLogger, encodedArgs);
 	}
 
 	trace(...args: string[]): void {
-		let encodedArgs: string[] = this.getPasswordEncodedArguments(args);
+		const encodedArgs: string[] = this.getPasswordEncodedArguments(args);
 		this.log4jsLogger.trace.apply(this.log4jsLogger, encodedArgs);
 	}
 
@@ -129,7 +129,7 @@ export class Logger implements ILogger {
 	}
 
 	public printMarkdown(...args: string[]): void {
-		let opts = {
+		const opts = {
 			unescape: true,
 			link: chalk.red,
 			tableOptions: {
@@ -145,7 +145,7 @@ export class Logger implements ILogger {
 		};
 
 		marked.setOptions({ renderer: new TerminalRenderer(opts) });
-		let formattedMessage = marked(util.format.apply(null, args));
+		const formattedMessage = marked(util.format.apply(null, args));
 		this.write(formattedMessage);
 	}
 

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -19,11 +19,11 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 	}
 
 	public async getInstalledApplications(): Promise<string[]> {
-		let result = await this.adb.executeShellCommand(["pm", "list", "packages"]) || "";
-		let regex = /package:(.+)/;
+		const result = await this.adb.executeShellCommand(["pm", "list", "packages"]) || "";
+		const regex = /package:(.+)/;
 		return result.split(EOL)
 			.map((packageString: string) => {
-				let match = packageString.match(regex);
+				const match = packageString.match(regex);
 				return match ? match[1] : null;
 			})
 			.filter((parsedPackage: string) => parsedPackage !== null);
@@ -32,7 +32,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 	@hook('install')
 	public async installApplication(packageFilePath: string, appIdentifier?: string): Promise<void> {
 		if (appIdentifier) {
-			let deviceRootPath = `/data/local/tmp/${appIdentifier}`;
+			const deviceRootPath = `/data/local/tmp/${appIdentifier}`;
 			await this.adb.executeShellCommand(["rm", "-rf", deviceRootPath]);
 		}
 
@@ -96,7 +96,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 	}
 
 	public async isLiveSyncSupported(appIdentifier: string): Promise<boolean> {
-		let liveSyncVersion = await this.adb.sendBroadcastToDevice(LiveSyncConstants.CHECK_LIVESYNC_INTENT_NAME, { "app-id": appIdentifier });
+		const liveSyncVersion = await this.adb.sendBroadcastToDevice(LiveSyncConstants.CHECK_LIVESYNC_INTENT_NAME, { "app-id": appIdentifier });
 		return liveSyncVersion === LiveSyncConstants.VERSION_2 || liveSyncVersion === LiveSyncConstants.VERSION_3;
 	}
 
@@ -105,16 +105,16 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 	}
 
 	public async getDebuggableAppViews(appIdentifiers: string[]): Promise<IDictionary<Mobile.IDebugWebViewInfo[]>> {
-		let mappedAppIdentifierPorts = await this.$androidProcessService.getMappedAbstractToTcpPorts(this.identifier, appIdentifiers, TARGET_FRAMEWORK_IDENTIFIERS.Cordova),
+		const mappedAppIdentifierPorts = await this.$androidProcessService.getMappedAbstractToTcpPorts(this.identifier, appIdentifiers, TARGET_FRAMEWORK_IDENTIFIERS.Cordova),
 			applicationViews: IDictionary<Mobile.IDebugWebViewInfo[]> = {};
 
 		await Promise.all(_.map(mappedAppIdentifierPorts, async (port: number, appIdentifier: string) => {
 			applicationViews[appIdentifier] = [];
-			let localAddress = `http://127.0.0.1:${port}/json`;
+			const localAddress = `http://127.0.0.1:${port}/json`;
 
 			try {
 				if (port) {
-					let apps = (await this.$httpClient.httpRequest(localAddress)).body;
+					const apps = (await this.$httpClient.httpRequest(localAddress)).body;
 					applicationViews[appIdentifier] = JSON.parse(apps);
 				}
 			} catch (err) {

--- a/mobile/android/android-debug-bridge-result-handler.ts
+++ b/mobile/android/android-debug-bridge-result-handler.ts
@@ -233,7 +233,7 @@ export class AndroidDebugBridgeResultHandler implements Mobile.IAndroidDebugBrid
 		private $errors: IErrors) { }
 
 	public checkForErrors(adbResult: any): Mobile.IAndroidDebugBridgeError[] {
-		let errors: Mobile.IAndroidDebugBridgeError[] = [];
+		const errors: Mobile.IAndroidDebugBridgeError[] = [];
 
 		if (adbResult) {
 			if (_.isArray(adbResult)) {
@@ -260,7 +260,7 @@ export class AndroidDebugBridgeResultHandler implements Mobile.IAndroidDebugBrid
 			this.$logger.trace(`Error name: ${error.name} result code: ${error.resultCode}`);
 		});
 
-		let errorMessages = _(errors).map((error: Mobile.IAndroidDebugBridgeError) => error.description)
+		const errorMessages = _(errors).map((error: Mobile.IAndroidDebugBridgeError) => error.description)
 			.join(EOL)
 			.toString();
 

--- a/mobile/android/android-debug-bridge.ts
+++ b/mobile/android/android-debug-bridge.ts
@@ -12,7 +12,7 @@ export class AndroidDebugBridge implements Mobile.IAndroidDebugBridge {
 
 	public async executeCommand(args: string[], options?: Mobile.IAndroidDebugBridgeCommandOptions): Promise<any> {
 		let event = "close";
-		let command = await this.composeCommand(args);
+		const command = await this.composeCommand(args);
 		let treatErrorsAsWarnings = false;
 		let childProcessOptions: any = undefined;
 
@@ -29,9 +29,9 @@ export class AndroidDebugBridge implements Mobile.IAndroidDebugBridge {
 		// If adb -s <invalid device id> install <smth> is executed the childProcess won't get any response
 		// because the adb will be waiting for valid device and will not send close or exit event.
 		// For example `adb -s <invalid device id> install <smth>` throws error 'error: device \'030939f508e6c773\' not found\r\n' exitCode 4294967295
-		let result: any = await this.$childProcess.spawnFromEvent(command.command, command.args, event, childProcessOptions, { throwError: false });
+		const result: any = await this.$childProcess.spawnFromEvent(command.command, command.args, event, childProcessOptions, { throwError: false });
 
-		let errors = this.$androidDebugBridgeResultHandler.checkForErrors(result);
+		const errors = this.$androidDebugBridgeResultHandler.checkForErrors(result);
 
 		if (errors && errors.length > 0) {
 			this.$androidDebugBridgeResultHandler.handleErrors(errors, treatErrorsAsWarnings);
@@ -42,13 +42,13 @@ export class AndroidDebugBridge implements Mobile.IAndroidDebugBridge {
 	}
 
 	protected async composeCommand(params: string[], identifier?: string): Promise<IComposeCommandResult> {
-		let command = await this.$staticConfig.getAdbFilePath();
+		const command = await this.$staticConfig.getAdbFilePath();
 		let deviceIdentifier: string[] = [];
 		if (identifier) {
 			deviceIdentifier = ["-s", `${identifier}`];
 		}
 
-		let args: string[] = deviceIdentifier.concat(params);
+		const args: string[] = deviceIdentifier.concat(params);
 		return { command, args };
 	}
 }

--- a/mobile/android/android-device-file-system.ts
+++ b/mobile/android/android-device-file-system.ts
@@ -22,7 +22,7 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 	}
 
 	public async getFile(deviceFilePath: string, appIdentifier: string, outputPath?: string): Promise<void> {
-		let stdout = !outputPath;
+		const stdout = !outputPath;
 
 		if (stdout) {
 			temp.track();
@@ -33,7 +33,7 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 
 		if (stdout) {
 			await new Promise<void>((resolve, reject) => {
-				let readStream = this.$fs.createReadStream(outputPath);
+				const readStream = this.$fs.createReadStream(outputPath);
 				readStream.pipe(process.stdout);
 				readStream.on("end", () => {
 					resolve();
@@ -75,7 +75,7 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 		);
 
 		// Update hashes
-		let deviceHashService = this.getDeviceHashService(deviceAppData.appIdentifier);
+		const deviceHashService = this.getDeviceHashService(deviceAppData.appIdentifier);
 		if (! await deviceHashService.updateHashes(localToDevicePaths)) {
 			this.$logger.trace("Unable to find hash file on device. The next livesync command will create it.");
 		}
@@ -87,10 +87,10 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 
 		await Promise.all(
 			localToDevicePaths.map(async localToDevicePathData => {
-				let localPath = localToDevicePathData.getLocalPath();
-				let stats = this.$fs.getFsStats(localPath);
+				const localPath = localToDevicePathData.getLocalPath();
+				const stats = this.$fs.getFsStats(localPath);
 				if (stats.isFile()) {
-					let fileShasum = await this.$fs.getFileShasum(localPath);
+					const fileShasum = await this.$fs.getFileShasum(localPath);
 					currentShasums[localPath] = fileShasum;
 				}
 
@@ -137,7 +137,7 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 
 	public async transferFile(localPath: string, devicePath: string): Promise<void> {
 		this.$logger.trace(`Transfering ${localPath} to ${devicePath}`);
-		let stats = this.$fs.getFsStats(localPath);
+		const stats = this.$fs.getFsStats(localPath);
 		if (stats.isDirectory()) {
 			await this.adb.executeShellCommand(["mkdir", path.dirname(devicePath)]);
 		} else {
@@ -146,8 +146,8 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 	}
 
 	public async createFileOnDevice(deviceFilePath: string, fileContent: string): Promise<void> {
-		let hostTmpDir = this.getTempDir();
-		let commandsFileHostPath = path.join(hostTmpDir, "temp.commands.file");
+		const hostTmpDir = this.getTempDir();
+		const commandsFileHostPath = path.join(hostTmpDir, "temp.commands.file");
 		this.$fs.writeFile(commandsFileHostPath, fileContent);
 
 		// copy it to the device

--- a/mobile/android/android-device-hash-service.ts
+++ b/mobile/android/android-device-hash-service.ts
@@ -18,12 +18,12 @@ export class AndroidDeviceHashService implements Mobile.IAndroidDeviceHashServic
 	}
 
 	public async doesShasumFileExistsOnDevice(): Promise<boolean> {
-		let lsResult = await this.adb.executeShellCommand(["ls", this.hashFileDevicePath]);
+		const lsResult = await this.adb.executeShellCommand(["ls", this.hashFileDevicePath]);
 		return !!(lsResult && lsResult.trim() === this.hashFileDevicePath);
 	}
 
 	public async getShasumsFromDevice(): Promise<IStringDictionary> {
-		let hashFileLocalPath = await this.downloadHashFileFromDevice();
+		const hashFileLocalPath = await this.downloadHashFileFromDevice();
 
 		if (this.$fs.exists(hashFileLocalPath)) {
 			return this.$fs.readJson(hashFileLocalPath);
@@ -37,10 +37,10 @@ export class AndroidDeviceHashService implements Mobile.IAndroidDeviceHashServic
 		if (_.isArray(data)) {
 			await Promise.all(
 				(<Mobile.ILocalToDevicePathData[]>data).map(async localToDevicePathData => {
-					let localPath = localToDevicePathData.getLocalPath();
-					let stats = this.$fs.getFsStats(localPath);
+					const localPath = localToDevicePathData.getLocalPath();
+					const stats = this.$fs.getFsStats(localPath);
 					if (stats.isFile()) {
-						let fileShasum = await this.$fs.getFileShasum(localPath);
+						const fileShasum = await this.$fs.getFileShasum(localPath);
 						shasums[localPath] = fileShasum;
 					}
 				})
@@ -54,11 +54,11 @@ export class AndroidDeviceHashService implements Mobile.IAndroidDeviceHashServic
 	}
 
 	public async updateHashes(localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<boolean> {
-		let oldShasums = await this.getShasumsFromDevice();
+		const oldShasums = await this.getShasumsFromDevice();
 		if (oldShasums) {
 			await Promise.all(
 				_.map(localToDevicePaths, async ldp => {
-					let localPath = ldp.getLocalPath();
+					const localPath = ldp.getLocalPath();
 					if (this.$fs.getFsStats(localPath).isFile()) {
 						// TODO: Use relative to project path for key
 						// This will speed up livesync on the same device for the same project on different PCs.
@@ -76,9 +76,9 @@ export class AndroidDeviceHashService implements Mobile.IAndroidDeviceHashServic
 	}
 
 	public async removeHashes(localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<boolean> {
-		let oldShasums = await this.getShasumsFromDevice();
+		const oldShasums = await this.getShasumsFromDevice();
 		if (oldShasums) {
-			let fileToShasumDictionary = <IStringDictionary>(_.omit(oldShasums, localToDevicePaths.map(ldp => ldp.getLocalPath())));
+			const fileToShasumDictionary = <IStringDictionary>(_.omit(oldShasums, localToDevicePaths.map(ldp => ldp.getLocalPath())));
 			await this.uploadHashFileToDevice(fileToShasumDictionary);
 			return true;
 		}

--- a/mobile/android/android-device.ts
+++ b/mobile/android/android-device.ts
@@ -68,7 +68,7 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 		}
 
 		this.$logger.trace(details);
-		let adbStatusInfo = AndroidDevice.ADB_DEVICE_STATUS_INFO[this.status];
+		const adbStatusInfo = AndroidDevice.ADB_DEVICE_STATUS_INFO[this.status];
 
 		this.deviceInfo = {
 			identifier: this.identifier,
@@ -91,9 +91,9 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 	}
 
 	public async getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo> {
-		let files = await this.fileSystem.listFiles(constants.LiveSyncConstants.ANDROID_FILES_PATH, applicationIdentifier),
-			androidFilesMatch = files.match(/(\S+)\.abproject/),
-			result: Mobile.IApplicationInfo = null;
+		const files = await this.fileSystem.listFiles(constants.LiveSyncConstants.ANDROID_FILES_PATH, applicationIdentifier);
+		const androidFilesMatch = files.match(/(\S+)\.abproject/);
+		let result: Mobile.IApplicationInfo = null;
 
 		if (androidFilesMatch && androidFilesMatch[1]) {
 			result = {
@@ -113,7 +113,7 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 	}
 
 	private async getDeviceDetails(shellCommandArgs: string[]): Promise<IAndroidDeviceDetails> {
-		let parsedDetails: any = {};
+		const parsedDetails: any = {};
 
 		this.$logger.trace(`Trying to get information for Android device. Command is: ${shellCommandArgs}`);
 
@@ -144,7 +144,7 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 	}
 
 	private async getType(): Promise<string> {
-		let runningEmulators = await this.$androidEmulatorServices.getAllRunningEmulators();
+		const runningEmulators = await this.$androidEmulatorServices.getAllRunningEmulators();
 		if (_.includes(runningEmulators, this.identifier)) {
 			return constants.DeviceTypes.Emulator;
 		}

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -73,12 +73,12 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 	}
 
 	public async getEmulatorId(): Promise<string> {
-		let image = this.getEmulatorImage();
+		const image = this.getEmulatorImage();
 		if (!image) {
 			this.$errors.fail("Could not find an emulator image to run your project.");
 		}
 
-		let emulatorId = await this.startEmulatorInstance(image);
+		const emulatorId = await this.startEmulatorInstance(image);
 		return emulatorId;
 	}
 
@@ -94,7 +94,7 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 			this.$errors.failWithoutHelp("You do not have any Android emulators installed. Please install at least one.");
 		}
 
-		let platform = this.$devicePlatformsConstants.Android;
+		const platform = this.$devicePlatformsConstants.Android;
 		if (!this.$emulatorSettingsService.canStart(platform)) {
 			this.$errors.fail("The current project does not target Android and cannot be run in the Android emulator.");
 		}
@@ -107,7 +107,7 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 
 		let emulatorId: string = null;
 
-		let image = this.getEmulatorImage(emulatorImage);
+		const image = this.getEmulatorImage(emulatorImage);
 		if (image) {
 			// start the emulator, if needed
 			emulatorId = await this.startEmulatorInstance(image);
@@ -129,7 +129,7 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 	}
 
 	public async runApplicationOnEmulator(app: string, emulatorOptions?: Mobile.IEmulatorOptions): Promise<void> {
-		let emulatorId = await this.startEmulator();
+		const emulatorId = await this.startEmulator();
 		await this.runApplicationOnEmulatorCore(app, emulatorOptions.appId, emulatorId);
 	}
 
@@ -148,7 +148,7 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 
 	private async checkGenymotionConfiguration(): Promise<void> {
 		try {
-			let condition = (childProcess: any) => childProcess.stderr && !_.startsWith(childProcess.stderr, "Usage:");
+			const condition = (childProcess: any) => childProcess.stderr && !_.startsWith(childProcess.stderr, "Usage:");
 			await this.$childProcess.tryExecuteApplication("player", [], "exit", AndroidEmulatorServices.MISSING_GENYMOTION_MESSAGE, condition);
 		} catch (err) {
 			this.$logger.trace(`Error while checking Genymotion configuration: ${err}`);
@@ -157,14 +157,14 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 	}
 
 	private getEmulatorImage(suggestedImage?: string): string {
-		let image = this.$options.avd || this.$options.geny || this.getBestFit(suggestedImage);
+		const image = this.$options.avd || this.$options.geny || this.getBestFit(suggestedImage);
 		return image;
 	}
 
 	private async runApplicationOnEmulatorCore(app: string, appId: string, emulatorId: string): Promise<void> {
 		// install the app
 		this.$logger.info("installing %s through adb", app);
-		let adb = this.getDeviceAndroidDebugBridge(emulatorId);
+		const adb = this.getDeviceAndroidDebugBridge(emulatorId);
 		let childProcess = await adb.executeCommand(["install", "-r", app], { returnChildProcess: true });
 		await this.$fs.futureFromEvent(childProcess, "close");
 
@@ -174,7 +174,7 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 		// run the installed app
 		this.$logger.info("running %s through adb", app);
 
-		let androidDebugBridgeCommandOptions: Mobile.IAndroidDebugBridgeCommandOptions = {
+		const androidDebugBridgeCommandOptions: Mobile.IAndroidDebugBridgeCommandOptions = {
 			childProcessOptions: { stdio: "ignore", detached: true },
 			returnChildProcess: true
 		};
@@ -187,8 +187,8 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 	}
 
 	private async unlockScreen(emulatorId: string): Promise<void> {
-		let adb = this.getDeviceAndroidDebugBridge(emulatorId);
-		let childProcess = await adb.executeShellCommand(["input", "keyevent", "82"], { returnChildProcess: true });
+		const adb = this.getDeviceAndroidDebugBridge(emulatorId);
+		const childProcess = await adb.executeShellCommand(["input", "keyevent", "82"], { returnChildProcess: true });
 		return this.$fs.futureFromEvent(childProcess, "close");
 	}
 
@@ -199,14 +199,14 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 	}
 
 	public async getRunningEmulatorId(image: string): Promise<string> {
-		let runningEmulators = await this.getRunningEmulators();
+		const runningEmulators = await this.getRunningEmulators();
 		if (runningEmulators.length === 0) {
 			return "";
 		}
 
 		// if we get here, there's at least one running emulator
-		let getNameFunction = this.$options.geny ? this.getNameFromGenymotionEmulatorId : this.getNameFromSDKEmulatorId;
-		for (let emulatorId of runningEmulators) {
+		const getNameFunction = this.$options.geny ? this.getNameFromGenymotionEmulatorId : this.getNameFromSDKEmulatorId;
+		for (const emulatorId of runningEmulators) {
 			const currentEmulatorName = await getNameFunction.apply(this, [emulatorId]);
 			if (currentEmulatorName === image) {
 				return emulatorId;
@@ -216,14 +216,14 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 
 	@invokeInit()
 	private async getNameFromGenymotionEmulatorId(emulatorId: string): Promise<string> {
-		let modelOutputLines: string = await this.$childProcess.execFile(this.adbFilePath, ["-s", emulatorId, "shell", "getprop", "ro.product.model"]);
+		const modelOutputLines: string = await this.$childProcess.execFile(this.adbFilePath, ["-s", emulatorId, "shell", "getprop", "ro.product.model"]);
 		this.$logger.trace(modelOutputLines);
-		let model = (<string>_.first(modelOutputLines.split(EOL))).trim();
+		const model = (<string>_.first(modelOutputLines.split(EOL))).trim();
 		return model;
 	}
 
 	private getNameFromSDKEmulatorId(emulatorId: string): Promise<string> {
-		let match = emulatorId.match(/^emulator-(\d+)/);
+		const match = emulatorId.match(/^emulator-(\d+)/);
 		let portNumber: string;
 		if (match && match[1]) {
 			portNumber = match[1];
@@ -234,14 +234,14 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 		return new Promise<string>((resolve, reject) => {
 			let isResolved = false;
 			let output: string = "";
-			let client = net.connect(portNumber, () => {
+			const client = net.connect(portNumber, () => {
 				client.write(`avd name${EOL}`);
 			});
 
 			client.on('data', (data: any) => {
 				output += data.toString();
 
-				let name = this.getEmulatorNameFromClientOutput(output);
+				const name = this.getEmulatorNameFromClientOutput(output);
 				// old output should look like:
 				// Android Console: type 'help' for a list of commands
 				// OK
@@ -268,16 +268,16 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 
 	private getEmulatorNameFromClientOutput(output: string): string {
 		// The lines should be trimmed after the split because the output has \r\n and when using split(EOL) on mac each line ends with \r.
-		let lines: string[] = _.map(output.split(EOL), (line: string) => line.trim());
+		const lines: string[] = _.map(output.split(EOL), (line: string) => line.trim());
 		let name: string;
 
-		let firstIndexOfOk = _.indexOf(lines, "OK");
+		const firstIndexOfOk = _.indexOf(lines, "OK");
 
 		if (firstIndexOfOk < 0) {
 			return null;
 		}
 
-		let secondIndexOfOk = _.indexOf(lines, "OK", firstIndexOfOk + 1);
+		const secondIndexOfOk = _.indexOf(lines, "OK", firstIndexOfOk + 1);
 
 		if (secondIndexOfOk < 0) {
 			return null;
@@ -307,7 +307,7 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 				{ stdio: "ignore", detached: true }).unref();
 		}
 
-		let isInfiniteWait = this.$utils.getMilliSecondsTimeout(AndroidEmulatorServices.TIMEOUT_SECONDS) === 0;
+		const isInfiniteWait = this.$utils.getMilliSecondsTimeout(AndroidEmulatorServices.TIMEOUT_SECONDS) === 0;
 		let hasTimeLeft = helpers.getCurrentEpochTime() < this.endTimeEpoch;
 
 		while (hasTimeLeft || isInfiniteWait) {
@@ -328,15 +328,15 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 	}
 
 	private async getRunningGenymotionEmulators(adbDevicesOutput: string[]): Promise<string[]> {
-		let results = await Promise.all<string>(
+		const results = await Promise.all<string>(
 			<Promise<string>[]>(_(adbDevicesOutput)
 				.filter(r => !r.match(AndroidEmulatorServices.RUNNING_ANDROID_EMULATOR_REGEX))
 				.map(async row => {
-					let match = row.match(/^(.+?)\s+device$/);
+					const match = row.match(/^(.+?)\s+device$/);
 					if (match && match[1]) {
 						// possible genymotion emulator
-						let emulatorId = match[1];
-						let result = await this.isGenymotionEmulator(emulatorId) ? emulatorId : undefined;
+						const emulatorId = match[1];
+						const result = await this.isGenymotionEmulator(emulatorId) ? emulatorId : undefined;
 						return Promise.resolve(result);
 					}
 
@@ -350,9 +350,9 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 	}
 
 	private async getRunningAvdEmulators(adbDevicesOutput: string[]): Promise<string[]> {
-		let emulatorDevices: string[] = [];
+		const emulatorDevices: string[] = [];
 		_.each(adbDevicesOutput, (device: string) => {
-			let rx = device.match(AndroidEmulatorServices.RUNNING_ANDROID_EMULATOR_REGEX);
+			const rx = device.match(AndroidEmulatorServices.RUNNING_ANDROID_EMULATOR_REGEX);
 
 			if (rx && rx[1]) {
 				emulatorDevices.push(rx[1]);
@@ -363,12 +363,12 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 
 	@invokeInit()
 	private async isGenymotionEmulator(emulatorId: string): Promise<boolean> {
-		let manufacturer = await this.$childProcess.execFile(this.adbFilePath, ["-s", emulatorId, "shell", "getprop", "ro.product.manufacturer"]);
+		const manufacturer = await this.$childProcess.execFile(this.adbFilePath, ["-s", emulatorId, "shell", "getprop", "ro.product.manufacturer"]);
 		if (manufacturer.match(/^Genymotion/i)) {
 			return true;
 		}
 
-		let buildProduct = await this.$childProcess.execFile(this.adbFilePath, ["-s", emulatorId, "shell", "getprop", "ro.build.product"]);
+		const buildProduct = await this.$childProcess.execFile(this.adbFilePath, ["-s", emulatorId, "shell", "getprop", "ro.build.product"]);
 		if (buildProduct && _.includes(buildProduct.toLowerCase(), "vbox")) {
 			return true;
 		}
@@ -378,14 +378,14 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 
 	@invokeInit()
 	public async getAllRunningEmulators(): Promise<string[]> {
-		let outputRaw: string[] = (await this.$childProcess.execFile(this.adbFilePath, ['devices'])).split(EOL);
-		let emulators = (await this.getRunningAvdEmulators(outputRaw)).concat(await this.getRunningGenymotionEmulators(outputRaw));
+		const outputRaw: string[] = (await this.$childProcess.execFile(this.adbFilePath, ['devices'])).split(EOL);
+		const emulators = (await this.getRunningAvdEmulators(outputRaw)).concat(await this.getRunningGenymotionEmulators(outputRaw));
 		return emulators;
 	}
 
 	@invokeInit()
 	private async getRunningEmulators(): Promise<string[]> {
-		let outputRaw: string[] = (await this.$childProcess.execFile(this.adbFilePath, ['devices'])).split(EOL);
+		const outputRaw: string[] = (await this.$childProcess.execFile(this.adbFilePath, ['devices'])).split(EOL);
 		if (this.$options.geny) {
 			return await this.getRunningGenymotionEmulators(outputRaw);
 		} else {
@@ -394,8 +394,8 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 	}
 
 	public getInfoFromAvd(avdName: string): Mobile.IAvdInfo {
-		let iniFile = path.join(this.avdDir, avdName + ".ini"),
-			avdInfo: Mobile.IAvdInfo = this.parseAvdFile(avdName, iniFile);
+		let iniFile = path.join(this.avdDir, avdName + ".ini");
+		let avdInfo: Mobile.IAvdInfo = this.parseAvdFile(avdName, iniFile);
 
 		if (avdInfo.path && this.$fs.exists(avdInfo.path)) {
 			iniFile = path.join(avdInfo.path, "config.ini");
@@ -408,7 +408,7 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 	public getAvds(): string[] {
 		let result: string[] = [];
 		if (this.$fs.exists(this.avdDir)) {
-			let entries = this.$fs.readDirectory(this.avdDir);
+			const entries = this.$fs.readDirectory(this.avdDir);
 			result = _.filter(entries, (e: string) => e.match(AndroidEmulatorServices.INI_FILES_MASK) !== null)
 				.map((e) => e.match(AndroidEmulatorServices.INI_FILES_MASK)[1]);
 		}
@@ -416,14 +416,14 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 	}
 
 	private getBestFit(suggestedImage?: string): string {
-		let minVersion = this.$emulatorSettingsService.minVersion;
+		const minVersion = this.$emulatorSettingsService.minVersion;
 
 		let avdResults = this.getAvds();
 		if (suggestedImage) {
 			avdResults = avdResults.filter(avd => avd === suggestedImage);
 		}
 
-		let best = _(avdResults)
+		const best = _(avdResults)
 			.map(avd => this.getInfoFromAvd(avd))
 			.filter(avd => !!avd)
 			.maxBy(avd => avd.targetNum);
@@ -438,12 +438,12 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 
 		// avd files can have different encoding, defined on the first line.
 		// find which one it is (if any) and use it to correctly read the file contents
-		let encoding = this.getAvdEncoding(avdFileName);
-		let contents = this.$fs.readText(avdFileName, encoding).split("\n");
+		const encoding = this.getAvdEncoding(avdFileName);
+		const contents = this.$fs.readText(avdFileName, encoding).split("\n");
 
 		avdInfo = _.reduce(contents, (result: Mobile.IAvdInfo, line: string) => {
-			let parsedLine = line.split("=");
-			let key = parsedLine[0];
+			const parsedLine = line.split("=");
+			const key = parsedLine[0];
 			switch (key) {
 				case "target":
 					result.target = parsedLine[1];
@@ -464,11 +464,11 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 
 	// Android L is not written as a number in the .ini files, and we need to convert it
 	private readTargetNum(target: string): number {
-		let platform = target.replace('android-', '');
+		const platform = target.replace('android-', '');
 		let platformNumber = +platform;
 		if (isNaN(platformNumber)) {
 			// this may be a google image
-			let googlePlatform = target.split(":")[2];
+			const googlePlatform = target.split(":")[2];
 			if (googlePlatform) {
 				platformNumber = +googlePlatform;
 			} else if (platform === "L") { // Android SDK 20 preview
@@ -488,7 +488,7 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 		if (contents.length > 0) {
 			contents = contents.split("\n", 1)[0];
 			if (contents.length > 0) {
-				let matches = contents.match(AndroidEmulatorServices.ENCODING_MASK);
+				const matches = contents.match(AndroidEmulatorServices.ENCODING_MASK);
 				if (matches) {
 					encoding = matches[1];
 				}
@@ -508,9 +508,9 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 	private async waitForEmulatorBootToComplete(emulatorId: string): Promise<void> {
 		this.$logger.printInfoMessageOnSameLine("Waiting for emulator device initialization...");
 
-		let isInfiniteWait = this.$utils.getMilliSecondsTimeout(AndroidEmulatorServices.TIMEOUT_SECONDS) === 0;
+		const isInfiniteWait = this.$utils.getMilliSecondsTimeout(AndroidEmulatorServices.TIMEOUT_SECONDS) === 0;
 		while (helpers.getCurrentEpochTime() < this.endTimeEpoch || isInfiniteWait) {
-			let isEmulatorBootCompleted = await this.isEmulatorBootCompleted(emulatorId);
+			const isEmulatorBootCompleted = await this.isEmulatorBootCompleted(emulatorId);
 
 			if (isEmulatorBootCompleted) {
 				this.$logger.printInfoMessageOnSameLine(EOL);
@@ -527,8 +527,8 @@ class AndroidEmulatorServices implements Mobile.IAndroidEmulatorServices {
 
 	@invokeInit()
 	private async isEmulatorBootCompleted(emulatorId: string): Promise<boolean> {
-		let output = await this.$childProcess.execFile(this.adbFilePath, ["-s", emulatorId, "shell", "getprop", "dev.bootcomplete"]);
-		let matches = output.match("1");
+		const output = await this.$childProcess.execFile(this.adbFilePath, ["-s", emulatorId, "shell", "getprop", "dev.bootcomplete"]);
+		const matches = output.match("1");
 		return matches && matches.length > 0;
 	}
 }

--- a/mobile/android/android-livesync-service.ts
+++ b/mobile/android/android-livesync-service.ts
@@ -33,7 +33,7 @@ export class AndroidLiveSyncService implements Mobile.IAndroidLiveSyncService {
 	}
 
 	public async livesync(appIdentifier: string, liveSyncRoot: string, commands: string[]): Promise<void> {
-		let commandsFileDevicePath = this.$mobileHelper.buildDevicePath(liveSyncRoot, AndroidLiveSyncService.COMMANDS_FILE);
+		const commandsFileDevicePath = this.$mobileHelper.buildDevicePath(liveSyncRoot, AndroidLiveSyncService.COMMANDS_FILE);
 		await this.createCommandsFileOnDevice(commandsFileDevicePath, commands);
 		await this.device.adb.sendBroadcastToDevice(AndroidLiveSyncService.LIVESYNC_BROADCAST_NAME, { "app-id": appIdentifier });
 	}

--- a/mobile/android/android-log-filter.ts
+++ b/mobile/android/android-log-filter.ts
@@ -1,4 +1,4 @@
-let os = require("os");
+const os = require("os");
 
 export class AndroidLogFilter implements Mobile.IPlatformLogFilter {
 

--- a/mobile/android/device-android-debug-bridge.ts
+++ b/mobile/android/device-android-debug-bridge.ts
@@ -22,13 +22,13 @@ export class DeviceAndroidDebugBridge extends AndroidDebugBridge implements Mobi
 
 	public async sendBroadcastToDevice(action: string, extras?: IStringDictionary): Promise<number> {
 		extras = extras || {};
-		let broadcastCommand = ["am", "broadcast", "-a", `${action}`];
+		const broadcastCommand = ["am", "broadcast", "-a", `${action}`];
 		_.each(extras, (value, key) => broadcastCommand.push("-e", key, value));
 
-		let result = await this.executeShellCommand(broadcastCommand);
+		const result = await this.executeShellCommand(broadcastCommand);
 		this.$logger.trace(`Broadcast result ${result} from ${broadcastCommand}`);
 
-		let match = result.match(/Broadcast completed: result=(\d+)/);
+		const match = result.match(/Broadcast completed: result=(\d+)/);
 		if (match) {
 			return +match[1];
 		}

--- a/mobile/android/logcat-helper.ts
+++ b/mobile/android/logcat-helper.ts
@@ -14,13 +14,13 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 
 	public async start(deviceIdentifier: string): Promise<void> {
 		if (deviceIdentifier && !this.mapDeviceToLoggingStarted[deviceIdentifier]) {
-			let adb: Mobile.IDeviceAndroidDebugBridge = this.$injector.resolve(DeviceAndroidDebugBridge, { identifier: deviceIdentifier });
+			const adb: Mobile.IDeviceAndroidDebugBridge = this.$injector.resolve(DeviceAndroidDebugBridge, { identifier: deviceIdentifier });
 
 			// remove cached logs:
 			await adb.executeCommand(["logcat", "-c"]);
 
-			let adbLogcat = await adb.executeCommand(["logcat"], { returnChildProcess: true });
-			let lineStream = byline(adbLogcat.stdout);
+			const adbLogcat = await adb.executeCommand(["logcat"], { returnChildProcess: true });
+			const lineStream = byline(adbLogcat.stdout);
 
 			adbLogcat.stderr.on("data", (data: NodeBuffer) => {
 				this.$logger.trace("ADB logcat stderr: " + data.toString());
@@ -38,7 +38,7 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 			});
 
 			lineStream.on('data', (line: NodeBuffer) => {
-				let lineText = line.toString();
+				const lineText = line.toString();
 				this.$deviceLogProvider.logData(lineText, this.$devicePlatformsConstants.Android, deviceIdentifier);
 			});
 

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -40,11 +40,11 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 				// use locking, so the next executions will not get into the body, while the first one is still working.
 				// In case we do not break the next executions, we'll report each app as newly installed several times.
 				try {
-					let currentlyInstalledAppIdentifiers = await this.getInstalledApplications();
-					let previouslyInstalledAppIdentifiers = this.lastInstalledAppIdentifiers || [];
+					const currentlyInstalledAppIdentifiers = await this.getInstalledApplications();
+					const previouslyInstalledAppIdentifiers = this.lastInstalledAppIdentifiers || [];
 
-					let newAppIdentifiers = _.difference(currentlyInstalledAppIdentifiers, previouslyInstalledAppIdentifiers);
-					let removedAppIdentifiers = _.difference(previouslyInstalledAppIdentifiers, currentlyInstalledAppIdentifiers);
+					const newAppIdentifiers = _.difference(currentlyInstalledAppIdentifiers, previouslyInstalledAppIdentifiers);
+					const removedAppIdentifiers = _.difference(previouslyInstalledAppIdentifiers, currentlyInstalledAppIdentifiers);
 
 					this.lastInstalledAppIdentifiers = currentlyInstalledAppIdentifiers;
 
@@ -91,11 +91,11 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 	public abstract async getDebuggableAppViews(appIdentifiers: string[]): Promise<IDictionary<Mobile.IDebugWebViewInfo[]>>;
 
 	private async checkForAvailableDebuggableAppsChanges(): Promise<void> {
-		let currentlyAvailableDebuggableApps = await this.getDebuggableApps();
-		let previouslyAvailableDebuggableApps = this.lastAvailableDebuggableApps || [];
+		const currentlyAvailableDebuggableApps = await this.getDebuggableApps();
+		const previouslyAvailableDebuggableApps = this.lastAvailableDebuggableApps || [];
 
-		let newAvailableDebuggableApps = _.differenceBy(currentlyAvailableDebuggableApps, previouslyAvailableDebuggableApps, "appIdentifier");
-		let notAvailableAppsForDebugging = _.differenceBy(previouslyAvailableDebuggableApps, currentlyAvailableDebuggableApps, "appIdentifier");
+		const newAvailableDebuggableApps = _.differenceBy(currentlyAvailableDebuggableApps, previouslyAvailableDebuggableApps, "appIdentifier");
+		const notAvailableAppsForDebugging = _.differenceBy(previouslyAvailableDebuggableApps, currentlyAvailableDebuggableApps, "appIdentifier");
 
 		this.lastAvailableDebuggableApps = currentlyAvailableDebuggableApps;
 
@@ -112,18 +112,18 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 			}
 		});
 
-		let cordovaDebuggableAppIdentifiers = _(currentlyAvailableDebuggableApps)
+		const cordovaDebuggableAppIdentifiers = _(currentlyAvailableDebuggableApps)
 			.filter(c => c.framework === TARGET_FRAMEWORK_IDENTIFIERS.Cordova)
 			.map(c => c.appIdentifier)
 			.value();
 
-		let currentlyAvailableAppViews = await this.getDebuggableAppViews(cordovaDebuggableAppIdentifiers);
+		const currentlyAvailableAppViews = await this.getDebuggableAppViews(cordovaDebuggableAppIdentifiers);
 
 		_.each(currentlyAvailableAppViews, (currentlyAvailableViews, appIdentifier) => {
-			let previouslyAvailableViews = this.lastAvailableDebuggableAppViews[appIdentifier];
+			const previouslyAvailableViews = this.lastAvailableDebuggableAppViews[appIdentifier];
 
-			let newAvailableViews = _.differenceBy(currentlyAvailableViews, previouslyAvailableViews, "id");
-			let notAvailableViews = _.differenceBy(previouslyAvailableViews, currentlyAvailableViews, "id");
+			const newAvailableViews = _.differenceBy(currentlyAvailableViews, previouslyAvailableViews, "id");
+			const notAvailableViews = _.differenceBy(previouslyAvailableViews, currentlyAvailableViews, "id");
 
 			_.each(notAvailableViews, debugWebViewInfo => {
 				this.emit("debuggableViewLost", appIdentifier, debugWebViewInfo);
@@ -134,9 +134,9 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 			});
 
 			// Determine which of the views had changed since last check and raise debuggableViewChanged event for them:
-			let keptViews = _.differenceBy(currentlyAvailableViews, newAvailableViews, "id");
+			const keptViews = _.differenceBy(currentlyAvailableViews, newAvailableViews, "id");
 			_.each(keptViews, view => {
-				let previousTimeViewInfo = _.find(previouslyAvailableViews, previousView => previousView.id === view.id);
+				const previousTimeViewInfo = _.find(previouslyAvailableViews, previousView => previousView.id === view.id);
 				if (!_.isEqual(view, previousTimeViewInfo)) {
 					this.emit("debuggableViewChanged", appIdentifier, view);
 				}

--- a/mobile/device-app-data/device-app-data-factory.ts
+++ b/mobile/device-app-data/device-app-data-factory.ts
@@ -4,9 +4,9 @@ export class DeviceAppDataFactory implements Mobile.IDeviceAppDataFactory {
 		private $options: ICommonOptions) { }
 
 	create<T>(appIdentifier: string, platform: string, device: Mobile.IDevice, liveSyncOptions?: { isForCompanionApp: boolean }): T {
-		let factoryRules = this.$deviceAppDataProvider.createFactoryRules();
-		let isForCompanionApp = (liveSyncOptions && liveSyncOptions.isForCompanionApp) || this.$options.companion;
-		let ctor = (<any>factoryRules[platform])[isForCompanionApp ? "companion" : "vanilla"];
+		const factoryRules = this.$deviceAppDataProvider.createFactoryRules();
+		const isForCompanionApp = (liveSyncOptions && liveSyncOptions.isForCompanionApp) || this.$options.companion;
+		const ctor = (<any>factoryRules[platform])[isForCompanionApp ? "companion" : "vanilla"];
 		return this.$injector.resolve(ctor, { _appIdentifier: appIdentifier, device: device, platform: platform });
 	}
 }

--- a/mobile/device-log-provider-base.ts
+++ b/mobile/device-log-provider-base.ts
@@ -18,7 +18,7 @@ export abstract class DeviceLogProviderBase extends EventEmitter implements Mobi
 	}
 
 	protected setDefaultLogLevelForDevice(deviceIdentifier: string): string {
-		let logLevel = (this.devicesLogOptions[deviceIdentifier] && this.devicesLogOptions[deviceIdentifier].logLevel) || this.$logFilter.loggingLevel;
+		const logLevel = (this.devicesLogOptions[deviceIdentifier] && this.devicesLogOptions[deviceIdentifier].logLevel) || this.$logFilter.loggingLevel;
 		this.setLogLevel(logLevel, deviceIdentifier);
 
 		return logLevel;
@@ -29,7 +29,7 @@ export abstract class DeviceLogProviderBase extends EventEmitter implements Mobi
 	}
 
 	protected setDeviceLogOptionsProperty(deviceIdentifier: string, propNameFunction: Function, propertyValue: string): void {
-		let propertyName = getPropertyName(propNameFunction);
+		const propertyName = getPropertyName(propNameFunction);
 
 		if (propertyName) {
 			this.devicesLogOptions[deviceIdentifier] = this.devicesLogOptions[deviceIdentifier] || <Mobile.IDeviceLogOptions>{};

--- a/mobile/device-log-provider.ts
+++ b/mobile/device-log-provider.ts
@@ -7,8 +7,8 @@ export class DeviceLogProvider extends DeviceLogProviderBase {
 	}
 
 	public logData(lineText: string, platform: string, deviceIdentifier: string): void {
-		let applicationPid = this.getApplicationPidForDevice(deviceIdentifier);
-		let data = this.$logFilter.filterData(platform, lineText, applicationPid);
+		const applicationPid = this.getApplicationPidForDevice(deviceIdentifier);
+		const data = this.$logFilter.filterData(platform, lineText, applicationPid);
 		if (data) {
 			this.$logger.write(data);
 		}

--- a/mobile/ios/device/ios-application-manager.ts
+++ b/mobile/ios/device/ios-application-manager.ts
@@ -63,7 +63,7 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 			await this.getApplicationsLiveSyncSupportedStatus();
 		}
 
-		let selectedApplication = _.find(this.applicationsLiveSyncInfos, app => app.applicationIdentifier === appIdentifier);
+		const selectedApplication = _.find(this.applicationsLiveSyncInfos, app => app.applicationIdentifier === appIdentifier);
 		return !!selectedApplication && selectedApplication.isLiveSyncSupported;
 	}
 

--- a/mobile/ios/device/ios-device-operations.ts
+++ b/mobile/ios/device/ios-device-operations.ts
@@ -35,7 +35,7 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 		this.isInitialized = true;
 		if (!this.deviceLib) {
 			let foundDevice = false;
-			let wrappedDeviceFoundCallback = (deviceInfo: IOSDeviceLib.IDeviceActionInfo) => {
+			const wrappedDeviceFoundCallback = (deviceInfo: IOSDeviceLib.IDeviceActionInfo) => {
 				foundDevice = true;
 
 				return deviceFoundCallback(deviceInfo);
@@ -48,10 +48,10 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 
 			// We need this because we need to make sure that we have devices.
 			await new Promise((resolve, reject) => {
-				let iterationsCount = 0,
-					maxIterationsCount = 3;
+				let iterationsCount = 0;
+				const maxIterationsCount = 3;
 
-				let intervalHandle: NodeJS.Timer = setInterval(() => {
+				const intervalHandle: NodeJS.Timer = setInterval(() => {
 					if (foundDevice) {
 						resolve();
 						return clearInterval(intervalHandle);
@@ -206,7 +206,7 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 		const result: T[] = [];
 		const promises = getPromisesMethod();
 
-		for (let promise of promises) {
+		for (const promise of promises) {
 			if (errorHandler) {
 				try {
 					result.push(await promise);

--- a/mobile/ios/device/ios-device.ts
+++ b/mobile/ios/device/ios-device.ts
@@ -75,8 +75,8 @@ export class IOSDevice implements Mobile.IiOSDevice {
 		let activeArchitecture = "";
 		if (productType) {
 			productType = productType.toLowerCase().trim();
-			let majorVersionAsString = productType.match(/.*?(\d+)\,(\d+)/)[1];
-			let majorVersion = parseInt(majorVersionAsString);
+			const majorVersionAsString = productType.match(/.*?(\d+)\,(\d+)/)[1];
+			const majorVersion = parseInt(majorVersionAsString);
 			let isArm64Architecture = false;
 			//https://en.wikipedia.org/wiki/List_of_iOS_devices
 			if (_.startsWith(productType, "iphone")) {

--- a/mobile/ios/ios-log-filter.ts
+++ b/mobile/ios/ios-log-filter.ts
@@ -4,14 +4,14 @@ export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 	constructor(private $loggingLevels: Mobile.ILoggingLevels) { }
 
 	public filterData(data: string, logLevel: string, pid?: string): string {
-		let specifiedLogLevel = (logLevel || '').toUpperCase();
+		const specifiedLogLevel = (logLevel || '').toUpperCase();
 
 		if (specifiedLogLevel === this.$loggingLevels.info && data) {
 			if (pid) {
 				return data.indexOf(`[${pid}]`) !== -1 ? data.trim() : null;
 			}
 
-			let matchingInfoMessage = data.match(this.infoFilterRegex);
+			const matchingInfoMessage = data.match(this.infoFilterRegex);
 			return matchingInfoMessage ? matchingInfoMessage[2] : null;
 		}
 

--- a/mobile/ios/simulator/ios-emulator-services.ts
+++ b/mobile/ios/simulator/ios-emulator-services.ts
@@ -28,7 +28,7 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 			this.$errors.failWithoutHelp("iOS Simulator is available only on Mac OS X.");
 		}
 
-		let platform = this.$devicePlatformsConstants.iOS;
+		const platform = this.$devicePlatformsConstants.iOS;
 		if (dependsOnProject && !this.$emulatorSettingsService.canStart(platform)) {
 			this.$errors.failWithoutHelp("The current project does not target iOS and cannot be run in the iOS Simulator.");
 		}
@@ -46,10 +46,10 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 	}
 
 	public async postDarwinNotification(notification: string): Promise<void> {
-		let iosSimPath = this.$iOSSimResolver.iOSSimPath;
-		let nodeCommandName = process.argv[0];
+		const iosSimPath = this.$iOSSimResolver.iOSSimPath;
+		const nodeCommandName = process.argv[0];
 
-		let iosSimArgs = [iosSimPath, "notify-post", notification];
+		const iosSimArgs = [iosSimPath, "notify-post", notification];
 
 		if (this.$options.device) {
 			iosSimArgs.push("--device", this.$options.device);
@@ -60,8 +60,8 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 
 	private async runApplicationOnEmulatorCore(app: string, emulatorOptions?: Mobile.IEmulatorOptions): Promise<any> {
 		this.$logger.info("Starting iOS Simulator");
-		let iosSimPath = this.$iOSSimResolver.iOSSimPath;
-		let nodeCommandName = process.argv[0];
+		const iosSimPath = this.$iOSSimResolver.iOSSimPath;
+		const nodeCommandName = process.argv[0];
 
 		if (this.$options.availableDevices) {
 			await this.$childProcess.spawnFromEvent(nodeCommandName, [iosSimPath, "device-types"], "close", { stdio: "inherit" });
@@ -114,7 +114,7 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 			opts.push("--skipInstall");
 		}
 
-		let stdioOpts = { stdio: (emulatorOptions && emulatorOptions.captureStdin) ? "pipe" : "inherit" };
+		const stdioOpts = { stdio: (emulatorOptions && emulatorOptions.captureStdin) ? "pipe" : "inherit" };
 
 		return this.$childProcess.spawn(nodeCommandName, opts, stdioOpts);
 	}

--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -24,9 +24,9 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 	public async installApplication(packageFilePath: string): Promise<void> {
 		if (this.$fs.exists(packageFilePath) && path.extname(packageFilePath) === ".zip") {
 			temp.track();
-			let dir = temp.mkdirSync("simulatorPackage");
+			const dir = temp.mkdirSync("simulatorPackage");
 			await this.$fs.unzip(packageFilePath, dir);
-			let app = _.find(this.$fs.readDirectory(dir), directory => path.extname(directory) === ".app");
+			const app = _.find(this.$fs.readDirectory(dir), directory => path.extname(directory) === ".app");
 			if (app) {
 				packageFilePath = path.join(dir, app);
 			}
@@ -40,8 +40,8 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 	}
 
 	public async startApplication(appIdentifier: string): Promise<void> {
-		let launchResult = this.iosSim.startApplication(this.identifier, appIdentifier);
-		let pid = launchResult.split(":")[1].trim();
+		const launchResult = this.iosSim.startApplication(this.identifier, appIdentifier);
+		const pid = launchResult.split(":")[1].trim();
 		this.$deviceLogProvider.setApplicationPidForDevice(this.identifier, pid);
 
 		if (!this.$options.justlaunch) {
@@ -58,8 +58,8 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 	}
 
 	public async getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo> {
-		let result: Mobile.IApplicationInfo = null,
-			plistContent = await this.getParsedPlistContent(applicationIdentifier);
+		let result: Mobile.IApplicationInfo = null;
+		const plistContent = await this.getParsedPlistContent(applicationIdentifier);
 
 		if (plistContent) {
 			result = {
@@ -73,7 +73,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 	}
 
 	public async isLiveSyncSupported(appIdentifier: string): Promise<boolean> {
-		let plistContent = await this.getParsedPlistContent(appIdentifier);
+		const plistContent = await this.getParsedPlistContent(appIdentifier);
 		if (plistContent) {
 			return !!plistContent && !!plistContent.IceniumLiveSyncEnabled;
 		}
@@ -86,7 +86,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 			return null;
 		}
 
-		let applicationPath = this.iosSim.getApplicationPath(this.identifier, appIdentifier),
+		const applicationPath = this.iosSim.getApplicationPath(this.identifier, appIdentifier),
 			pathToInfoPlist = path.join(applicationPath, "Info.plist");
 
 		return this.$fs.exists(pathToInfoPlist) ? (await this.$bplistParser.parseFile(pathToInfoPlist))[0] : null;

--- a/mobile/ios/simulator/ios-simulator-file-system.ts
+++ b/mobile/ios/simulator/ios-simulator-file-system.ts
@@ -31,9 +31,9 @@ export class IOSSimulatorFileSystem implements Mobile.IDeviceFileSystem {
 	}
 
 	public async transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<Mobile.ILocalToDevicePathData[]> {
-		let destinationPath = await deviceAppData.getDeviceProjectRootPath();
+		const destinationPath = await deviceAppData.getDeviceProjectRootPath();
 		this.$logger.trace(`Transferring from ${projectFilesPath} to ${destinationPath}`);
-		let sourcePath = path.join(projectFilesPath, "*");
+		const sourcePath = path.join(projectFilesPath, "*");
 		shelljs.cp("-Rf", sourcePath, destinationPath);
 		return localToDevicePaths;
 	}

--- a/mobile/ios/simulator/ios-simulator-log-provider.ts
+++ b/mobile/ios/simulator/ios-simulator-log-provider.ts
@@ -10,9 +10,9 @@ export class IOSSimulatorLogProvider implements Mobile.IiOSSimulatorLogProvider 
 
 	public startLogProcess(deviceIdentifier: string): void {
 		if (!this.isStarted) {
-			let deviceLogChildProcess: ChildProcess = this.$iOSSimResolver.iOSSim.getDeviceLogProcess(deviceIdentifier);
+			const deviceLogChildProcess: ChildProcess = this.$iOSSimResolver.iOSSim.getDeviceLogProcess(deviceIdentifier);
 
-			let action = (data: NodeBuffer | string) => {
+			const action = (data: NodeBuffer | string) => {
 				this.$deviceLogProvider.logData(data.toString(), this.$devicePlatformsConstants.iOS, deviceIdentifier);
 			};
 

--- a/mobile/local-to-device-path-data-factory.ts
+++ b/mobile/local-to-device-path-data-factory.ts
@@ -16,7 +16,7 @@ class LocalToDevicePathData implements Mobile.ILocalToDevicePathData {
 
 	public getDevicePath(): string {
 		if (!this.devicePath) {
-			let devicePath = path.join(this.deviceProjectRootPath, path.dirname(this.getRelativeToProjectBasePath()), this.onDeviceFileName);
+			const devicePath = path.join(this.deviceProjectRootPath, path.dirname(this.getRelativeToProjectBasePath()), this.onDeviceFileName);
 			this.devicePath = helpers.fromWindowsRelativePathToUnix(devicePath);
 		}
 

--- a/mobile/log-filter.ts
+++ b/mobile/log-filter.ts
@@ -16,7 +16,7 @@ export class LogFilter implements Mobile.ILogFilter {
 	}
 
 	public filterData(platform: string, data: string, pid?: string, logLevel?: string): string {
-		let deviceLogFilter = this.getDeviceLogFilterInstance(platform);
+		const deviceLogFilter = this.getDeviceLogFilterInstance(platform);
 		if (deviceLogFilter) {
 			return deviceLogFilter.filterData(data, logLevel || this.loggingLevel, pid);
 		}
@@ -38,7 +38,7 @@ export class LogFilter implements Mobile.ILogFilter {
 	}
 
 	private verifyLogLevel(logLevel: string): boolean {
-		let upperCaseLogLevel = (logLevel || '').toUpperCase();
+		const upperCaseLogLevel = (logLevel || '').toUpperCase();
 		return upperCaseLogLevel === this.$loggingLevels.info.toUpperCase() || upperCaseLogLevel === this.$loggingLevels.full.toUpperCase();
 	}
 

--- a/mobile/mobile-core/android-device-discovery.ts
+++ b/mobile/mobile-core/android-device-discovery.ts
@@ -20,7 +20,7 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery implements Mobile.IA
 
 	private async createAndAddDevice(adbDeviceInfo: IAdbAndroidDeviceInfo): Promise<void> {
 		this._devices.push(adbDeviceInfo);
-		let device: Mobile.IAndroidDevice = this.$injector.resolve(AndroidDevice, { identifier: adbDeviceInfo.identifier, status: adbDeviceInfo.status });
+		const device: Mobile.IAndroidDevice = this.$injector.resolve(AndroidDevice, { identifier: adbDeviceInfo.identifier, status: adbDeviceInfo.status });
 		await device.init();
 		this.addDevice(device);
 	}
@@ -39,7 +39,7 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery implements Mobile.IA
 	}
 
 	public async checkForDevices(): Promise<void> {
-		let result = await this.$adb.executeCommand(["devices"], { returnChildProcess: true });
+		const result = await this.$adb.executeCommand(["devices"], { returnChildProcess: true });
 		return new Promise<void>((resolve, reject) => {
 			let adbData = "";
 			let errorData = "";
@@ -80,13 +80,13 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery implements Mobile.IA
 	private async checkCurrentData(result: any): Promise<void> {
 		const currentData = result.toString();
 
-		let currentDevices: IAdbAndroidDeviceInfo[] = currentData
+		const currentDevices: IAdbAndroidDeviceInfo[] = currentData
 			.split(EOL)
 			.slice(1)
 			.filter((element: string) => !helpers.isNullOrWhitespace(element) && element.indexOf("* daemon ") === -1 && element.indexOf("adb server") === -1)
 			.map((element: string) => {
 				// http://developer.android.com/tools/help/adb.html#devicestatus
-				let data = element.split('\t'),
+				const data = element.split('\t'),
 					identifier = data[0],
 					status = data[1];
 				return {

--- a/mobile/mobile-core/android-process-service.ts
+++ b/mobile/mobile-core/android-process-service.ts
@@ -18,10 +18,10 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 	private get androidPortInformationRegExp(): RegExp {
 		// The RegExp should look like this:
 		// /(\d+):\s+([0-9A-Za-z]+:[0-9A-Za-z]+)\s+([0-9A-Za-z]+:[0-9A-Za-z]+)\s+[0-9A-Za-z]+\s+[0-9A-Za-z]+:[0-9A-Za-z]+\s+[0-9A-Za-z]+:[0-9A-Za-z]+\s+[0-9A-Za-z]+\s+(\d+)/g
-		let wordCharacters = "[0-9A-Za-z]+";
-		let hexIpAddressWithPort = "[0-9A-Za-z]+:[0-9A-Za-z]+";
-		let hexIpAddressWithPortWithSpace = `${hexIpAddressWithPort}\\s+`;
-		let hexIpAddressWithPortWithSpaceMatch = `(${hexIpAddressWithPort})\\s+`;
+		const wordCharacters = "[0-9A-Za-z]+";
+		const hexIpAddressWithPort = "[0-9A-Za-z]+:[0-9A-Za-z]+";
+		const hexIpAddressWithPortWithSpace = `${hexIpAddressWithPort}\\s+`;
+		const hexIpAddressWithPortWithSpaceMatch = `(${hexIpAddressWithPort})\\s+`;
 
 		return new RegExp(`(\\d+):\\s+${hexIpAddressWithPortWithSpaceMatch}${hexIpAddressWithPortWithSpaceMatch}${wordCharacters}\\s+${hexIpAddressWithPortWithSpace}${hexIpAddressWithPortWithSpace}${wordCharacters}\\s+(\\d+)`, "g");
 	}
@@ -29,16 +29,16 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 	public async mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string, framework: string): Promise<string> {
 		this.tryAttachToProcessExitSignals();
 
-		let adb = this.getAdb(deviceIdentifier);
-		let processId = (await this.getProcessIds(adb, [appIdentifier]))[appIdentifier];
-		let applicationNotStartedErrorMessage = `The application is not started on the device with identifier ${deviceIdentifier}.`;
+		const adb = this.getAdb(deviceIdentifier);
+		const processId = (await this.getProcessIds(adb, [appIdentifier]))[appIdentifier];
+		const applicationNotStartedErrorMessage = `The application is not started on the device with identifier ${deviceIdentifier}.`;
 
 		if (!processId) {
 			this.$errors.failWithoutHelp(applicationNotStartedErrorMessage);
 		}
 
-		let abstractPortsInformation = await this.getAbstractPortsInformation(adb);
-		let abstractPort = await this.getAbstractPortForApplication(adb, processId, appIdentifier, abstractPortsInformation, framework);
+		const abstractPortsInformation = await this.getAbstractPortsInformation(adb);
+		const abstractPort = await this.getAbstractPortForApplication(adb, processId, appIdentifier, abstractPortsInformation, framework);
 
 		if (!abstractPort) {
 			this.$errors.failWithoutHelp(applicationNotStartedErrorMessage);
@@ -56,7 +56,7 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 	}
 
 	public async getMappedAbstractToTcpPorts(deviceIdentifier: string, appIdentifiers: string[], framework: string): Promise<IDictionary<number>> {
-		let adb = this.getAdb(deviceIdentifier),
+		const adb = this.getAdb(deviceIdentifier),
 			abstractPortsInformation = await this.getAbstractPortsInformation(adb),
 			processIds = await this.getProcessIds(adb, appIdentifiers),
 			adbForwardList = await adb.executeCommand(["forward", "--list"]),
@@ -65,19 +65,19 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 		await Promise.all(
 			_.map(appIdentifiers, async appIdentifier => {
 				localPorts[appIdentifier] = null;
-				let processId = processIds[appIdentifier];
+				const processId = processIds[appIdentifier];
 
 				if (!processId) {
 					return;
 				}
 
-				let abstractPort = await this.getAbstractPortForApplication(adb, processId, appIdentifier, abstractPortsInformation, framework);
+				const abstractPort = await this.getAbstractPortForApplication(adb, processId, appIdentifier, abstractPortsInformation, framework);
 
 				if (!abstractPort) {
 					return;
 				}
 
-				let localPort = await this.getAlreadyMappedPort(adb, deviceIdentifier, abstractPort, adbForwardList);
+				const localPort = await this.getAlreadyMappedPort(adb, deviceIdentifier, abstractPort, adbForwardList);
 
 				if (localPort) {
 					localPorts[appIdentifier] = localPort;
@@ -88,8 +88,8 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 	}
 
 	public async getDebuggableApps(deviceIdentifier: string): Promise<Mobile.IDeviceApplicationInformation[]> {
-		let adb = this.getAdb(deviceIdentifier);
-		let androidWebViewPortInformation = (await this.getAbstractPortsInformation(adb)).split(EOL);
+		const adb = this.getAdb(deviceIdentifier);
+		const androidWebViewPortInformation = (await this.getAbstractPortsInformation(adb)).split(EOL);
 
 		// TODO: Add tests and make sure only unique names are returned. Input before groupBy is:
 		// [ { deviceIdentifier: 'SH26BW100473',
@@ -104,7 +104,7 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 		// 	{ deviceIdentifier: 'SH26BW100473',
 		// 	appIdentifier: 'chrome',
 		// 	framework: 'Cordova' } ]
-		let portInformation = await Promise.all(
+		const portInformation = await Promise.all(
 			_.map(androidWebViewPortInformation, async line => await this.getApplicationInfoFromWebViewPortInformation(adb, deviceIdentifier, line)
 				|| await this.getNativeScriptApplicationInformation(adb, deviceIdentifier, line)
 			)
@@ -127,17 +127,17 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 
 	private async getApplicationInfoFromWebViewPortInformation(adb: Mobile.IDeviceAndroidDebugBridge, deviceIdentifier: string, information: string): Promise<Mobile.IDeviceApplicationInformation> {
 		// Need to search by processId to check for old Android webviews (@webview_devtools_remote_<processId>).
-		let processIdRegExp = /@webview_devtools_remote_(.+)/g,
-			processIdMatches = processIdRegExp.exec(information),
-			cordovaAppIdentifier: string;
+		const processIdRegExp = /@webview_devtools_remote_(.+)/g;
+		const processIdMatches = processIdRegExp.exec(information);
+		let cordovaAppIdentifier: string;
 
 		if (processIdMatches) {
-			let processId = processIdMatches[1];
+			const processId = processIdMatches[1];
 			cordovaAppIdentifier = await this.getApplicationIdentifierFromPid(adb, processId);
 		} else {
 			// Search for appIdentifier (@<appIdentifier>_devtools_remote).
-			let chromeAppIdentifierRegExp = /@(.+)_devtools_remote\s?/g;
-			let chromeAppIdentifierMatches = chromeAppIdentifierRegExp.exec(information);
+			const chromeAppIdentifierRegExp = /@(.+)_devtools_remote\s?/g;
+			const chromeAppIdentifierMatches = chromeAppIdentifierRegExp.exec(information);
 
 			if (chromeAppIdentifierMatches && chromeAppIdentifierMatches.length > 0) {
 				cordovaAppIdentifier = chromeAppIdentifierMatches[1];
@@ -157,11 +157,11 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 
 	private async getNativeScriptApplicationInformation(adb: Mobile.IDeviceAndroidDebugBridge, deviceIdentifier: string, information: string): Promise<Mobile.IDeviceApplicationInformation> {
 		// Search for appIdentifier (@<appIdentifier-debug>).
-		let nativeScriptAppIdentifierRegExp = /@(.+)-(debug|inspectorServer)/g;
-		let nativeScriptAppIdentifierMatches = nativeScriptAppIdentifierRegExp.exec(information);
+		const nativeScriptAppIdentifierRegExp = /@(.+)-(debug|inspectorServer)/g;
+		const nativeScriptAppIdentifierMatches = nativeScriptAppIdentifierRegExp.exec(information);
 
 		if (nativeScriptAppIdentifierMatches && nativeScriptAppIdentifierMatches.length > 0) {
-			let appIdentifier = nativeScriptAppIdentifierMatches[1];
+			const appIdentifier = nativeScriptAppIdentifierMatches[1];
 			return {
 				deviceIdentifier: deviceIdentifier,
 				appIdentifier: appIdentifier,
@@ -204,9 +204,9 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 	}
 
 	private getPortInformation(abstractPortsInformation: string, searchedInfo: string | number): string {
-		let processRegExp = new RegExp(`\\w+:\\s+(?:\\w+\\s+){1,6}@(.*?${searchedInfo})$`, "gm");
+		const processRegExp = new RegExp(`\\w+:\\s+(?:\\w+\\s+){1,6}@(.*?${searchedInfo})$`, "gm");
 
-		let match = processRegExp.exec(abstractPortsInformation);
+		const match = processRegExp.exec(abstractPortsInformation);
 		return match && match[1];
 	}
 
@@ -214,10 +214,10 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 		// Process information will look like this (without the columns names):
 		// USER     PID   PPID  VSIZE   RSS   WCHAN    PC         NAME
 		// u0_a63   25512 1334  1519560 96040 ffffffff f76a8f75 S com.telerik.appbuildertabstest
-		let result: IDictionary<number> = {};
-		let processIdInformation: string = await adb.executeShellCommand(["ps"]);
+		const result: IDictionary<number> = {};
+		const processIdInformation: string = await adb.executeShellCommand(["ps"]);
 		_.each(appIdentifiers, appIdentifier => {
-			let processIdRegExp = new RegExp(`^\\w*\\s*(\\d+).*?${appIdentifier}$`);
+			const processIdRegExp = new RegExp(`^\\w*\\s*(\\d+).*?${appIdentifier}$`);
 			result[appIdentifier] = this.getFirstMatchingGroupFromMultilineResult<number>(processIdInformation, processIdRegExp);
 		});
 
@@ -225,14 +225,14 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 	}
 
 	private async getAlreadyMappedPort(adb: Mobile.IDeviceAndroidDebugBridge, deviceIdentifier: string, abstractPort: string, adbForwardList?: any): Promise<number> {
-		let allForwardedPorts: string = adbForwardList || await adb.executeCommand(["forward", "--list"]) || "";
+		const allForwardedPorts: string = adbForwardList || await adb.executeCommand(["forward", "--list"]) || "";
 
 		// Sample output:
 		// 5e2e580b tcp:62503 localabstract:webview_devtools_remote_7985
 		// 5e2e580b tcp:62524 localabstract:webview_devtools_remote_7986
 		// 5e2e580b tcp:63160 localabstract:webview_devtools_remote_7987
 		// 5e2e580b tcp:57577 localabstract:com.telerik.nrel-debug
-		let regex = new RegExp(`${deviceIdentifier}\\s+?tcp:(\\d+?)\\s+?.*?${abstractPort}$`);
+		const regex = new RegExp(`${deviceIdentifier}\\s+?tcp:(\\d+?)\\s+?.*?${abstractPort}$`);
 
 		return this.getFirstMatchingGroupFromMultilineResult<number>(allForwardedPorts, regex);
 	}
@@ -260,7 +260,7 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 			.map(line => line.trim())
 			.filter(line => !!line)
 			.each(line => {
-				let matches = line.match(regex);
+				const matches = line.match(regex);
 				if (matches && matches[1]) {
 					result = <any>matches[1];
 					return false;

--- a/mobile/mobile-core/device-discovery.ts
+++ b/mobile/mobile-core/device-discovery.ts
@@ -10,7 +10,7 @@ export class DeviceDiscovery extends EventEmitter implements Mobile.IDeviceDisco
 	}
 
 	public removeDevice(deviceIdentifier: string) {
-		let device = this.devices[deviceIdentifier];
+		const device = this.devices[deviceIdentifier];
 		if (!device) {
 			return;
 		}

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -105,8 +105,8 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	}
 
 	private getPlatform(platform: string): string {
-		let allSupportedPlatforms = this.getAllPlatforms();
-		let normalizedPlatform = this.$mobileHelper.validatePlatformName(platform);
+		const allSupportedPlatforms = this.getAllPlatforms();
+		const normalizedPlatform = this.$mobileHelper.validatePlatformName(platform);
 		if (!_.includes(allSupportedPlatforms, normalizedPlatform)) {
 			this.$errors.failWithoutHelp("Deploying to %s connected devices is not supported. Build the " +
 				"app using the `build` command and deploy the package manually.", normalizedPlatform);
@@ -207,7 +207,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	 * @param identifier running emulator or device identifier
 	 */
 	public getDeviceByIdentifier(identifier: string): Mobile.IDevice {
-		let searchedDevice = _.find(this.getDeviceInstances(), (device: Mobile.IDevice) => { return device.deviceInfo.identifier === identifier; });
+		const searchedDevice = _.find(this.getDeviceInstances(), (device: Mobile.IDevice) => { return device.deviceInfo.identifier === identifier; });
 		if (!searchedDevice) {
 			this.$errors.fail(this.$messages.Devices.NotFoundDeviceByIdentifierErrorMessageWithIdentifier, identifier, this.$staticConfig.CLIENT_NAME.toLowerCase());
 		}
@@ -266,7 +266,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 
 		let emulatorIdentifier = null;
 		if (this._platform) {
-			let emulatorService = this.resolveEmulatorServices();
+			const emulatorService = this.resolveEmulatorServices();
 			emulatorIdentifier = await emulatorService.getRunningEmulatorId(deviceOption);
 		}
 
@@ -302,12 +302,12 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	 * @param canExecute predicate to decide whether the command can be ran
 	 */
 	private async executeOnAllConnectedDevices<T>(action: (dev: Mobile.IDevice) => Promise<T>, canExecute?: (_dev: Mobile.IDevice) => boolean): Promise<Mobile.IDeviceActionResult<T>[]> {
-		let devices = this.filterDevicesByPlatform();
-		let sortedDevices = _.sortBy(devices, device => device.deviceInfo.platform);
+		const devices = this.filterDevicesByPlatform();
+		const sortedDevices = _.sortBy(devices, device => device.deviceInfo.platform);
 		const result: Mobile.IDeviceActionResult<T>[] = [];
 
-		let errors: Mobile.IDeviceError[] = [];
-		for (let device of sortedDevices) {
+		const errors: Mobile.IDeviceError[] = [];
+		for (const device of sortedDevices) {
 			try {
 				if (!canExecute || canExecute(device)) {
 					result.push({ deviceIdentifier: device.deviceInfo.identifier, result: await action(device) });
@@ -324,7 +324,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 				preErrorMsg = "Multiple errors were thrown:" + EOL;
 			}
 
-			let singleError = <Mobile.IDevicesOperationError>(new Error(`${preErrorMsg}${errors.map(e => e.message || e).join(EOL)}`));
+			const singleError = <Mobile.IDevicesOperationError>(new Error(`${preErrorMsg}${errors.map(e => e.message || e).join(EOL)}`));
 			singleError.allErrors = errors;
 			throw singleError;
 		}
@@ -352,13 +352,13 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 				&& this.$mobileHelper.isiOSPlatform(this._platform)
 				&& this.$options.emulator && !this.isOnlyiOSSimultorRunning()) {
 				// Executes the command only on iOS simulator
-				let originalCanExecute = canExecute;
+				const originalCanExecute = canExecute;
 				canExecute = (dev: Mobile.IDevice): boolean => this.isiOSSimulator(dev) && (!originalCanExecute || !!(originalCanExecute(dev)));
 			}
 
 			return await this.executeCore(action, canExecute);
 		} else {
-			let message = constants.ERROR_NO_DEVICES;
+			const message = constants.ERROR_NO_DEVICES;
 			if (options && options.allowNoDevices) {
 				this.$logger.info(message);
 			} else {
@@ -390,7 +390,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 			} catch (err) {
 				this.$logger.trace("Error while checking for devices.", err);
 			}
-			let deviceInstances = this.getDeviceInstances();
+			const deviceInstances = this.getDeviceInstances();
 
 			if (!data.deviceId && _.isEmpty(deviceInstances)) {
 				if (!this.$hostInfo.isDarwin && this.$mobileHelper.isiOSPlatform(data.platform)) {
@@ -419,7 +419,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 			//check if --device(value) is running, if it's not or it's not the same as is specified, start with name from --device(value)
 			if (data.deviceId) {
 				if (!helpers.isNumber(data.deviceId)) {
-					let activeDeviceInstance = _.find(deviceInstances, (device: Mobile.IDevice) => { return device.deviceInfo.identifier === data.deviceId; });
+					const activeDeviceInstance = _.find(deviceInstances, (device: Mobile.IDevice) => { return device.deviceInfo.identifier === data.deviceId; });
 					if (!activeDeviceInstance) {
 						return await this.startEmulator(data.platform, data.deviceId);
 					}
@@ -428,7 +428,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 
 			// if only emulator flag is passed and no other emulators are running, start default emulator
 			if (data.emulator && deviceInstances.length) {
-				let runningDeviceInstance = _.some(deviceInstances, (value) => value.isEmulator);
+				const runningDeviceInstance = _.some(deviceInstances, (value) => value.isEmulator);
 				if (!runningDeviceInstance) {
 					return await this.startEmulator(data.platform);
 				}
@@ -456,8 +456,8 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 		}
 
 		this._data = data;
-		let platform = data.platform;
-		let deviceOption = data.deviceId;
+		const platform = data.platform;
+		const deviceOption = data.deviceId;
 
 		if (platform && deviceOption) {
 			this._platform = this.getPlatform(data.platform);
@@ -484,8 +484,8 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 			} else {
 				await this.detectCurrentlyAttachedDevices();
 
-				let devices = this.getDeviceInstances();
-				let platforms = _(devices)
+				const devices = this.getDeviceInstances();
+				const platforms = _(devices)
 					.map(device => device.deviceInfo.platform)
 					.filter(pl => {
 						try {
@@ -524,7 +524,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	}
 
 	public isOnlyiOSSimultorRunning(): boolean {
-		let devices = this.getDeviceInstances();
+		const devices = this.getDeviceInstances();
 		return this._platform && this.$mobileHelper.isiOSPlatform(this._platform) && _.find(devices, d => d.isEmulator) && !_.find(devices, d => !d.isEmulator);
 	}
 
@@ -544,7 +544,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 
 	@exported("devicesService")
 	public async getDebuggableViews(deviceIdentifier: string, appIdentifier: string): Promise<Mobile.IDebugWebViewInfo[]> {
-		let device = this.getDeviceByIdentifier(deviceIdentifier),
+		const device = this.getDeviceByIdentifier(deviceIdentifier),
 			debuggableViewsPerApp = await device.applicationManager.getDebuggableAppViews([appIdentifier]);
 
 		return debuggableViewsPerApp && debuggableViewsPerApp[appIdentifier];
@@ -559,12 +559,12 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	}
 
 	private async getDebuggableAppsCore(deviceIdentifier: string): Promise<Mobile.IDeviceApplicationInformation[]> {
-		let device = this.getDeviceByIdentifier(deviceIdentifier);
+		const device = this.getDeviceByIdentifier(deviceIdentifier);
 		return await device.applicationManager.getDebuggableApps();
 	}
 
 	private async deployOnDevice(deviceIdentifier: string, packageFile: string, packageName: string): Promise<void> {
-		let device = this.getDeviceByIdentifier(deviceIdentifier);
+		const device = this.getDeviceByIdentifier(deviceIdentifier);
 		await device.applicationManager.reinstallApplication(packageName, packageFile);
 		this.$logger.info(`Successfully deployed on device with identifier '${device.deviceInfo.identifier}'.`);
 		await device.applicationManager.tryStartApplication(packageName);
@@ -618,7 +618,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 
 		platform = platform || this._platform;
 		const deviceLookingOptions = this.getDeviceLookingOptions(platform);
-		let emulatorServices = this.resolveEmulatorServices(platform);
+		const emulatorServices = this.resolveEmulatorServices(platform);
 		if (!emulatorServices) {
 			this.$errors.failWithoutHelp("Unable to detect platform for which to start emulator.");
 		}
@@ -641,9 +641,9 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	}
 
 	private async isApplicationInstalledOnDevice(deviceIdentifier: string, appIdentifier: string): Promise<IAppInstalledInfo> {
-		let isInstalled = false,
-			isLiveSyncSupported = false,
-			device = this.getDeviceByIdentifier(deviceIdentifier);
+		let isInstalled = false;
+		let isLiveSyncSupported = false;
+		const device = this.getDeviceByIdentifier(deviceIdentifier);
 
 		try {
 			isInstalled = await device.applicationManager.isApplicationInstalled(appIdentifier);
@@ -662,10 +662,10 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	}
 
 	private async isCompanionAppInstalledOnDevice(deviceIdentifier: string, framework: string): Promise<IAppInstalledInfo> {
-		let isInstalled = false,
-			isLiveSyncSupported = false,
-			device = this.getDeviceByIdentifier(deviceIdentifier),
-			appIdentifier = this.$companionAppsService.getCompanionAppIdentifier(framework, device.deviceInfo.platform);
+		let isInstalled = false;
+		let isLiveSyncSupported = false;
+		const device = this.getDeviceByIdentifier(deviceIdentifier);
+		const appIdentifier = this.$companionAppsService.getCompanionAppIdentifier(framework, device.deviceInfo.platform);
 
 		try {
 			isLiveSyncSupported = isInstalled = await device.applicationManager.isApplicationInstalled(appIdentifier);

--- a/mobile/mobile-core/ios-device-discovery.ts
+++ b/mobile/mobile-core/ios-device-discovery.ts
@@ -38,7 +38,7 @@ export class IOSDeviceDiscovery extends DeviceDiscovery {
 	}
 
 	private createAndAddDevice(deviceActionInfo: IOSDeviceLib.IDeviceActionInfo): void {
-		let device = this.$injector.resolve(IOSDevice, { deviceActionInfo: deviceActionInfo });
+		const device = this.$injector.resolve(IOSDevice, { deviceActionInfo: deviceActionInfo });
 		this.addDevice(device);
 	}
 }

--- a/mobile/mobile-core/ios-simulator-discovery.ts
+++ b/mobile/mobile-core/ios-simulator-discovery.ts
@@ -50,7 +50,7 @@ export class IOSSimulatorDiscovery extends DeviceDiscovery {
 
 	private async isSimulatorRunning(): Promise<boolean> {
 		try {
-			let output = await this.$childProcess.exec("ps cax | grep launchd_sim");
+			const output = await this.$childProcess.exec("ps cax | grep launchd_sim");
 			return output.indexOf('launchd_sim') !== -1;
 		} catch (e) {
 			return false;

--- a/mobile/mobile-helper.ts
+++ b/mobile/mobile-helper.ts
@@ -16,8 +16,8 @@ export class MobileHelper implements Mobile.IMobileHelper {
 	}
 
 	public getPlatformCapabilities(platform: string): Mobile.IPlatformCapabilities {
-		let platformNames = this.$mobilePlatformsCapabilities.getPlatformNames();
-		let validPlatformName = this.validatePlatformName(platform);
+		const platformNames = this.$mobilePlatformsCapabilities.getPlatformNames();
+		const validPlatformName = this.validatePlatformName(platform);
 		if (!_.some(platformNames, platformName => platformName === validPlatformName)) {
 			this.$errors.failWithoutHelp("'%s' is not a valid device platform. Valid platforms are %s.", platform, platformNames);
 		}
@@ -58,7 +58,7 @@ export class MobileHelper implements Mobile.IMobileHelper {
 			this.$errors.fail("No device platform specified.");
 		}
 
-		let normalizedPlatform = this.normalizePlatformName(platform);
+		const normalizedPlatform = this.normalizePlatformName(platform);
 		if (!normalizedPlatform || !_.includes(this.platformNames, normalizedPlatform)) {
 			this.$errors.fail("'%s' is not a valid device platform. Valid platforms are %s.",
 				platform, helpers.formatListOfNames(this.platformNames));

--- a/mobile/wp8/wp8-emulator-services.ts
+++ b/mobile/wp8/wp8-emulator-services.ts
@@ -38,7 +38,7 @@ class Wp8EmulatorServices implements Mobile.IEmulatorPlatformServices {
 			this.$errors.fail("Windows Phone Emulator is available only on Windows 8 or later.");
 		}
 
-		let platform = this.$devicePlatformsConstants.WP8;
+		const platform = this.$devicePlatformsConstants.WP8;
 		if (!this.$emulatorSettingsService.canStart(platform)) {
 			this.$errors.fail("The current project does not target Windows Phone 8 and cannot be run in the Windows Phone emulator.");
 		}
@@ -50,7 +50,7 @@ class Wp8EmulatorServices implements Mobile.IEmulatorPlatformServices {
 
 	public async runApplicationOnEmulator(app: string, emulatorOptions?: Mobile.IEmulatorOptions): Promise<void> {
 		this.$logger.info("Starting Windows Phone Emulator");
-		let emulatorStarter = this.getPathToEmulatorStarter();
+		const emulatorStarter = this.getPathToEmulatorStarter();
 		this.$childProcess.spawn(emulatorStarter, ["/installlaunch", app, "/targetdevice:xd"], { stdio: "ignore", detached: true }).unref();
 	}
 

--- a/options.ts
+++ b/options.ts
@@ -37,7 +37,7 @@ export class OptionsBase {
 	}
 
 	public get shorthands(): string[] {
-		let result: string[] = [];
+		const result: string[] = [];
 		_.each(_.keys(this.options), optionName => {
 			if (this.options[optionName].alias) {
 				result.push(this.options[optionName].alias);
@@ -98,7 +98,7 @@ export class OptionsBase {
 			this.setArgv();
 		}
 
-		let parsed = Object.create(null);
+		const parsed = Object.create(null);
 		// DO NOT REMOVE { } as when they are missing and some of the option values is false, the each stops as it thinks we have set "return false".
 		_.each(_.keys(this.argv), optionName => {
 			parsed[optionName] = this.getOptionValue(optionName);
@@ -110,14 +110,14 @@ export class OptionsBase {
 				return;
 			}
 
-			let optionName = this.getCorrectOptionName(originalOptionName);
+			const optionName = this.getCorrectOptionName(originalOptionName);
 
 			if (!_.includes(this.optionsWhiteList, optionName)) {
 				if (!this.isOptionSupported(optionName)) {
 					this.$errors.failWithoutHelp(`The option '${originalOptionName}' is not supported. To see command's options, use '$ ${this.$staticConfig.CLIENT_NAME.toLowerCase()} help ${process.argv[2]}'. To see all commands use '$ ${this.$staticConfig.CLIENT_NAME.toLowerCase()} help'.`);
 				}
 
-				let optionType = this.getOptionType(optionName),
+				const optionType = this.getOptionType(optionName),
 					optionValue = parsed[optionName];
 
 				if (_.isArray(optionValue) && optionType !== OptionType.Array) {
@@ -132,23 +132,23 @@ export class OptionsBase {
 	}
 
 	private getCorrectOptionName(optionName: string): string {
-		let secondaryOptionName = this.getNonDashedOptionName(optionName);
+		const secondaryOptionName = this.getNonDashedOptionName(optionName);
 		return _.includes(this.optionNames, secondaryOptionName) ? secondaryOptionName : optionName;
 	}
 
 	private getOptionType(optionName: string): string {
-		let option = this.options[optionName] || this.tryGetOptionByAliasName(optionName);
+		const option = this.options[optionName] || this.tryGetOptionByAliasName(optionName);
 		return option ? option.type : "";
 	}
 
 	private tryGetOptionByAliasName(aliasName: string) {
-		let option = _.find(this.options, opt => opt.alias === aliasName);
+		const option = _.find(this.options, opt => opt.alias === aliasName);
 		return option;
 	}
 
 	private isOptionSupported(option: string): boolean {
 		if (!this.options[option]) {
-			let opt = this.tryGetOptionByAliasName(option);
+			const opt = this.tryGetOptionByAliasName(option);
 			return !!opt;
 		}
 
@@ -161,11 +161,11 @@ export class OptionsBase {
 	// IMPORTANT: In your code, it is better to use the value without dashes (profileDir in the example).
 	// This way your code will work in case "$ <cli name> emulate android --profile-dir" or "$ <cli name> emulate android --profileDir" is used by user.
 	private getNonDashedOptionName(optionName: string): string {
-		let matchUpperCaseLetters = optionName.match(OptionsBase.NONDASHED_OPTION_REGEX);
+		const matchUpperCaseLetters = optionName.match(OptionsBase.NONDASHED_OPTION_REGEX);
 		if (matchUpperCaseLetters) {
 			// get here if option with upperCase letter is specified, for example profileDir
 			// check if in knownOptions we have its kebabCase presentation
-			let secondaryOptionName = matchUpperCaseLetters[1] + matchUpperCaseLetters[2].toUpperCase() + matchUpperCaseLetters[3] || '';
+			const secondaryOptionName = matchUpperCaseLetters[1] + matchUpperCaseLetters[2].toUpperCase() + matchUpperCaseLetters[3] || '';
 			return this.getNonDashedOptionName(secondaryOptionName);
 		}
 
@@ -173,9 +173,9 @@ export class OptionsBase {
 	}
 
 	private getDashedOptionName(optionName: string): string {
-		let matchUpperCaseLetters = optionName.match(OptionsBase.DASHED_OPTION_REGEX);
+		const matchUpperCaseLetters = optionName.match(OptionsBase.DASHED_OPTION_REGEX);
 		if (matchUpperCaseLetters) {
-			let secondaryOptionName = `${matchUpperCaseLetters[1]}-${matchUpperCaseLetters[2].toLowerCase()}${matchUpperCaseLetters[3] || ''}`;
+			const secondaryOptionName = `${matchUpperCaseLetters[1]}-${matchUpperCaseLetters[2].toLowerCase()}${matchUpperCaseLetters[3] || ''}`;
 			return this.getDashedOptionName(secondaryOptionName);
 		}
 
@@ -183,7 +183,7 @@ export class OptionsBase {
 	}
 
 	private setArgv(): void {
-		let opts: IDictionary<IDashedOption> = <IDictionary<IDashedOption>>{};
+		const opts: IDictionary<IDashedOption> = <IDictionary<IDashedOption>>{};
 		_.each(this.options, (value: IDashedOption, key: string) => {
 			opts[this.getDashedOptionName(key)] = value;
 		});

--- a/plugin-variables-helper.ts
+++ b/plugin-variables-helper.ts
@@ -16,7 +16,7 @@ export class PluginVariablesHelper implements IPluginVariablesHelper {
 	public getPluginVariableFromVarOption(variableName: string, configuration?: string): any {
 		let varOption = this.$options.var;
 		configuration = configuration ? configuration.toLowerCase() : undefined;
-		let lowerCasedVariableName = variableName.toLowerCase();
+		const lowerCasedVariableName = variableName.toLowerCase();
 		if (varOption) {
 			let configVariableValue: string;
 			let generalVariableValue: string;
@@ -36,9 +36,9 @@ export class PluginVariablesHelper implements IPluginVariablesHelper {
 				}
 			});
 
-			let value = configVariableValue || generalVariableValue;
+			const value = configVariableValue || generalVariableValue;
 			if (value) {
-				let obj = Object.create(null);
+				const obj = Object.create(null);
 				obj[variableName] = value.toString();
 				return obj;
 			}
@@ -58,7 +58,7 @@ export class PluginVariablesHelper implements IPluginVariablesHelper {
 	 */
 	public simplifyYargsObject(obj: any, configuration?: string): any {
 		if (obj && typeof (obj) === "object") {
-			let convertedObject: any = Object.create({});
+			const convertedObject: any = Object.create({});
 
 			_.each(obj, (propValue: any, propKey: string) => {
 				if (typeof (propValue) !== "object") {
@@ -67,7 +67,7 @@ export class PluginVariablesHelper implements IPluginVariablesHelper {
 				}
 
 				configuration = configuration ? configuration.toLowerCase() : undefined;
-				let innerObj = this.simplifyYargsObject(propValue, configuration);
+				const innerObj = this.simplifyYargsObject(propValue, configuration);
 
 				if (propKey.toLowerCase() === configuration) {
 					// for --var.debug.DATA.APP.ID testId

--- a/progress-indicator.ts
+++ b/progress-indicator.ts
@@ -2,7 +2,7 @@ export class ProgressIndicator implements IProgressIndicator {
 	constructor(private $logger: ILogger) { }
 
 	public async showProgressIndicator<T>(promise: Promise<T>, timeout: number, options?: { surpressTrailingNewLine?: boolean }): Promise<T> {
-		let surpressTrailingNewLine = options && options.surpressTrailingNewLine;
+		const surpressTrailingNewLine = options && options.surpressTrailingNewLine;
 
 		let isResolved = false;
 

--- a/project-helper.ts
+++ b/project-helper.ts
@@ -18,7 +18,7 @@ export class ProjectHelper implements IProjectHelper {
 		let projectDir = path.resolve(this.$options.path || ".");
 		while (true) {
 			this.$logger.trace("Looking for project in '%s'", projectDir);
-			let projectFilePath = path.join(projectDir, this.$staticConfig.PROJECT_FILE_NAME);
+			const projectFilePath = path.join(projectDir, this.$staticConfig.PROJECT_FILE_NAME);
 
 			if (this.$fs.exists(projectFilePath) && this.isProjectFileCorrect(projectFilePath)) {
 				this.$logger.debug("Project directory is '%s'.", projectDir);
@@ -26,7 +26,7 @@ export class ProjectHelper implements IProjectHelper {
 				break;
 			}
 
-			let dir = path.dirname(projectDir);
+			const dir = path.dirname(projectDir);
 			if (dir === projectDir) {
 				this.$logger.debug("No project found at or above '%s'.", this.$options.path || path.resolve("."));
 				break;
@@ -51,15 +51,15 @@ export class ProjectHelper implements IProjectHelper {
 	}
 
 	public sanitizeName(appName: string): string {
-		let sanitizedName = _.filter(appName.split(""), (c) => /[a-zA-Z0-9]/.test(c)).join("");
+		const sanitizedName = _.filter(appName.split(""), (c) => /[a-zA-Z0-9]/.test(c)).join("");
 		return sanitizedName;
 	}
 
 	private isProjectFileCorrect(projectFilePath: string): boolean {
 		if (this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE) {
 			try {
-				let fileContent = this.$fs.readJson(projectFilePath);
-				let clientSpecificData = fileContent[this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE];
+				const fileContent = this.$fs.readJson(projectFilePath);
+				const clientSpecificData = fileContent[this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE];
 				return !!clientSpecificData;
 			} catch (err) {
 				this.$errors.failWithoutHelp("The project file is corrupted. Additional technical information: %s", err);

--- a/prompter.ts
+++ b/prompter.ts
@@ -2,7 +2,7 @@ import * as prompt from "inquirer";
 import * as helpers from "./helpers";
 import * as readline from "readline";
 import { ReadStream } from "tty";
-let MuteStream = require("mute-stream");
+const MuteStream = require("mute-stream");
 
 export class Prompter implements IPrompter {
 	private ctrlcReader: readline.ReadLine;
@@ -25,7 +25,7 @@ export class Prompter implements IPrompter {
 					if (_.some(schemas, s => !s.default)) {
 						reject(new Error("Console is not interactive and no default action specified."));
 					} else {
-						let result: any = {};
+						const result: any = {};
 
 						_.each(schemas, s => {
 							// Curly brackets needed because s.default() may return false and break the loop
@@ -52,57 +52,57 @@ export class Prompter implements IPrompter {
 	}
 
 	public async getPassword(prompt: string, options?: IAllowEmpty): Promise<string> {
-		let schema: IPromptSchema = {
+		const schema: IPromptSchema = {
 			message: prompt,
 			type: "password",
 			name: "password",
 			validate: (value: any) => {
-				let allowEmpty = options && options.allowEmpty;
+				const allowEmpty = options && options.allowEmpty;
 				return (!allowEmpty && !value) ? "Password must be non-empty" : true;
 			}
 		};
 
-		let result = await this.get([schema]);
+		const result = await this.get([schema]);
 		return result.password;
 	}
 
 	public async getString(prompt: string, options?: IPrompterOptions): Promise<string> {
-		let schema: IPromptSchema = {
+		const schema: IPromptSchema = {
 			message: prompt,
 			type: "input",
 			name: "inputString",
 			validate: (value: any) => {
-				let doesNotAllowEmpty = options && _.has(options, "allowEmpty") && !options.allowEmpty;
+				const doesNotAllowEmpty = options && _.has(options, "allowEmpty") && !options.allowEmpty;
 				return (doesNotAllowEmpty && !value) ? `${prompt} must be non-empty` : true;
 			},
 			default: options && options.defaultAction
 		};
 
-		let result = await this.get([schema]);
+		const result = await this.get([schema]);
 		return result.inputString;
 	}
 
 	public async promptForChoice(promptMessage: string, choices: any[]): Promise<string> {
-		let schema: IPromptSchema = {
+		const schema: IPromptSchema = {
 			message: promptMessage,
 			type: "list",
 			name: "userAnswer",
 			choices: choices
 		};
 
-		let result = await this.get([schema]);
+		const result = await this.get([schema]);
 		return result.userAnswer;
 	}
 
 	public async confirm(prompt: string, defaultAction?: () => boolean): Promise<boolean> {
-		let schema = {
+		const schema = {
 			type: "confirm",
 			name: "prompt",
 			default: defaultAction,
 			message: prompt
 		};
 
-		let result = await this.get([schema]);
+		const result = await this.get([schema]);
 		return result.prompt;
 	}
 
@@ -142,7 +142,7 @@ export class Prompter implements IPrompter {
 	private cleanEventListeners(stream: NodeJS.WritableStream): void {
 		// The events names and listeners names can be found here https://github.com/nodejs/node/blob/master/lib/stream.js
 		// Which event cause memory leak can be tested with stream.listeners("event-name") and if the listeners count keeps increasing with each prompt we need to remove the listener.
-		let memoryLeakEvents: IMemoryLeakEvent[] = [{
+		const memoryLeakEvents: IMemoryLeakEvent[] = [{
 			eventName: "close",
 			listenerName: "cleanup"
 		}, {
@@ -157,9 +157,9 @@ export class Prompter implements IPrompter {
 	}
 
 	private cleanListener(stream: NodeJS.WritableStream, eventName: string, listenerName: string): void {
-		let eventListeners: any[] = process.stdout.listeners(eventName);
+		const eventListeners: any[] = process.stdout.listeners(eventName);
 
-		let listenerFunction: Function = _.find(eventListeners, (func: any) => func.name === listenerName);
+		const listenerFunction: Function = _.find(eventListeners, (func: any) => func.name === listenerName);
 
 		if (listenerFunction) {
 			stream.removeListener(eventName, listenerFunction);

--- a/services/analytics-service-base.ts
+++ b/services/analytics-service-base.ts
@@ -40,7 +40,7 @@ export class AnalyticsServiceBase implements IAnalyticsService {
 					+ this.$analyticsSettingsService.getClientName()
 					+ " by automatically sending anonymous usage statistics? We will not use this information to identify or contact you."
 					+ " You can read our official Privacy Policy at");
-				let message = this.$analyticsSettingsService.getPrivacyPolicyLink();
+				const message = this.$analyticsSettingsService.getPrivacyPolicyLink();
 
 				trackFeatureUsage = await this.$prompter.confirm(message, () => true);
 				await this.setStatus(this.$staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, trackFeatureUsage);
@@ -57,7 +57,7 @@ export class AnalyticsServiceBase implements IAnalyticsService {
 	}
 
 	public trackFeature(featureName: string): Promise<void> {
-		let category = this.$options.analyticsClient ||
+		const category = this.$options.analyticsClient ||
 			(helpers.isInteractive() ? "CLI" : "Non-interactive");
 		return this.track(category, featureName);
 	}
@@ -113,7 +113,7 @@ export class AnalyticsServiceBase implements IAnalyticsService {
 	}
 
 	public async isEnabled(settingName: string): Promise<boolean> {
-		let analyticsStatus = await this.getStatus(settingName);
+		const analyticsStatus = await this.getStatus(settingName);
 		return analyticsStatus === AnalyticsStatus.enabled;
 	}
 
@@ -159,10 +159,10 @@ export class AnalyticsServiceBase implements IAnalyticsService {
 
 	private async getStatus(settingName: string): Promise<AnalyticsStatus> {
 		if (!_.has(this.analyticsStatuses, settingName)) {
-			let settingValue = await this.$userSettingsService.getSettingValue<string>(settingName);
+			const settingValue = await this.$userSettingsService.getSettingValue<string>(settingName);
 
 			if (settingValue) {
-				let isEnabled = helpers.toBoolean(settingValue);
+				const isEnabled = helpers.toBoolean(settingValue);
 				if (isEnabled) {
 					this.analyticsStatuses[settingName] = AnalyticsStatus.enabled;
 				} else {
@@ -183,7 +183,7 @@ export class AnalyticsServiceBase implements IAnalyticsService {
 
 		require("../vendor/EqatecMonitor.min");
 		analyticsProjectKey = analyticsProjectKey || this.$staticConfig.ANALYTICS_API_KEY;
-		let settings = cliGlobal._eqatec.createSettings(analyticsProjectKey);
+		const settings = cliGlobal._eqatec.createSettings(analyticsProjectKey);
 		settings.useHttps = false;
 		settings.userAgent = this.getUserAgentString();
 		settings.version = this.$staticConfig.version;
@@ -223,13 +223,13 @@ export class AnalyticsServiceBase implements IAnalyticsService {
 	}
 
 	private async reportNodeVersion(): Promise<void> {
-		let reportedVersion: string = process.version.slice(1).replace(/[.]/g, "_");
+		const reportedVersion: string = process.version.slice(1).replace(/[.]/g, "_");
 		await this.track("NodeJSVersion", reportedVersion);
 	}
 
 	private getUserAgentString(): string {
 		let userAgentString: string;
-		let osType = this.$osInfo.type();
+		const osType = this.$osInfo.type();
 		if (osType === "Windows_NT") {
 			userAgentString = "(Windows NT " + this.$osInfo.release() + ")";
 		} else if (osType === "Darwin") {
@@ -242,7 +242,7 @@ export class AnalyticsServiceBase implements IAnalyticsService {
 	}
 
 	private async isNotConfirmed(settingName: string): Promise<boolean> {
-		let analyticsStatus = await this.getStatus(settingName);
+		const analyticsStatus = await this.getStatus(settingName);
 		return analyticsStatus === AnalyticsStatus.notConfirmed;
 	}
 
@@ -259,8 +259,8 @@ export class AnalyticsServiceBase implements IAnalyticsService {
 	}
 
 	private async getJsonStatusMessage(settingName: string): Promise<string> {
-		let status = await this.getStatus(settingName);
-		let enabled = status === AnalyticsStatus.notConfirmed ? null : status === AnalyticsStatus.disabled ? false : true;
+		const status = await this.getStatus(settingName);
+		const enabled = status === AnalyticsStatus.notConfirmed ? null : status === AnalyticsStatus.disabled ? false : true;
 		return JSON.stringify({ enabled: enabled });
 	}
 
@@ -268,7 +268,7 @@ export class AnalyticsServiceBase implements IAnalyticsService {
 		if (await this.$analyticsSettingsService.canDoRequest()) {
 			if (!this.isAnalyticsStatusesInitialized) {
 				this.$logger.trace("Initializing analytics statuses.");
-				let settingsNames = [this.$staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, this.$staticConfig.ERROR_REPORT_SETTING_NAME];
+				const settingsNames = [this.$staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, this.$staticConfig.ERROR_REPORT_SETTING_NAME];
 				for (let settingsIndex = 0; settingsIndex < settingsNames.length; ++settingsIndex) {
 					const settingName = settingsNames[settingsIndex];
 					await this.getStatus(settingName);
@@ -287,11 +287,11 @@ export class AnalyticsServiceBase implements IAnalyticsService {
 
 	private waitForSending(): Promise<void> {
 		return new Promise<void>((resolve, reject) => {
-			let intervalTime = 100;
+			const intervalTime = 100;
 			let remainingTime = AnalyticsServiceBase.MAX_WAIT_SENDING_INTERVAL;
 			if (this.getIsSending()) {
 				this.$logger.trace(`Waiting for analytics to send information. Will check in a ${intervalTime}ms.`);
-				let interval = setInterval(() => {
+				const interval = setInterval(() => {
 					if (!this.getIsSending() || (remainingTime <= 0)) {
 						clearInterval(interval);
 						resolve();

--- a/services/auto-completion-service.ts
+++ b/services/auto-completion-service.ts
@@ -41,20 +41,20 @@ export class AutoCompletionService implements IAutoCompletionService {
 	}
 
 	private getTabTabObsoleteRegex(clientName: string): RegExp {
-		let tabTabStartPoint = util.format(AutoCompletionService.TABTAB_COMPLETION_START_REGEX_PATTERN, clientName.toLowerCase());
-		let tabTabEndPoint = util.format(AutoCompletionService.TABTAB_COMPLETION_END_REGEX_PATTERN, clientName.toLowerCase());
-		let tabTabRegex = new RegExp(util.format("%s[\\s\\S]*%s", tabTabStartPoint, tabTabEndPoint));
+		const tabTabStartPoint = util.format(AutoCompletionService.TABTAB_COMPLETION_START_REGEX_PATTERN, clientName.toLowerCase());
+		const tabTabEndPoint = util.format(AutoCompletionService.TABTAB_COMPLETION_END_REGEX_PATTERN, clientName.toLowerCase());
+		const tabTabRegex = new RegExp(util.format("%s[\\s\\S]*%s", tabTabStartPoint, tabTabEndPoint));
 		return tabTabRegex;
 	}
 
 	private removeObsoleteAutoCompletion(): void {
 		// In previous releases we were writing directly in .bash_profile, .bashrc, .zshrc and .profile - remove this old code
-		let shellProfilesToBeCleared = this.shellProfiles;
+		const shellProfilesToBeCleared = this.shellProfiles;
 		// Add .profile only here as we do not want new autocompletion in this file, but we have to remove our old code from it.
 		shellProfilesToBeCleared.push(this.getHomePath(".profile"));
 		shellProfilesToBeCleared.forEach(file => {
 			try {
-				let text = this.$fs.readText(file);
+				const text = this.$fs.readText(file);
 				let newText = text.replace(this.getTabTabObsoleteRegex(this.$staticConfig.CLIENT_NAME), "");
 				if (this.$staticConfig.CLIENT_NAME_ALIAS) {
 					newText = newText.replace(this.getTabTabObsoleteRegex(this.$staticConfig.CLIENT_NAME_ALIAS), "");
@@ -74,9 +74,9 @@ export class AutoCompletionService implements IAutoCompletionService {
 
 	@cache()
 	private get completionShellScriptContent() {
-		let startText = util.format(AutoCompletionService.COMPLETION_START_COMMENT_PATTERN, this.$staticConfig.CLIENT_NAME.toLowerCase());
-		let content = util.format("if [ -f %s ]; then \n    source %s \nfi", this.cliRunCommandsFile, this.cliRunCommandsFile);
-		let endText = util.format(AutoCompletionService.COMPLETION_END_COMMENT_PATTERN, this.$staticConfig.CLIENT_NAME.toLowerCase());
+		const startText = util.format(AutoCompletionService.COMPLETION_START_COMMENT_PATTERN, this.$staticConfig.CLIENT_NAME.toLowerCase());
+		const content = util.format("if [ -f %s ]; then \n    source %s \nfi", this.cliRunCommandsFile, this.cliRunCommandsFile);
+		const endText = util.format(AutoCompletionService.COMPLETION_END_COMMENT_PATTERN, this.$staticConfig.CLIENT_NAME.toLowerCase());
 		return util.format("\n%s\n%s\n%s\n", startText, content, endText);
 	}
 
@@ -127,7 +127,7 @@ export class AutoCompletionService implements IAutoCompletionService {
 
 	private isNewAutoCompletionEnabledInFile(fileName: string): boolean {
 		try {
-			let data = this.$fs.readText(fileName);
+			const data = this.$fs.readText(fileName);
 			if (data && data.indexOf(this.completionShellScriptContent) !== -1) {
 				return true;
 			}
@@ -140,7 +140,7 @@ export class AutoCompletionService implements IAutoCompletionService {
 
 	private isObsoleteAutoCompletionEnabledInFile(fileName: string): boolean {
 		try {
-			let text = this.$fs.readText(fileName);
+			const text = this.$fs.readText(fileName);
 			return !!(text.match(this.getTabTabObsoleteRegex(this.$staticConfig.CLIENT_NAME)) || text.match(this.getTabTabObsoleteRegex(this.$staticConfig.CLIENT_NAME)));
 		} catch (err) {
 			this.$logger.trace("Error while checking is obsolete autocompletion enabled in file %s. Error is: '%s'", fileName, err.toString());
@@ -187,13 +187,13 @@ export class AutoCompletionService implements IAutoCompletionService {
 	}
 
 	private async updateCLIShellScript(): Promise<void> {
-		let filePath = this.cliRunCommandsFile;
+		const filePath = this.cliRunCommandsFile;
 
 		try {
 			let doUpdate = true;
 			if (this.$fs.exists(filePath)) {
-				let contents = this.$fs.readText(filePath);
-				let regExp = new RegExp(util.format("%s\\s+completion\\s+--\\s+", this.$staticConfig.CLIENT_NAME.toLowerCase()));
+				const contents = this.$fs.readText(filePath);
+				const regExp = new RegExp(util.format("%s\\s+completion\\s+--\\s+", this.$staticConfig.CLIENT_NAME.toLowerCase()));
 				let matchCondition = contents.match(regExp);
 				if (this.$staticConfig.CLIENT_NAME_ALIAS) {
 					matchCondition = matchCondition || contents.match(new RegExp(util.format("%s\\s+completion\\s+--\\s+", this.$staticConfig.CLIENT_NAME_ALIAS.toLowerCase())));
@@ -205,8 +205,8 @@ export class AutoCompletionService implements IAutoCompletionService {
 			}
 
 			if (doUpdate) {
-				let clientExecutableFileName = (this.$staticConfig.CLIENT_NAME_ALIAS || this.$staticConfig.CLIENT_NAME).toLowerCase();
-				let pathToExecutableFile = path.join(__dirname, `../../../bin/${clientExecutableFileName}.js`);
+				const clientExecutableFileName = (this.$staticConfig.CLIENT_NAME_ALIAS || this.$staticConfig.CLIENT_NAME).toLowerCase();
+				const pathToExecutableFile = path.join(__dirname, `../../../bin/${clientExecutableFileName}.js`);
 				await this.$childProcess.exec(`"${process.argv[0]}" "${pathToExecutableFile}" completion >> "${filePath}"`);
 				this.$fs.chmod(filePath, "0644");
 			}

--- a/services/cancellation.ts
+++ b/services/cancellation.ts
@@ -1,8 +1,8 @@
-let gaze = require("gaze");
+const gaze = require("gaze");
 import * as path from "path";
 import * as os from "os";
 
-let hostInfo: IHostInfo = $injector.resolve("hostInfo");
+const hostInfo: IHostInfo = $injector.resolve("hostInfo");
 
 class CancellationService implements ICancellationService {
 	private watches: IDictionary<IWatcherInstance> = {};
@@ -14,7 +14,7 @@ class CancellationService implements ICancellationService {
 	}
 
 	public async begin(name: string): Promise<void> {
-		let triggerFile = CancellationService.makeKillSwitchFileName(name);
+		const triggerFile = CancellationService.makeKillSwitchFileName(name);
 
 		if (!this.$fs.exists(triggerFile)) {
 			this.$fs.writeFile(triggerFile, "");
@@ -26,7 +26,7 @@ class CancellationService implements ICancellationService {
 
 		this.$logger.trace("Starting watch on killswitch %s", triggerFile);
 
-		let watcherInitialized = new Promise<IWatcherInstance>((resolve, reject) => {
+		const watcherInitialized = new Promise<IWatcherInstance>((resolve, reject) => {
 			gaze(triggerFile, function (err: any, watcher: any) {
 				this.on("deleted", (filePath: string) => process.exit());
 
@@ -38,7 +38,7 @@ class CancellationService implements ICancellationService {
 			});
 		});
 
-		let watcher = await watcherInitialized;
+		const watcher = await watcherInitialized;
 
 		if (watcher) {
 			this.watches[name] = watcher;
@@ -46,7 +46,7 @@ class CancellationService implements ICancellationService {
 	}
 
 	public end(name: string): void {
-		let watcher = this.watches[name];
+		const watcher = this.watches[name];
 		delete this.watches[name];
 		watcher.close();
 	}

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -1,4 +1,4 @@
-let jaroWinklerDistance = require("../vendor/jaro-winkler_distance");
+const jaroWinklerDistance = require("../vendor/jaro-winkler_distance");
 import * as helpers from "../helpers";
 import { EOL } from "os";
 
@@ -28,22 +28,22 @@ export class CommandsService implements ICommandsService {
 	}
 
 	public allCommands(opts: { includeDevCommands: boolean }): string[] {
-		let commands = this.$injector.getRegisteredCommandsNames(opts.includeDevCommands);
+		const commands = this.$injector.getRegisteredCommandsNames(opts.includeDevCommands);
 		return _.reject(commands, (command) => _.includes(command, '|'));
 	}
 
 	public async executeCommandUnchecked(commandName: string, commandArguments: string[]): Promise<boolean> {
-		let command = this.$injector.resolveCommand(commandName);
+		const command = this.$injector.resolveCommand(commandName);
 		if (command) {
 			if (!this.$staticConfig.disableAnalytics && !command.disableAnalytics) {
-				let analyticsService = this.$injector.resolve("analyticsService"); // This should be resolved here due to cyclic dependency
+				const analyticsService = this.$injector.resolve("analyticsService"); // This should be resolved here due to cyclic dependency
 				await analyticsService.checkConsent();
 				await analyticsService.trackFeature(commandName);
 			}
 
 			if (!this.$staticConfig.disableCommandHooks && (command.enableHooks === undefined || command.enableHooks === true)) {
 				// Handle correctly hierarchical commands
-				let hierarchicalCommandName = this.$injector.buildHierarchicalCommand(commandName, commandArguments);
+				const hierarchicalCommandName = this.$injector.buildHierarchicalCommand(commandName, commandArguments);
 				if (hierarchicalCommandName) {
 					commandName = helpers.stringReplaceAll(hierarchicalCommandName.commandName, CommandsService.HIERARCHICAL_COMMANDS_DEFAULT_COMMAND_DELIMITER, CommandsService.HOOKS_COMMANDS_DELIMITER);
 					commandName = helpers.stringReplaceAll(commandName, CommandsService.HIERARCHICAL_COMMANDS_DELIMITER, CommandsService.HOOKS_COMMANDS_DELIMITER);
@@ -56,9 +56,9 @@ export class CommandsService implements ICommandsService {
 				await command.execute(commandArguments);
 			}
 
-			let commandHelp = this.getCommandHelp();
+			const commandHelp = this.getCommandHelp();
 			if (!command.disableCommandHelpSuggestion && commandHelp && commandHelp[commandName]) {
-				let suggestionText: string = commandHelp[commandName];
+				const suggestionText: string = commandHelp[commandName];
 				this.$logger.printMarkdown(~suggestionText.indexOf('%s') ? require('util').format(suggestionText, commandArguments) : suggestionText);
 			}
 
@@ -79,7 +79,7 @@ export class CommandsService implements ICommandsService {
 	}
 
 	private async tryExecuteCommandAction(commandName: string, commandArguments: string[]): Promise<boolean> {
-		let command = this.$injector.resolveCommand(commandName);
+		const command = this.$injector.resolveCommand(commandName);
 		this.$options.validateOptions(command ? command.dashedOptions : null);
 
 		if (!this.areDynamicSubcommandsRegistered) {
@@ -94,7 +94,7 @@ export class CommandsService implements ICommandsService {
 			await this.executeCommandAction(commandName, commandArguments, this.executeCommandUnchecked);
 		} else {
 			// If canExecuteCommand returns false, the command cannot be executed or there's no such command at all.
-			let command = this.$injector.resolveCommand(commandName);
+			const command = this.$injector.resolveCommand(commandName);
 			if (command) {
 				// If command cannot be executed we should print its help.
 				await this.printHelp(commandName);
@@ -103,8 +103,8 @@ export class CommandsService implements ICommandsService {
 	}
 
 	private async canExecuteCommand(commandName: string, commandArguments: string[], isDynamicCommand?: boolean): Promise<boolean> {
-		let command = this.$injector.resolveCommand(commandName);
-		let beautifiedName = helpers.stringReplaceAll(commandName, "|", " ");
+		const command = this.$injector.resolveCommand(commandName);
+		const beautifiedName = helpers.stringReplaceAll(commandName, "|", " ");
 		if (command) {
 			// Verify command is enabled
 			if (command.isDisabled) {
@@ -141,12 +141,12 @@ export class CommandsService implements ICommandsService {
 	}
 
 	private async validateMandatoryParams(commandArguments: string[], mandatoryParams: ICommandParameter[]): Promise<CommandArgumentsValidationHelper> {
-		let commandArgsHelper = new CommandArgumentsValidationHelper(true, commandArguments);
+		const commandArgsHelper = new CommandArgumentsValidationHelper(true, commandArguments);
 
 		if (mandatoryParams.length > 0) {
 			// If command has more mandatory params than the passed ones, we shouldn't execute it
 			if (mandatoryParams.length > commandArguments.length) {
-				let customErrorMessages = _.map(mandatoryParams, mp => mp.errorMessage);
+				const customErrorMessages = _.map(mandatoryParams, mp => mp.errorMessage);
 				customErrorMessages.splice(0, 0, "You need to provide all the required parameters.");
 				this.$errors.fail(customErrorMessages.join(EOL));
 			}
@@ -175,8 +175,8 @@ export class CommandsService implements ICommandsService {
 	}
 
 	private async validateCommandArguments(command: ICommand, commandArguments: string[]): Promise<boolean> {
-		let mandatoryParams: ICommandParameter[] = _.filter(command.allowedParameters, (param) => param.mandatory);
-		let commandArgsHelper = await this.validateMandatoryParams(commandArguments, mandatoryParams);
+		const mandatoryParams: ICommandParameter[] = _.filter(command.allowedParameters, (param) => param.mandatory);
+		const commandArgsHelper = await this.validateMandatoryParams(commandArguments, mandatoryParams);
 		if (!commandArgsHelper.isValid) {
 			return false;
 		}
@@ -188,7 +188,7 @@ export class CommandsService implements ICommandsService {
 			}
 		} else {
 			// Exclude mandatory params, we've already checked them
-			let unverifiedAllowedParams = command.allowedParameters.filter((param) => !param.mandatory);
+			const unverifiedAllowedParams = command.allowedParameters.filter((param) => !param.mandatory);
 
 			for (let remainingArgsIndex = 0; remainingArgsIndex < commandArgsHelper.remainingArguments.length; ++remainingArgsIndex) {
 				const argument = commandArgsHelper.remainingArguments[remainingArgsIndex];
@@ -202,7 +202,7 @@ export class CommandsService implements ICommandsService {
 				}
 
 				if (parameter) {
-					let index = unverifiedAllowedParams.indexOf(parameter);
+					const index = unverifiedAllowedParams.indexOf(parameter);
 					// Remove the matched parameter from unverifiedAllowedParams collection, so it will not be used to verify another argument.
 					unverifiedAllowedParams.splice(index, 1);
 				} else {
@@ -215,12 +215,12 @@ export class CommandsService implements ICommandsService {
 	}
 
 	private tryMatchCommand(commandName: string): void {
-		let allCommands = this.allCommands({ includeDevCommands: false });
+		const allCommands = this.allCommands({ includeDevCommands: false });
 		let similarCommands: ISimilarCommand[] = [];
 		_.each(allCommands, (command) => {
 			if (!this.$injector.isDefaultCommand(command)) {
 				command = helpers.stringReplaceAll(command, "|", " ");
-				let distance = jaroWinklerDistance(commandName, command);
+				const distance = jaroWinklerDistance(commandName, command);
 				if (commandName.length > 3 && command.indexOf(commandName) !== -1) {
 					similarCommands.push({ rating: 1, name: command });
 				} else if (distance >= 0.65) {
@@ -234,7 +234,7 @@ export class CommandsService implements ICommandsService {
 		}).slice(0, 5);
 
 		if (similarCommands.length > 0) {
-			let message = ["Did you mean?"];
+			const message = ["Did you mean?"];
 			_.each(similarCommands, (command) => {
 				message.push("\t" + command.name);
 			});
@@ -243,19 +243,19 @@ export class CommandsService implements ICommandsService {
 	}
 
 	public async completeCommand(): Promise<boolean> {
-		let tabtab = require("tabtab");
+		const tabtab = require("tabtab");
 
-		let completeCallback = (err: Error, data: any) => {
+		const completeCallback = (err: Error, data: any) => {
 			if (err || !data) {
 				return;
 			}
 
-			let commands = this.$injector.getRegisteredCommandsNames(false);
-			let splittedLine = data.line.split(/[ ]+/);
-			let line = _.filter(splittedLine, (w) => w !== "");
+			const commands = this.$injector.getRegisteredCommandsNames(false);
+			const splittedLine = data.line.split(/[ ]+/);
+			const line = _.filter(splittedLine, (w) => w !== "");
 			let commandName = <string>(line[line.length - 2]);
 
-			let childrenCommands = this.$injector.getChildrenCommandsNames(commandName);
+			const childrenCommands = this.$injector.getChildrenCommandsNames(commandName);
 
 			if (data.last && _.startsWith(data.last, "--")) {
 				return tabtab.log(_.keys(this.$options.options), data, "--");
@@ -266,7 +266,7 @@ export class CommandsService implements ICommandsService {
 			}
 
 			if (data.words === 1) {
-				let allCommands = this.allCommands({ includeDevCommands: false });
+				const allCommands = this.allCommands({ includeDevCommands: false });
 				return tabtab.log(allCommands, data);
 			}
 
@@ -278,9 +278,9 @@ export class CommandsService implements ICommandsService {
 				}
 			}
 
-			let command = this.$injector.resolveCommand(commandName);
+			const command = this.$injector.resolveCommand(commandName);
 			if (command) {
-				let completionData = command.completionData;
+				const completionData = command.completionData;
 				if (completionData) {
 					return tabtab.log(completionData, data);
 				} else {
@@ -292,13 +292,13 @@ export class CommandsService implements ICommandsService {
 
 				if (data.words !== line.length) {
 					sanitizedChildrenCommands = nonDefaultSubCommands.map((commandToMap: string) => {
-						let pipePosition = commandToMap.indexOf("|");
+						const pipePosition = commandToMap.indexOf("|");
 						return commandToMap.substring(0, pipePosition !== -1 ? pipePosition : commandToMap.length);
 					});
 				} else {
 					nonDefaultSubCommands = nonDefaultSubCommands.filter((commandNameToFilter: string) => commandNameToFilter.indexOf("|") !== -1);
 					sanitizedChildrenCommands = nonDefaultSubCommands.map((commandToMap: string) => {
-						let pipePosition = commandToMap.lastIndexOf("|");
+						const pipePosition = commandToMap.lastIndexOf("|");
 						return commandToMap.substring(pipePosition !== -1 ? pipePosition + 1 : 0, commandToMap.length);
 					});
 				}
@@ -336,12 +336,12 @@ export class CommandsService implements ICommandsService {
 	}
 
 	private logChildrenCommandsNames(commandName: string, commands: string[], tabtab: any, data: any) {
-		let matchingCommands = commands.filter((commandToFilter: string) => {
+		const matchingCommands = commands.filter((commandToFilter: string) => {
 			return commandToFilter.indexOf(commandName + "|") !== -1 && commandToFilter !== commandName;
 		})
 			.map((commandToMap: string) => {
 
-				let commandResult = commandToMap.replace(commandName + "|", "");
+				const commandResult = commandToMap.replace(commandName + "|", "");
 
 				return commandResult.substring(0, commandResult.indexOf("|") !== -1 ? commandResult.indexOf("|") : commandResult.length);
 			});

--- a/services/dynamic-help-service.ts
+++ b/services/dynamic-help-service.ts
@@ -9,14 +9,14 @@ export class DynamicHelpService implements IDynamicHelpService {
 	}
 
 	public isPlatform(...args: string[]): boolean {
-		let platform = os.platform().toLowerCase();
+		const platform = os.platform().toLowerCase();
 		return _.some(args, arg => arg.toLowerCase() === platform);
 	}
 
 	public getLocalVariables(options: { isHtml: boolean }): IDictionary<any> {
-		let isHtml = options.isHtml;
+		const isHtml = options.isHtml;
 		//in html help we want to show all help. Only CONSOLE specific help(wrapped in if(isConsole) ) must be omitted
-		let localVariables = this.$dynamicHelpProvider.getLocalVariables(options);
+		const localVariables = this.$dynamicHelpProvider.getLocalVariables(options);
 		localVariables["isLinux"] = isHtml || this.isPlatform("linux");
 		localVariables["isWindows"] = isHtml || this.isPlatform("win32");
 		localVariables["isMacOS"] = isHtml || this.isPlatform("darwin");

--- a/services/emulator-image-service.ts
+++ b/services/emulator-image-service.ts
@@ -13,15 +13,15 @@ export class EmulatorImageService implements Mobile.IEmulatorImageService {
 
 	public async getEmulatorInfo(platform: string, idOrName: string): Promise<Mobile.IEmulatorInfo> {
 		if (this.$mobileHelper.isAndroidPlatform(platform)) {
-			let androidEmulators = this.getAndroidEmulators();
-			let found = androidEmulators.filter((info: Mobile.IEmulatorInfo) => info.id === idOrName);
+			const androidEmulators = this.getAndroidEmulators();
+			const found = androidEmulators.filter((info: Mobile.IEmulatorInfo) => info.id === idOrName);
 			if (found.length > 0) {
 				return found[0];
 			}
 
 			await this.$devicesService.initialize({ platform: platform, deviceId: null, skipInferPlatform: true });
 			let info: Mobile.IEmulatorInfo = null;
-			let action = async (device: Mobile.IDevice) => {
+			const action = async (device: Mobile.IDevice) => {
 				if (device.deviceInfo.identifier === idOrName) {
 					info = {
 						id: device.deviceInfo.identifier,
@@ -38,15 +38,15 @@ export class EmulatorImageService implements Mobile.IEmulatorImageService {
 		}
 
 		if (this.$mobileHelper.isiOSPlatform(platform)) {
-			let emulators = await this.getiOSEmulators();
+			const emulators = await this.getiOSEmulators();
 			let sdk: string = null;
-			let versionStart = idOrName.indexOf("(");
+			const versionStart = idOrName.indexOf("(");
 			if (versionStart > 0) {
 				sdk = idOrName.substring(versionStart + 1, idOrName.indexOf(")", versionStart)).trim();
 				idOrName = idOrName.substring(0, versionStart - 1).trim();
 			}
-			let found = emulators.filter((info: Mobile.IEmulatorInfo) => {
-				let sdkMatch = sdk ? info.version === sdk : true;
+			const found = emulators.filter((info: Mobile.IEmulatorInfo) => {
+				const sdkMatch = sdk ? info.version === sdk : true;
 				return sdkMatch && info.id === idOrName || info.name === idOrName;
 			});
 			return found.length > 0 ? found[0] : null;
@@ -59,14 +59,14 @@ export class EmulatorImageService implements Mobile.IEmulatorImageService {
 	public async listAvailableEmulators(platform: string): Promise<void> {
 		let emulators: Mobile.IEmulatorInfo[] = [];
 		if (!platform || this.$mobileHelper.isiOSPlatform(platform)) {
-			let iosEmulators = await this.getiOSEmulators();
+			const iosEmulators = await this.getiOSEmulators();
 			if (iosEmulators) {
 				emulators = emulators.concat(iosEmulators);
 			}
 		}
 
 		if (!platform || this.$mobileHelper.isAndroidPlatform(platform)) {
-			let androidEmulators = this.getAndroidEmulators();
+			const androidEmulators = this.getAndroidEmulators();
 			if (androidEmulators) {
 				emulators = emulators.concat(androidEmulators);
 			}
@@ -76,20 +76,20 @@ export class EmulatorImageService implements Mobile.IEmulatorImageService {
 	}
 
 	public async getiOSEmulators(): Promise<Mobile.IEmulatorInfo[]> {
-		let output = await this.$childProcess.exec("xcrun simctl list --json");
-		let list = JSON.parse(output);
-		let emulators: Mobile.IEmulatorInfo[] = [];
-		for (let osName in list["devices"]) {
+		const output = await this.$childProcess.exec("xcrun simctl list --json");
+		const list = JSON.parse(output);
+		const emulators: Mobile.IEmulatorInfo[] = [];
+		for (const osName in list["devices"]) {
 			if (osName.indexOf("iOS") === -1) {
 				continue;
 			}
-			let os = list["devices"][osName];
-			let version = this.parseiOSVersion(osName);
-			for (let device of os) {
+			const os = list["devices"][osName];
+			const version = this.parseiOSVersion(osName);
+			for (const device of os) {
 				if (device["availability"] !== "(available)") {
 					continue;
 				}
-				let emulatorInfo: Mobile.IEmulatorInfo = {
+				const emulatorInfo: Mobile.IEmulatorInfo = {
 					id: device["udid"],
 					name: device["name"],
 					isRunning: device["state"] === "Booted",
@@ -124,8 +124,8 @@ export class EmulatorImageService implements Mobile.IEmulatorImageService {
 
 	private outputEmulators(title: string, emulators: Mobile.IEmulatorInfo[]) {
 		this.$logger.out(title);
-		let table: any = createTable(["Device Name", "Platform", "Version", "Device Identifier"], []);
-		for (let info of emulators) {
+		const table: any = createTable(["Device Name", "Platform", "Version", "Device Identifier"], []);
+		for (const info of emulators) {
 			table.push([info.name, info.platform, info.version, info.id]);
 		}
 

--- a/services/hooks-service.ts
+++ b/services/hooks-service.ts
@@ -31,7 +31,7 @@ export class HooksService implements IHooksService {
 	private initialize(projectDir: string): void {
 		this.cachedHooks = {};
 
-		let relativeToLibPath = path.join(__dirname, "../../");
+		const relativeToLibPath = path.join(__dirname, "../../");
 		this.hooksDirectories = [
 			path.join(relativeToLibPath, HooksService.HOOKS_DIRECTORY_NAME),
 			path.join(relativeToLibPath, "common", HooksService.HOOKS_DIRECTORY_NAME)
@@ -52,14 +52,14 @@ export class HooksService implements IHooksService {
 	}
 
 	public executeBeforeHooks(commandName: string, hookArguments?: IDictionary<any>): Promise<void> {
-		let beforeHookName = `before-${HooksService.formatHookName(commandName)}`;
-		let traceMessage = `BeforeHookName for command ${commandName} is ${beforeHookName}`;
+		const beforeHookName = `before-${HooksService.formatHookName(commandName)}`;
+		const traceMessage = `BeforeHookName for command ${commandName} is ${beforeHookName}`;
 		return this.executeHooks(beforeHookName, traceMessage, hookArguments);
 	}
 
 	public executeAfterHooks(commandName: string, hookArguments?: IDictionary<any>): Promise<void> {
-		let afterHookName = `after-${HooksService.formatHookName(commandName)}`;
-		let traceMessage = `AfterHookName for command ${commandName} is ${afterHookName}`;
+		const afterHookName = `after-${HooksService.formatHookName(commandName)}`;
+		const traceMessage = `AfterHookName for command ${commandName} is ${afterHookName}`;
 		return this.executeHooks(afterHookName, traceMessage, hookArguments);
 	}
 
@@ -77,7 +77,7 @@ export class HooksService implements IHooksService {
 		this.$logger.trace(traceMessage);
 
 		try {
-			for (let hooksDirectory of this.hooksDirectories) {
+			for (const hooksDirectory of this.hooksDirectories) {
 				await this.executeHooksInDirectory(hooksDirectory, hookName, hookArguments);
 			}
 		} catch (err) {
@@ -88,7 +88,7 @@ export class HooksService implements IHooksService {
 
 	private async executeHooksInDirectory(directoryPath: string, hookName: string, hookArguments?: IDictionary<any>): Promise<void> {
 		hookArguments = hookArguments || {};
-		let hooks = this.getHooksByName(directoryPath, hookName);
+		const hooks = this.getHooksByName(directoryPath, hookName);
 		for (let i = 0; i < hooks.length; ++i) {
 			const hook = hooks[i];
 			this.$logger.info("Executing %s hook from %s", hookName, hook.fullPath);
@@ -104,11 +104,11 @@ export class HooksService implements IHooksService {
 
 			if (inProc) {
 				this.$logger.trace("Executing %s hook at location %s in-process", hookName, hook.fullPath);
-				let hookEntryPoint = require(hook.fullPath);
+				const hookEntryPoint = require(hook.fullPath);
 
 				this.$logger.trace(`Validating ${hookName} arguments.`);
 
-				let invalidArguments = this.validateHookArguments(hookEntryPoint);
+				const invalidArguments = this.validateHookArguments(hookEntryPoint);
 
 				if (invalidArguments.length) {
 					this.$logger.warn(`${hookName} will NOT be executed because it has invalid arguments - ${invalidArguments.join(", ").grey}.`);
@@ -125,7 +125,7 @@ export class HooksService implements IHooksService {
 					hookArguments["projectData"] = hookArguments["$projectData"] = projectDataHookArg;
 				}
 
-				let maybePromise = this.$injector.resolve(hookEntryPoint, hookArguments);
+				const maybePromise = this.$injector.resolve(hookEntryPoint, hookArguments);
 				if (maybePromise) {
 					this.$logger.trace('Hook promises to signal completion');
 					try {
@@ -140,10 +140,10 @@ export class HooksService implements IHooksService {
 
 					this.$logger.trace('Hook completed');
 				} else {
-					let environment = this.prepareEnvironment(hook.fullPath);
+					const environment = this.prepareEnvironment(hook.fullPath);
 					this.$logger.trace("Executing %s hook at location %s with environment ", hookName, hook.fullPath, environment);
 
-					let output = await this.$childProcess.spawnFromEvent(command, [hook.fullPath], "close", environment, { throwError: false });
+					const output = await this.$childProcess.spawnFromEvent(command, [hook.fullPath], "close", environment, { throwError: false });
 					if (output.exitCode !== 0) {
 						throw new Error(output.stdout + output.stderr);
 					}
@@ -153,9 +153,9 @@ export class HooksService implements IHooksService {
 	}
 
 	private getHooksByName(directoryPath: string, hookName: string): IHook[] {
-		let allBaseHooks = this.getHooksInDirectory(directoryPath);
-		let baseHooks = _.filter(allBaseHooks, hook => hook.name.toLowerCase() === hookName.toLowerCase());
-		let moreHooks = this.getHooksInDirectory(path.join(directoryPath, hookName));
+		const allBaseHooks = this.getHooksInDirectory(directoryPath);
+		const baseHooks = _.filter(allBaseHooks, hook => hook.name.toLowerCase() === hookName.toLowerCase());
+		const moreHooks = this.getHooksInDirectory(path.join(directoryPath, hookName));
 		return baseHooks.concat(moreHooks);
 	}
 
@@ -163,15 +163,15 @@ export class HooksService implements IHooksService {
 		if (!this.cachedHooks[directoryPath]) {
 			let hooks: IHook[] = [];
 			if (directoryPath && this.$fs.exists(directoryPath) && this.$fs.getFsStats(directoryPath).isDirectory()) {
-				let directoryContent = this.$fs.readDirectory(directoryPath);
-				let files = _.filter(directoryContent, (entry: string) => {
-					let fullPath = path.join(directoryPath, entry);
-					let isFile = this.$fs.getFsStats(fullPath).isFile();
+				const directoryContent = this.$fs.readDirectory(directoryPath);
+				const files = _.filter(directoryContent, (entry: string) => {
+					const fullPath = path.join(directoryPath, entry);
+					const isFile = this.$fs.getFsStats(fullPath).isFile();
 					return isFile;
 				});
 
 				hooks = _.map(files, file => {
-					let fullPath = path.join(directoryPath, file);
+					const fullPath = path.join(directoryPath, file);
 					return new Hook(this.getBaseFilename(file), fullPath);
 				});
 			}
@@ -183,9 +183,9 @@ export class HooksService implements IHooksService {
 	}
 
 	private prepareEnvironment(hookFullPath: string): any {
-		let clientName = this.$staticConfig.CLIENT_NAME.toUpperCase();
+		const clientName = this.$staticConfig.CLIENT_NAME.toUpperCase();
 
-		let environment: IStringDictionary = {};
+		const environment: IStringDictionary = {};
 		environment[util.format("%s-COMMANDLINE", clientName)] = process.argv.join(' ');
 		environment[util.format("%s-HOOK_FULL_PATH", clientName)] = hookFullPath;
 		environment[util.format("%s-VERSION", clientName)] = this.$staticConfig.version;
@@ -200,9 +200,9 @@ export class HooksService implements IHooksService {
 	private getSheBangInterpreter(hook: IHook): string {
 		let interpreter: string = null;
 		let shMatch: string[] = [];
-		let fileContent = this.$fs.readText(hook.fullPath);
+		const fileContent = this.$fs.readText(hook.fullPath);
 		if (fileContent) {
-			let sheBangMatch = fileContent.split('\n')[0].match(/^#!(?:\/usr\/bin\/env )?([^\r\n]+)/m);
+			const sheBangMatch = fileContent.split('\n')[0].match(/^#!(?:\/usr\/bin\/env )?([^\r\n]+)/m);
 			if (sheBangMatch) {
 				interpreter = sheBangMatch[1];
 			}
@@ -224,8 +224,8 @@ export class HooksService implements IHooksService {
 
 	private shouldExecuteInProcess(scriptSource: string): boolean {
 		try {
-			let esprima = require('esprima');
-			let ast = esprima.parse(scriptSource);
+			const esprima = require('esprima');
+			const ast = esprima.parse(scriptSource);
 
 			let inproc = false;
 			ast.body.forEach((statement: any) => {
@@ -234,7 +234,7 @@ export class HooksService implements IHooksService {
 					return;
 				}
 
-				let left = statement.expression.left;
+				const left = statement.expression.left;
 				if (left.type === 'MemberExpression' &&
 					left.object && left.object.type === 'Identifier' && left.object.name === 'module'
 					&& left.property && left.property.type === 'Identifier' && left.property.name === 'exports') {
@@ -249,7 +249,7 @@ export class HooksService implements IHooksService {
 	}
 
 	private validateHookArguments(hookConstructor: Function): string[] {
-		let invalidArguments: string[] = [];
+		const invalidArguments: string[] = [];
 
 		// We need to annotate the hook in order to have the arguments of the constructor.
 		annotate(hookConstructor);

--- a/services/html-help-service.ts
+++ b/services/html-help-service.ts
@@ -45,28 +45,28 @@ export class HtmlHelpService implements IHtmlHelpService {
 	}
 
 	public async generateHtmlPages(): Promise<void> {
-		let mdFiles = this.$fs.enumerateFilesInDirectorySync(this.pathToManPages);
-		let basicHtmlPage = this.$fs.readText(this.pathToBasicPage);
+		const mdFiles = this.$fs.enumerateFilesInDirectorySync(this.pathToManPages);
+		const basicHtmlPage = this.$fs.readText(this.pathToBasicPage);
 		await Promise.all(_.map(mdFiles, markdownFile => this.createHtmlPage(basicHtmlPage, markdownFile)));
 		this.$logger.trace("Finished generating HTML files.");
 	}
 
 	// This method should return Promise in order to generate all html pages simultaneously.
 	private async createHtmlPage(basicHtmlPage: string, pathToMdFile: string): Promise<void> {
-		let mdFileName = path.basename(pathToMdFile);
-		let htmlFileName = mdFileName.replace(HtmlHelpService.MARKDOWN_FILE_EXTENSION, HtmlHelpService.HTML_FILE_EXTENSION);
+		const mdFileName = path.basename(pathToMdFile);
+		const htmlFileName = mdFileName.replace(HtmlHelpService.MARKDOWN_FILE_EXTENSION, HtmlHelpService.HTML_FILE_EXTENSION);
 		this.$logger.trace("Generating '%s' help topic.", htmlFileName);
 
-		let helpText = this.$fs.readText(pathToMdFile);
-		let outputText = await this.$microTemplateService.parseContent(helpText, { isHtml: true });
-		let htmlText = marked(outputText);
+		const helpText = this.$fs.readText(pathToMdFile);
+		const outputText = await this.$microTemplateService.parseContent(helpText, { isHtml: true });
+		const htmlText = marked(outputText);
 
-		let filePath = pathToMdFile
+		const filePath = pathToMdFile
 			.replace(path.basename(this.pathToManPages), path.basename(this.pathToHtmlPages))
 			.replace(mdFileName, htmlFileName);
 		this.$logger.trace("HTML file path for '%s' man page is: '%s'.", mdFileName, filePath);
 
-		let outputHtml = basicHtmlPage
+		const outputHtml = basicHtmlPage
 			.replace(HtmlHelpService.MAN_PAGE_NAME_REGEX, mdFileName.replace(HtmlHelpService.MARKDOWN_FILE_EXTENSION, ""))
 			.replace(HtmlHelpService.HTML_COMMAND_HELP_REGEX, htmlText)
 			.replace(HtmlHelpService.RELATIVE_PATH_TO_STYLES_CSS_REGEX, path.relative(path.dirname(filePath), this.pathToStylesCss))
@@ -78,7 +78,7 @@ export class HtmlHelpService implements IHtmlHelpService {
 	}
 
 	public async openHelpForCommandInBrowser(commandName: string): Promise<void> {
-		let htmlPage = await this.convertCommandNameToFileName(commandName) + HtmlHelpService.HTML_FILE_EXTENSION;
+		const htmlPage = await this.convertCommandNameToFileName(commandName) + HtmlHelpService.HTML_FILE_EXTENSION;
 		this.$logger.trace("Opening help for command '%s'. FileName is '%s'.", commandName, htmlPage);
 
 		this.$fs.ensureDirectoryExists(this.pathToHtmlPages);
@@ -93,16 +93,16 @@ export class HtmlHelpService implements IHtmlHelpService {
 	}
 
 	private async convertCommandNameToFileName(commandName: string): Promise<string> {
-		let defaultCommandMatch = commandName.match(/(\w+?)\|\*/);
+		const defaultCommandMatch = commandName.match(/(\w+?)\|\*/);
 		if (defaultCommandMatch) {
 			this.$logger.trace("Default command found. Replace current command name '%s' with '%s'.", commandName, defaultCommandMatch[1]);
 			commandName = defaultCommandMatch[1];
 		}
 
-		let availableCommands = this.$injector.getRegisteredCommandsNames(true).sort();
+		const availableCommands = this.$injector.getRegisteredCommandsNames(true).sort();
 		this.$logger.trace("List of registered commands: %s", availableCommands.join(", "));
 		if (commandName && _.startsWith(commandName, this.$commandsServiceProvider.dynamicCommandsPrefix) && !_.includes(availableCommands, commandName)) {
-			let dynamicCommands = await this.$commandsServiceProvider.getDynamicCommands();
+			const dynamicCommands = await this.$commandsServiceProvider.getDynamicCommands();
 			if (!_.includes(dynamicCommands, commandName)) {
 				this.$errors.failWithoutHelp("Unknown command '%s'. Try '$ %s help' for a full list of supported commands.", commandName, this.$staticConfig.CLIENT_NAME.toLowerCase());
 			}
@@ -112,9 +112,9 @@ export class HtmlHelpService implements IHtmlHelpService {
 	}
 
 	private tryOpeningSelectedPage(htmlPage: string): boolean {
-		let fileList = this.$fs.enumerateFilesInDirectorySync(this.pathToHtmlPages);
+		const fileList = this.$fs.enumerateFilesInDirectorySync(this.pathToHtmlPages);
 		this.$logger.trace("File list: " + fileList);
-		let pageToOpen = _.find(fileList, file => path.basename(file) === htmlPage);
+		const pageToOpen = _.find(fileList, file => path.basename(file) === htmlPage);
 
 		if (pageToOpen) {
 			this.$logger.trace("Found page to open: '%s'", pageToOpen);
@@ -127,10 +127,10 @@ export class HtmlHelpService implements IHtmlHelpService {
 	}
 
 	private async readMdFileForCommand(commandName: string): Promise<string> {
-		let mdFileName = await this.convertCommandNameToFileName(commandName) + HtmlHelpService.MARKDOWN_FILE_EXTENSION;
+		const mdFileName = await this.convertCommandNameToFileName(commandName) + HtmlHelpService.MARKDOWN_FILE_EXTENSION;
 		this.$logger.trace("Reading help for command '%s'. FileName is '%s'.", commandName, mdFileName);
 
-		let markdownFile = _.find(this.$fs.enumerateFilesInDirectorySync(this.pathToManPages), file => path.basename(file) === mdFileName);
+		const markdownFile = _.find(this.$fs.enumerateFilesInDirectorySync(this.pathToManPages), file => path.basename(file) === mdFileName);
 		if (markdownFile) {
 			return this.$fs.readText(markdownFile);
 		}
@@ -139,7 +139,7 @@ export class HtmlHelpService implements IHtmlHelpService {
 	}
 
 	public async getCommandLineHelpForCommand(commandName: string): Promise<string> {
-		let helpText = await this.readMdFileForCommand(commandName);
+		const helpText = await this.readMdFileForCommand(commandName);
 		const commandLineHelp = (await this.$microTemplateService.parseContent(helpText, { isHtml: false }))
 			.replace(/&nbsp;/g, " ")
 			.replace(HtmlHelpService.MARKDOWN_LINK_REGEX, "$1")

--- a/services/livesync/sync-batch.ts
+++ b/services/livesync/sync-batch.ts
@@ -11,7 +11,7 @@ export class SyncBatch {
 		private done: () => Promise<void>) { }
 
 	private get filesToSync(): string[] {
-		let filteredFiles = _.remove(this.syncQueue, syncFile => this.$projectFilesManager.isFileExcluded(syncFile));
+		const filteredFiles = _.remove(this.syncQueue, syncFile => this.$projectFilesManager.isFileExcluded(syncFile));
 		this.$logger.trace("Removed files from syncQueue: ", filteredFiles);
 		return this.syncQueue;
 	}

--- a/services/message-contract-generator.ts
+++ b/services/message-contract-generator.ts
@@ -10,8 +10,8 @@ export class MessageContractGenerator implements IServiceContractGenerator {
 	}
 
 	public async generate(): Promise<IServiceContractClientCode> {
-		let interfacesFile = new Block();
-		let implementationsFile = new Block();
+		const interfacesFile = new Block();
+		const implementationsFile = new Block();
 
 		implementationsFile.writeLine("//");
 		implementationsFile.writeLine("// automatically generated code; do not edit manually!");
@@ -24,11 +24,11 @@ export class MessageContractGenerator implements IServiceContractGenerator {
 		interfacesFile.writeLine("//");
 		interfacesFile.writeLine("/* tslint:disable:all */");
 
-		let messagesClass = new Block("export class Messages implements IMessages");
-		let messagesInterface = new Block("interface IMessages");
+		const messagesClass = new Block("export class Messages implements IMessages");
+		const messagesInterface = new Block("interface IMessages");
 
 		_.each(this.$messagesService.pathsToMessageJsonFiles, jsonFilePath => {
-			let jsonContents = this.$fs.readJson(jsonFilePath),
+			const jsonContents = this.$fs.readJson(jsonFilePath),
 				implementationBlock: CodeGeneration.IBlock = new Block(),
 				interfaceBlock: CodeGeneration.IBlock = new Block();
 
@@ -47,7 +47,7 @@ export class MessageContractGenerator implements IServiceContractGenerator {
 		implementationsFile.writeLine("/* tslint:enable */");
 		implementationsFile.writeLine("");
 
-		let codePrinter = new CodePrinter();
+		const codePrinter = new CodePrinter();
 		return {
 			interfaceFile: codePrinter.composeBlock(interfacesFile),
 			implementationFile: codePrinter.composeBlock(implementationsFile)
@@ -56,19 +56,19 @@ export class MessageContractGenerator implements IServiceContractGenerator {
 
 	private generateFileRecursive(jsonContents: any, propertyValue: string, block: CodeGeneration.IBlock, depth: number, options: { shouldGenerateInterface: boolean }): void {
 		_.each(jsonContents, (val: any, key: string) => {
-			let newPropertyValue = propertyValue + key,
-				separator = options.shouldGenerateInterface || depth ? ":" : "=",
-				endingSymbol = options.shouldGenerateInterface || !depth ? ";" : ",";
+			let newPropertyValue = propertyValue + key;
+			const separator = options.shouldGenerateInterface || depth ? ":" : "=";
+			const endingSymbol = options.shouldGenerateInterface || !depth ? ";" : ",";
 
 			if (typeof val === "string") {
-				let actualValue = options.shouldGenerateInterface ? "string" : `"${newPropertyValue}"`;
+				const actualValue = options.shouldGenerateInterface ? "string" : `"${newPropertyValue}"`;
 
 				block.writeLine(`${key}${separator} ${actualValue}${endingSymbol}`);
 				newPropertyValue = propertyValue;
 				return;
 			}
 
-			let newBlock = new Block(`${key} ${separator} `);
+			const newBlock = new Block(`${key} ${separator} `);
 			newBlock.endingCharacter = endingSymbol;
 			this.generateFileRecursive(val, newPropertyValue + ".", newBlock, depth + 1, options);
 			block.addBlock(newBlock);

--- a/services/messages-service.ts
+++ b/services/messages-service.ts
@@ -37,11 +37,11 @@ export class MessagesService implements IMessagesService {
 	public getMessage(id: string, ...args: string[]): string {
 		const argsArray = args || [];
 
-		let keys = id.split("."),
-			result = this.getFormatedMessage.apply(this, [id].concat(argsArray));
+		const keys = id.split(".");
+		let result = this.getFormatedMessage.apply(this, [id].concat(argsArray));
 
 		_.each(this.messageJsonFilesContents, jsonFileContents => {
-			let messageValue = this.getMessageFromJsonRecursive(keys, jsonFileContents, 0);
+			const messageValue = this.getMessageFromJsonRecursive(keys, jsonFileContents, 0);
 			if (messageValue) {
 				result = this.getFormatedMessage.apply(this, [messageValue].concat(argsArray));
 				return false;
@@ -56,7 +56,7 @@ export class MessagesService implements IMessagesService {
 			return null;
 		}
 
-		let jsonValue = jsonContents[keys[index]];
+		const jsonValue = jsonContents[keys[index]];
 		if (!jsonValue) {
 			return null;
 		}

--- a/services/micro-templating-service.ts
+++ b/services/micro-templating-service.ts
@@ -11,8 +11,8 @@ export class MicroTemplateService implements IMicroTemplateService {
 	}
 
 	public async parseContent(data: string, options: { isHtml: boolean }): Promise<string> {
-		let localVariables = this.$dynamicHelpService.getLocalVariables(options);
-		let compiledTemplate = _.template(data.replace(this.dynamicCallRegex, "this.$injector.getDynamicCallData(\"$1\")"));
+		const localVariables = this.$dynamicHelpService.getLocalVariables(options);
+		const compiledTemplate = _.template(data.replace(this.dynamicCallRegex, "this.$injector.getDynamicCallData(\"$1\")"));
 		// When debugging parsing, uncomment the line below:
 		// console.log(compiledTemplate.source);
 		return await compiledTemplate.apply(this, [localVariables]);

--- a/services/net-service.ts
+++ b/services/net-service.ts
@@ -4,12 +4,12 @@ export class Net implements INet {
 	constructor(private $errors: IErrors) { }
 
 	public async getFreePort(): Promise<number> {
-		let server = net.createServer((sock: string) => { /* empty - noone will connect here */ });
+		const server = net.createServer((sock: string) => { /* empty - noone will connect here */ });
 
 		return new Promise<number>((resolve, reject) => {
 			let isResolved = false;
 			server.listen(0, () => {
-				let portUsed = server.address().port;
+				const portUsed = server.address().port;
 				server.close();
 
 				if (!isResolved) {
@@ -31,7 +31,7 @@ export class Net implements INet {
 	public async isPortAvailable(port: number): Promise<boolean> {
 		return new Promise<boolean>((resolve, reject) => {
 			let isResolved = false;
-			let server = net.createServer();
+			const server = net.createServer();
 
 			server.on("error", (err: Error) => {
 				if (!isResolved) {

--- a/services/plugins/npm-plugins-service.ts
+++ b/services/plugins/npm-plugins-service.ts
@@ -6,9 +6,9 @@ export class NpmPluginsService implements INpmPluginsService {
 	constructor(private $injector: IInjector) { }
 
 	public async search(projectDir: string, keywords: string[], modifySearchQuery: (keywords: string[]) => string[]): Promise<IPluginsSource> {
-		let query = modifySearchQuery ? modifySearchQuery(keywords) : keywords;
+		const query = modifySearchQuery ? modifySearchQuery(keywords) : keywords;
 
-		let pluginsSource = await this.searchCore(NpmjsPluginsSource, projectDir, keywords) ||
+		const pluginsSource = await this.searchCore(NpmjsPluginsSource, projectDir, keywords) ||
 			await this.searchCore(NpmRegistryPluginsSource, projectDir, keywords) ||
 			await this.preparePluginsSource(NpmPluginsSource, projectDir, query);
 
@@ -20,13 +20,13 @@ export class NpmPluginsService implements INpmPluginsService {
 	}
 
 	private async searchCore(pluginsSourceConstructor: Function, projectDir: string, keywords: string[]): Promise<IPluginsSource> {
-		let npmPluginsSource = await this.preparePluginsSource(pluginsSourceConstructor, projectDir, keywords);
+		const npmPluginsSource = await this.preparePluginsSource(pluginsSourceConstructor, projectDir, keywords);
 
 		return npmPluginsSource.hasPlugins() ? npmPluginsSource : null;
 	}
 
 	private async preparePluginsSource(pluginsSourceConstructor: Function, projectDir: string, keywords: string[]): Promise<IPluginsSource> {
-		let pluginsSource: IPluginsSource = this.$injector.resolve(pluginsSourceConstructor, { projectDir, keywords });
+		const pluginsSource: IPluginsSource = this.$injector.resolve(pluginsSourceConstructor, { projectDir, keywords });
 		await pluginsSource.initialize(projectDir, keywords);
 		return pluginsSource;
 	}

--- a/services/plugins/npm-plugins-source.ts
+++ b/services/plugins/npm-plugins-source.ts
@@ -12,7 +12,7 @@ export class NpmPluginsSource extends PluginsSourceBase implements IPluginsSourc
 	}
 
 	public async getPlugins(page: number, count: number): Promise<IBasicPluginInformation[]> {
-		let skip = page * count;
+		const skip = page * count;
 
 		return _.slice(this.plugins, skip, skip + count);
 	}

--- a/services/plugins/npm-registry-plugins-source.ts
+++ b/services/plugins/npm-registry-plugins-source.ts
@@ -16,7 +16,7 @@ export class NpmRegistryPluginsSource extends PluginsSourceBase implements IPlug
 	}
 
 	protected async initializeCore(projectDir: string, keywords: string[]): Promise<void> {
-		let plugin = await this.getPluginFromNpmRegistry(keywords[0]);
+		const plugin = await this.getPluginFromNpmRegistry(keywords[0]);
 		this.plugins = plugin ? [plugin] : null;
 	}
 
@@ -25,11 +25,11 @@ export class NpmRegistryPluginsSource extends PluginsSourceBase implements IPlug
 	}
 
 	private async getPluginFromNpmRegistry(plugin: string): Promise<IBasicPluginInformation> {
-		let dependencyInfo = this.$npmService.getDependencyInformation(plugin);
+		const dependencyInfo = this.$npmService.getDependencyInformation(plugin);
 
-		let pluginName = this.$npmService.isScopedDependency(plugin) ? this.prepareScopedPluginName(dependencyInfo.name) : dependencyInfo.name;
+		const pluginName = this.$npmService.isScopedDependency(plugin) ? this.prepareScopedPluginName(dependencyInfo.name) : dependencyInfo.name;
 
-		let result = await this.$npmService.getPackageJsonFromNpmRegistry(pluginName, dependencyInfo.version);
+		const result = await this.$npmService.getPackageJsonFromNpmRegistry(pluginName, dependencyInfo.version);
 
 		if (!result) {
 			return null;

--- a/services/plugins/npmjs-plugins-source.ts
+++ b/services/plugins/npmjs-plugins-source.ts
@@ -19,12 +19,12 @@ export class NpmjsPluginsSource extends PluginsSourceBase implements IPluginsSou
 	}
 
 	public async getPlugins(page: number, count: number): Promise<IBasicPluginInformation[]> {
-		let loadedPlugins = this._pages[page];
+		const loadedPlugins = this._pages[page];
 		if (loadedPlugins) {
 			return loadedPlugins;
 		}
 
-		let result = await this.getPluginsFromNpmjs(this._keywords, page);
+		const result = await this.getPluginsFromNpmjs(this._keywords, page);
 
 		this._pages[page] = result;
 
@@ -61,21 +61,21 @@ export class NpmjsPluginsSource extends PluginsSourceBase implements IPluginsSou
 	}
 
 	private async getPluginsFromNpmjs(keywords: string[], page: number): Promise<IBasicPluginInformation[]> {
-		let pluginName = encodeURIComponent(keywords.join(" "));
-		let url = `${NpmjsPluginsSource.NPMJS_ADDRESS}/search?q=${pluginName}&page=${page}`;
+		const pluginName = encodeURIComponent(keywords.join(" "));
+		const url = `${NpmjsPluginsSource.NPMJS_ADDRESS}/search?q=${pluginName}&page=${page}`;
 
 		try {
-			let responseBody: string = (await this.$httpClient.httpRequest(url)).body;
+			const responseBody: string = (await this.$httpClient.httpRequest(url)).body;
 
-			let document = parse5.parse(responseBody);
-			let html = _.find(document.childNodes, (node: parse5.ASTNode) => node.nodeName === "html");
+			const document = parse5.parse(responseBody);
+			const html = _.find(document.childNodes, (node: parse5.ASTNode) => node.nodeName === "html");
 
-			let resultsContainer = this.findNodeByClass(html, "search-results");
+			const resultsContainer = this.findNodeByClass(html, "search-results");
 			if (!resultsContainer || !resultsContainer.childNodes) {
 				return null;
 			}
 
-			let resultsElements = _.filter(resultsContainer.childNodes, (node: parse5.ASTNode) => node.nodeName === "li");
+			const resultsElements = _.filter(resultsContainer.childNodes, (node: parse5.ASTNode) => node.nodeName === "li");
 			return _.map(resultsElements, (node: parse5.ASTNode) => this.getPluginInfo(node));
 		} catch (err) {
 			this.$logger.trace(`Error while getting information for ${keywords} from http://npmjs.org - ${err}`);
@@ -84,10 +84,10 @@ export class NpmjsPluginsSource extends PluginsSourceBase implements IPluginsSou
 	}
 
 	private getPluginInfo(node: parse5.ASTNode): IBasicPluginInformation {
-		let name = this.getTextFromElementWithClass(node, "name");
-		let version = this.getTextFromElementWithClass(node, "version");
-		let description = this.getTextFromElementWithClass(node, "description");
-		let author = this.getTextFromElementWithClass(node, "author");
+		const name = this.getTextFromElementWithClass(node, "name");
+		const version = this.getTextFromElementWithClass(node, "version");
+		const description = this.getTextFromElementWithClass(node, "description");
+		const author = this.getTextFromElementWithClass(node, "author");
 
 		return {
 			name,
@@ -103,12 +103,12 @@ export class NpmjsPluginsSource extends PluginsSourceBase implements IPluginsSou
 		}
 
 		for (let i = 0; i < parent.childNodes.length; i++) {
-			let node = parent.childNodes[i];
+			const node = parent.childNodes[i];
 
 			if (_.some(node.attrs, (attr: parse5.ASTAttribute) => attr.name === "class" && attr.value === className)) {
 				return node;
 			} else {
-				let result = this.findNodeByClass(node, className);
+				const result = this.findNodeByClass(node, className);
 
 				if (result) {
 					return result;
@@ -118,10 +118,10 @@ export class NpmjsPluginsSource extends PluginsSourceBase implements IPluginsSou
 	}
 
 	private getTextFromElementWithClass(node: parse5.ASTNode, className: string): string {
-		let element = this.findNodeByClass(node, className);
+		const element = this.findNodeByClass(node, className);
 
 		if (element && element.childNodes) {
-			let textElement = _.find(element.childNodes, (child: parse5.ASTNode) => child.nodeName === "#text");
+			const textElement = _.find(element.childNodes, (child: parse5.ASTNode) => child.nodeName === "#text");
 			if (textElement) {
 				return textElement.value;
 			}

--- a/services/plugins/print-plugins-service.ts
+++ b/services/plugins/print-plugins-service.ts
@@ -16,10 +16,10 @@ export class PrintPluginsService implements IPrintPluginsService {
 			return;
 		}
 
-		let count: number = options.count || PrintPluginsService.COUNT_OF_PLUGINS_TO_DISPLAY;
+		const count: number = options.count || PrintPluginsService.COUNT_OF_PLUGINS_TO_DISPLAY;
 
 		if (!isInteractive() || options.showAllPlugins) {
-			let allPlugins = await pluginsSource.getAllPlugins();
+			const allPlugins = await pluginsSource.getAllPlugins();
 			this.displayTableWithPlugins(allPlugins);
 			return;
 		}
@@ -50,15 +50,15 @@ export class PrintPluginsService implements IPrintPluginsService {
 		let data: string[][] = [];
 		data = this.createTableCells(plugins);
 
-		let table: any = this.createPluginsTable(data);
+		const table: any = this.createPluginsTable(data);
 
 		this.$logger.out(table.toString());
 	}
 
 	private createPluginsTable(data: string[][]): any {
-		let headers: string[] = ["Plugin", "Version", "Author", "Description"];
+		const headers: string[] = ["Plugin", "Version", "Author", "Description"];
 
-		let table: any = createTable(headers, data);
+		const table: any = createTable(headers, data);
 
 		return table;
 	}

--- a/services/process-service.ts
+++ b/services/process-service.ts
@@ -11,7 +11,7 @@ export class ProcessService implements IProcessService {
 	}
 
 	public attachToProcessExitSignals(context: any, callback: () => void): void {
-		let callbackToString = callback.toString();
+		const callbackToString = callback.toString();
 
 		if (this._listeners.length === 0) {
 			_.each(ProcessService.PROCESS_EXIT_SIGNALS, (signal: string) => {

--- a/services/project-files-manager.ts
+++ b/services/project-files-manager.ts
@@ -9,9 +9,9 @@ export class ProjectFilesManager implements IProjectFilesManager {
 		private $projectFilesProvider: IProjectFilesProvider) { }
 
 	public getProjectFiles(projectFilesPath: string, excludedProjectDirsAndFiles?: string[], filter?: (filePath: string, stat: IFsStats) => boolean, opts?: any): string[] {
-		let projectFiles = this.$fs.enumerateFilesInDirectorySync(projectFilesPath, (filePath, stat) => {
-			let isFileExcluded = this.isFileExcluded(path.relative(projectFilesPath, filePath), excludedProjectDirsAndFiles);
-			let isFileFiltered = filter ? filter(filePath, stat) : false;
+		const projectFiles = this.$fs.enumerateFilesInDirectorySync(projectFilesPath, (filePath, stat) => {
+			const isFileExcluded = this.isFileExcluded(path.relative(projectFilesPath, filePath), excludedProjectDirsAndFiles);
+			const isFileFiltered = filter ? filter(filePath, stat) : false;
 			return !isFileExcluded && !isFileFiltered;
 		}, opts);
 
@@ -21,7 +21,7 @@ export class ProjectFilesManager implements IProjectFilesManager {
 	}
 
 	public isFileExcluded(filePath: string, excludedProjectDirsAndFiles?: string[]): boolean {
-		let isInExcludedList = !!_.find(excludedProjectDirsAndFiles, (pattern) => minimatch(filePath, pattern, { nocase: true }));
+		const isInExcludedList = !!_.find(excludedProjectDirsAndFiles, (pattern) => minimatch(filePath, pattern, { nocase: true }));
 		return isInExcludedList || this.$projectFilesProvider.isFileExcluded(filePath);
 	}
 
@@ -29,7 +29,7 @@ export class ProjectFilesManager implements IProjectFilesManager {
 		const deviceProjectRootPath = await deviceAppData.getDeviceProjectRootPath();
 
 		files = files || this.getProjectFiles(projectFilesPath, excludedProjectDirsAndFiles, null, { enumerateDirectories: true });
-		let localToDevicePaths = Promise.all(files
+		const localToDevicePaths = Promise.all(files
 			.map(projectFile => this.$projectFilesProvider.getProjectFileInfo(projectFile, deviceAppData.platform, projectFilesConfig))
 			.filter(projectFileInfo => projectFileInfo.shouldIncludeFile)
 			.map(async projectFileInfo => this.$localToDevicePathDataFactory.create(projectFileInfo.filePath, projectFilesPath, projectFileInfo.onDeviceFileName, deviceProjectRootPath)));
@@ -38,12 +38,12 @@ export class ProjectFilesManager implements IProjectFilesManager {
 	}
 
 	public processPlatformSpecificFiles(directoryPath: string, platform: string, projectFilesConfig: IProjectFilesConfig, excludedDirs?: string[]): void {
-		let contents = this.$fs.readDirectory(directoryPath);
-		let files: string[] = [];
+		const contents = this.$fs.readDirectory(directoryPath);
+		const files: string[] = [];
 
 		_.each(contents, fileName => {
-			let filePath = path.join(directoryPath, fileName);
-			let fsStat = this.$fs.getFsStats(filePath);
+			const filePath = path.join(directoryPath, fileName);
+			const fsStat = this.$fs.getFsStats(filePath);
 			if (fsStat.isDirectory() && !_.includes(excludedDirs, fileName)) {
 				this.processPlatformSpecificFilesCore(platform, this.$fs.enumerateFilesInDirectorySync(filePath), projectFilesConfig);
 			} else if (fsStat.isFile()) {
@@ -57,18 +57,18 @@ export class ProjectFilesManager implements IProjectFilesManager {
 	private processPlatformSpecificFilesCore(platform: string, files: string[],  projectFilesConfig: IProjectFilesConfig): void {
 		// Renames the files that have `platform` as substring and removes the files from other platform
 		_.each(files, filePath => {
-			let projectFileInfo = this.$projectFilesProvider.getProjectFileInfo(filePath, platform,  projectFilesConfig);
+			const projectFileInfo = this.$projectFilesProvider.getProjectFileInfo(filePath, platform,  projectFilesConfig);
 			if (!projectFileInfo.shouldIncludeFile) {
 				this.$fs.deleteFile(filePath);
 			} else if (projectFileInfo.onDeviceFileName) {
-				let onDeviceFilePath = path.join(path.dirname(filePath), projectFileInfo.onDeviceFileName);
+				const onDeviceFilePath = path.join(path.dirname(filePath), projectFileInfo.onDeviceFileName);
 
 				// Fix .js.map entries
-				let extension = path.extname(projectFileInfo.onDeviceFileName);
+				const extension = path.extname(projectFileInfo.onDeviceFileName);
 				if (onDeviceFilePath !== filePath) {
 					if (extension === ".js" || extension === ".map") {
-						let oldName = extension === ".map" ? this.getFileName(filePath, extension) : path.basename(filePath);
-						let newName = extension === ".map" ? this.getFileName(projectFileInfo.onDeviceFileName, extension) : path.basename(projectFileInfo.onDeviceFileName);
+						const oldName = extension === ".map" ? this.getFileName(filePath, extension) : path.basename(filePath);
+						const newName = extension === ".map" ? this.getFileName(projectFileInfo.onDeviceFileName, extension) : path.basename(projectFileInfo.onDeviceFileName);
 
 						let fileContent = this.$fs.readText(filePath);
 						fileContent = fileContent.replace(new RegExp(oldName, 'g'), newName);

--- a/services/project-files-provider-base.ts
+++ b/services/project-files-provider-base.ts
@@ -10,7 +10,7 @@ export abstract class ProjectFilesProviderBase implements IProjectFilesProvider 
 		protected $options: ICommonOptions) { }
 
 	public getPreparedFilePath(filePath: string, projectFilesConfig?: IProjectFilesConfig): string {
-		let projectFileInfo = this.getProjectFileInfo(filePath, "", projectFilesConfig);
+		const projectFileInfo = this.getProjectFileInfo(filePath, "", projectFilesConfig);
 		return path.join(path.dirname(filePath), projectFileInfo.onDeviceFileName);
 	}
 
@@ -24,10 +24,10 @@ export abstract class ProjectFilesProviderBase implements IProjectFilesProvider 
 		}
 
 		let parsed = this.parseFile(filePath, this.$mobileHelper.platformNames, platform || "");
-		let basicConfigurations = [Configurations.Debug.toLowerCase(), Configurations.Release.toLowerCase()];
+		const basicConfigurations = [Configurations.Debug.toLowerCase(), Configurations.Release.toLowerCase()];
 		if (!parsed) {
 
-			let validValues = basicConfigurations.concat(projectFilesConfig && projectFilesConfig.additionalConfigurations || []),
+			const validValues = basicConfigurations.concat(projectFilesConfig && projectFilesConfig.additionalConfigurations || []),
 				value = projectFilesConfig && projectFilesConfig.configuration || basicConfigurations[0];
 			parsed = this.parseFile(filePath, validValues, value);
 		}
@@ -40,8 +40,8 @@ export abstract class ProjectFilesProviderBase implements IProjectFilesProvider 
 	}
 
 	private parseFile(filePath: string, validValues: string[], value: string): IProjectFileInfo {
-		let regex = util.format("^(.+?)[.](%s)([.].+?)$", validValues.join("|"));
-		let parsed = filePath.match(new RegExp(regex, "i"));
+		const regex = util.format("^(.+?)[.](%s)([.].+?)$", validValues.join("|"));
+		const parsed = filePath.match(new RegExp(regex, "i"));
 		if (parsed) {
 			return {
 				filePath: filePath,

--- a/services/typescript-service.ts
+++ b/services/typescript-service.ts
@@ -39,12 +39,12 @@ export class TypeScriptService implements ITypeScriptService {
 	@exported("typeScriptService")
 	public async transpile(projectDir: string, typeScriptFiles?: string[], definitionFiles?: string[], options?: ITypeScriptTranspileOptions): Promise<void> {
 		options = options || {};
-		let compilerOptions = this.getCompilerOptions(projectDir, options);
-		let typeScriptCompilerSettings = await this.getTypeScriptCompilerSettings({ useLocalTypeScriptCompiler: options.useLocalTypeScriptCompiler }, projectDir);
+		const compilerOptions = this.getCompilerOptions(projectDir, options);
+		const typeScriptCompilerSettings = await this.getTypeScriptCompilerSettings({ useLocalTypeScriptCompiler: options.useLocalTypeScriptCompiler }, projectDir);
 		this.noEmitOnError = compilerOptions.noEmitOnError;
 		this.typeScriptFiles = typeScriptFiles || [];
 		this.definitionFiles = definitionFiles || [];
-		let runTranspilationOptions: IRunTranspilationOptions = { compilerOptions };
+		const runTranspilationOptions: IRunTranspilationOptions = { compilerOptions };
 
 		if (this.typeScriptFiles.length > 0) {
 			let typeScriptDefinitionsFiles: string[] = [];
@@ -54,7 +54,7 @@ export class TypeScriptService implements ITypeScriptService {
 
 			typeScriptDefinitionsFiles = typeScriptDefinitionsFiles.concat(this.getTypeScriptFilesData(projectDir).definitionFiles);
 
-			let filesToTranspile = this.typeScriptFiles.concat(typeScriptDefinitionsFiles);
+			const filesToTranspile = this.typeScriptFiles.concat(typeScriptDefinitionsFiles);
 
 			// Log some messages
 			this.$logger.out("Compiling...".yellow);
@@ -72,16 +72,16 @@ export class TypeScriptService implements ITypeScriptService {
 
 	public getTypeScriptFilesData(projectDir: string): ITypeScriptFiles {
 		// Skip root's node_modules
-		let rootNodeModules = path.join(projectDir, NODE_MODULES_DIR_NAME);
-		let projectFiles = this.$fs.enumerateFilesInDirectorySync(projectDir,
+		const rootNodeModules = path.join(projectDir, NODE_MODULES_DIR_NAME);
+		const projectFiles = this.$fs.enumerateFilesInDirectorySync(projectDir,
 			(fileName: string, fstat: IFsStats) => fileName !== rootNodeModules);
-		let typeScriptFiles = _.filter(projectFiles, this.isTypeScriptFile);
-		let definitionFiles = _.filter(typeScriptFiles, file => _.endsWith(file, FileExtensions.TYPESCRIPT_DEFINITION_FILE));
+		const typeScriptFiles = _.filter(projectFiles, this.isTypeScriptFile);
+		const definitionFiles = _.filter(typeScriptFiles, file => _.endsWith(file, FileExtensions.TYPESCRIPT_DEFINITION_FILE));
 		return { definitionFiles: definitionFiles, typeScriptFiles: _.difference(typeScriptFiles, definitionFiles) };
 	}
 
 	public isTypeScriptProject(projectDir: string): boolean {
-		let typeScriptFilesData = this.getTypeScriptFilesData(projectDir);
+		const typeScriptFilesData = this.getTypeScriptFilesData(projectDir);
 
 		return !!typeScriptFilesData.typeScriptFiles.length;
 	}
@@ -100,19 +100,19 @@ export class TypeScriptService implements ITypeScriptService {
 
 	private getCompilerOptions(projectDir: string, options: ITypeScriptTranspileOptions): ITypeScriptCompilerOptions {
 		let tsConfigFile: ITypeScriptConfig;
-		let pathToConfigJsonFile = this.getPathToTsConfigFile(projectDir);
+		const pathToConfigJsonFile = this.getPathToTsConfigFile(projectDir);
 
 		if (this.hasTsConfigFile(projectDir)) {
 			tsConfigFile = this.$fs.readJson(pathToConfigJsonFile);
 		}
 
 		tsConfigFile = tsConfigFile || { compilerOptions: {} };
-		let compilerOptions = options.compilerOptions || {};
-		let defaultOptions = options.defaultCompilerOptions || {};
+		const compilerOptions = options.compilerOptions || {};
+		const defaultOptions = options.defaultCompilerOptions || {};
 
-		let compilerOptionsKeys = _.union(_.keys(compilerOptions), _.keys(tsConfigFile.compilerOptions), _.keys(defaultOptions));
+		const compilerOptionsKeys = _.union(_.keys(compilerOptions), _.keys(tsConfigFile.compilerOptions), _.keys(defaultOptions));
 
-		let result: ITypeScriptCompilerOptions = {};
+		const result: ITypeScriptCompilerOptions = {};
 		_.each(compilerOptionsKeys, (key: string) => {
 			result[key] = this.getCompilerOptionByKey(key, compilerOptions, tsConfigFile.compilerOptions, defaultOptions);
 		});
@@ -136,8 +136,8 @@ export class TypeScriptService implements ITypeScriptService {
 	}
 
 	private async getTypeScriptCompilerSettings(options: { useLocalTypeScriptCompiler: boolean }, projectDir: string): Promise<ITypeScriptCompilerSettings> {
-		let typeScriptInNodeModulesDir = path.join(NODE_MODULES_DIR_NAME, TypeScriptService.TYPESCRIPT_MODULE_NAME);
-		let typeScriptInProjectsNodeModulesDir = path.join(projectDir, typeScriptInNodeModulesDir);
+		const typeScriptInNodeModulesDir = path.join(NODE_MODULES_DIR_NAME, TypeScriptService.TYPESCRIPT_MODULE_NAME);
+		const typeScriptInProjectsNodeModulesDir = path.join(projectDir, typeScriptInNodeModulesDir);
 		let typeScriptCompilerVersion: string;
 		if (this.$fs.exists(typeScriptInProjectsNodeModulesDir)) {
 			typeScriptCompilerVersion = this.$fs.readJson(path.join(typeScriptInProjectsNodeModulesDir, this.$projectConstants.PACKAGE_JSON_NAME)).version;
@@ -150,12 +150,12 @@ export class TypeScriptService implements ITypeScriptService {
 
 		if (!this.typeScriptModuleFilePath) {
 			if (options.useLocalTypeScriptCompiler) {
-				let typeScriptJsFilePath = require.resolve(TypeScriptService.TYPESCRIPT_MODULE_NAME);
+				const typeScriptJsFilePath = require.resolve(TypeScriptService.TYPESCRIPT_MODULE_NAME);
 
 				this.typeScriptModuleFilePath = typeScriptJsFilePath.substring(0, typeScriptJsFilePath.indexOf(typeScriptInNodeModulesDir) + typeScriptInNodeModulesDir.length);
 			} else {
-				let typeScriptModuleInstallationDir = this.createTempDirectoryForTsc();
-				let pluginToInstall: INpmDependency = {
+				const typeScriptModuleInstallationDir = this.createTempDirectoryForTsc();
+				const pluginToInstall: INpmDependency = {
 					name: TypeScriptService.TYPESCRIPT_MODULE_NAME,
 					version: TypeScriptService.DEFAULT_TSC_VERSION,
 					installTypes: false
@@ -166,7 +166,7 @@ export class TypeScriptService implements ITypeScriptService {
 			}
 		}
 
-		let typeScriptCompilerPath = path.join(this.typeScriptModuleFilePath, "lib", "tsc");
+		const typeScriptCompilerPath = path.join(this.typeScriptModuleFilePath, "lib", "tsc");
 		typeScriptCompilerVersion = typeScriptCompilerVersion || this.$fs.readJson(path.join(this.typeScriptModuleFilePath, this.$projectConstants.PACKAGE_JSON_NAME)).version;
 
 		return { pathToCompiler: typeScriptCompilerPath, version: typeScriptCompilerVersion };
@@ -174,7 +174,7 @@ export class TypeScriptService implements ITypeScriptService {
 
 	private async runTranspilation(projectDir: string, typeScriptCompilerPath: string, options?: IRunTranspilationOptions): Promise<void> {
 		options = options || {};
-		let startTime = new Date().getTime();
+		const startTime = new Date().getTime();
 		let params = _([])
 			.concat(typeScriptCompilerPath)
 			.concat(options.filesToTranspile || [])
@@ -184,15 +184,15 @@ export class TypeScriptService implements ITypeScriptService {
 		// HACK: if we're using the project's own typescript module, do not pass any additional arguments
 		params = ~typeScriptCompilerPath.indexOf(projectDir) ? [typeScriptCompilerPath] : params;
 
-		let output = await this.$childProcess.spawnFromEvent(process.argv[0], params, "close", { cwd: projectDir, stdio: "inherit" }, { throwError: false });
+		const output = await this.$childProcess.spawnFromEvent(process.argv[0], params, "close", { cwd: projectDir, stdio: "inherit" }, { throwError: false });
 
 		// https://github.com/Microsoft/TypeScript/blob/8947757d096338532f1844d55788df87fb5a39ed/src/compiler/types.ts#L605
 		if (output.exitCode === 1 || output.exitCode === 5) {
 			this.$errors.failWithoutHelp(`TypeScript compiler failed with exit code ${output.exitCode}.`);
 		}
 
-		let endTime = new Date().getTime();
-		let time = (endTime - startTime) / 1000;
+		const endTime = new Date().getTime();
+		const time = (endTime - startTime) / 1000;
 		this.$logger.out(`${os.EOL}Success: ${time.toFixed(2)}s${os.EOL}.`.green);
 
 		this.startWatchProcess(params, projectDir);
@@ -211,7 +211,7 @@ export class TypeScriptService implements ITypeScriptService {
 		return _(options)
 			.keys()
 			.map((option: string) => {
-				let value: any = options[option];
+				const value: any = options[option];
 
 				if (typeof (value) === "string") {
 					return [`--${option}`, value];
@@ -233,17 +233,17 @@ export class TypeScriptService implements ITypeScriptService {
 			return [];
 		}
 
-		let defaultDefinitionsFiles = this.$fs.readDirectory(defaultTypeScriptDefinitionsFilesPath);
+		const defaultDefinitionsFiles = this.$fs.readDirectory(defaultTypeScriptDefinitionsFilesPath);
 
 		// Exclude definition files from default path, which are already part of the project (check only the name of the file)
-		let remainingDefaultDefinitionFiles = _.filter(defaultDefinitionsFiles, defFile => !_.some(this.definitionFiles, f => path.basename(f) === defFile));
+		const remainingDefaultDefinitionFiles = _.filter(defaultDefinitionsFiles, defFile => !_.some(this.definitionFiles, f => path.basename(f) === defFile));
 		return _.map(remainingDefaultDefinitionFiles, (definitionFilePath: string) => {
 			return path.join(defaultTypeScriptDefinitionsFilesPath, definitionFilePath);
 		}).concat(this.definitionFiles);
 	}
 
 	private createTempDirectoryForTsc(): string {
-		let tempDir = temp.mkdirSync(`typescript-compiler-${TypeScriptService.DEFAULT_TSC_VERSION}`);
+		const tempDir = temp.mkdirSync(`typescript-compiler-${TypeScriptService.DEFAULT_TSC_VERSION}`);
 		this.$fs.writeJson(path.join(tempDir, this.$projectConstants.PACKAGE_JSON_NAME), { name: "tsc-container", version: "1.0.0" });
 		return tempDir;
 	}

--- a/services/user-settings-service.ts
+++ b/services/user-settings-service.ts
@@ -15,7 +15,7 @@ export class UserSettingsServiceBase implements IUserSettingsService {
 	}
 
 	public async saveSetting<T>(key: string, value: T): Promise<void> {
-		let settingObject: any = {};
+		const settingObject: any = {};
 		settingObject[key] = value;
 
 		return this.saveSettings(settingObject);
@@ -45,14 +45,14 @@ export class UserSettingsServiceBase implements IUserSettingsService {
 	public async loadUserSettingsFile(): Promise<void> {
 		if (!this.userSettingsData) {
 			if (!this.$fs.exists(this.userSettingsFilePath)) {
-				let unexistingDirs = this.getUnexistingDirectories(this.userSettingsFilePath);
+				const unexistingDirs = this.getUnexistingDirectories(this.userSettingsFilePath);
 
 				this.$fs.writeFile(this.userSettingsFilePath, null);
 
 				// when running under 'sudo' we create the <path to home dir>/.local/share/.nativescript-cli dir with root as owner
 				// and other Applications cannot access this directory anymore. (bower/heroku/etc)
 				if (process.env.SUDO_USER) {
-					for (let dir of unexistingDirs) {
+					for (const dir of unexistingDirs) {
 						await this.$fs.setCurrentUserAsOwner(dir, process.env.SUDO_USER);
 					}
 				}
@@ -63,7 +63,7 @@ export class UserSettingsServiceBase implements IUserSettingsService {
 	}
 
 	private getUnexistingDirectories(filePath: string): Array<string> {
-		let unexistingDirs: Array<string> = [];
+		const unexistingDirs: Array<string> = [];
 		let currentDir = path.join(filePath, "..");
 		while (true) {
 			// this directory won't be created.

--- a/services/xcode-select-service.ts
+++ b/services/xcode-select-service.ts
@@ -13,7 +13,7 @@ export class XcodeSelectService implements IXcodeSelectService {
 			this.$errors.failWithoutHelp("xcode-select is only available on Mac OS X.");
 		}
 
-		let childProcess = await this.$childProcess.spawnFromEvent("xcode-select", ["-print-path"], "close", {}, { throwError: false }),
+		const childProcess = await this.$childProcess.spawnFromEvent("xcode-select", ["-print-path"], "close", {}, { throwError: false }),
 			result = childProcess.stdout.trim();
 
 		if (!result) {
@@ -29,13 +29,13 @@ export class XcodeSelectService implements IXcodeSelectService {
 
 	@cache()
 	public async getXcodeVersion(): Promise<IVersionData> {
-		let sysInfoBase = this.$injector.resolve("sysInfoBase");
-		let xcodeVer = await sysInfoBase.getXCodeVersion();
+		const sysInfoBase = this.$injector.resolve("sysInfoBase");
+		const xcodeVer = await sysInfoBase.getXCodeVersion();
 		if (!xcodeVer) {
 			this.$errors.failWithoutHelp("xcodebuild execution failed. Make sure that you have latest Xcode and tools installed.");
 		}
 
-		let xcodeVersionMatch = xcodeVer.match(/Xcode (.*)/),
+		const xcodeVersionMatch = xcodeVer.match(/Xcode (.*)/),
 			xcodeVersionGroup = xcodeVersionMatch && xcodeVersionMatch[1],
 			xcodeVersionSplit = xcodeVersionGroup && xcodeVersionGroup.split(".");
 

--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -61,11 +61,11 @@ export class StaticConfigBase implements Config.IStaticConfig {
 	}
 
 	private async getAdbFilePathCore(): Promise<string> {
-		let $childProcess: IChildProcess = this.$injector.resolve("$childProcess");
+		const $childProcess: IChildProcess = this.$injector.resolve("$childProcess");
 
 		try {
 			// Do NOT use the adb wrapper because it will end blow up with Segmentation fault because the wrapper uses this method!!!
-			let proc = await $childProcess.spawnFromEvent("adb", ["version"], "exit", undefined, { throwError: false });
+			const proc = await $childProcess.spawnFromEvent("adb", ["version"], "exit", undefined, { throwError: false });
 
 			if (proc.stderr) {
 				return await this.spawnPrivateAdb();
@@ -91,18 +91,18 @@ export class StaticConfigBase implements Config.IStaticConfig {
 		- Adb is named differently on OSes and may have additional files. The code is hairy to accommodate these differences
 	 */
 	private async spawnPrivateAdb(): Promise<string> {
-		let $fs: IFileSystem = this.$injector.resolve("$fs"),
+		const $fs: IFileSystem = this.$injector.resolve("$fs"),
 			$childProcess: IChildProcess = this.$injector.resolve("$childProcess"),
 			$hostInfo: IHostInfo = this.$injector.resolve("$hostInfo");
 
 		// prepare the directory to host our copy of adb
-		let defaultAdbDirPath = path.join(__dirname, `resources/platform-tools/android/${process.platform}`);
-		let commonLibVersion = require(path.join(__dirname, "package.json")).version;
-		let tmpDir = path.join(os.tmpdir(), `telerik-common-lib-${commonLibVersion}`);
+		const defaultAdbDirPath = path.join(__dirname, `resources/platform-tools/android/${process.platform}`);
+		const commonLibVersion = require(path.join(__dirname, "package.json")).version;
+		const tmpDir = path.join(os.tmpdir(), `telerik-common-lib-${commonLibVersion}`);
 		$fs.createDirectory(tmpDir);
 
 		// copy the adb and associated files
-		let targetAdb = path.join(tmpDir, "adb");
+		const targetAdb = path.join(tmpDir, "adb");
 
 		// In case directory is missing or it's empty, copy the new adb
 		if (!$fs.exists(tmpDir) || !$fs.readDirectory(tmpDir).length) {

--- a/sys-info-base.ts
+++ b/sys-info-base.ts
@@ -18,7 +18,7 @@ export class SysInfoBase implements ISysInfo {
 		if (!this.javaVerCache) {
 			try {
 				// different java has different format for `java -version` command
-				let output = (await this.$childProcess.spawnFromEvent("java", ["-version"], "exit")).stderr;
+				const output = (await this.$childProcess.spawnFromEvent("java", ["-version"], "exit")).stderr;
 				this.javaVerCache = /(?:openjdk|java) version \"((?:\d+\.)+(?:\d+))/i.exec(output)[1];
 			} catch (e) {
 				this.javaVerCache = null;
@@ -30,7 +30,7 @@ export class SysInfoBase implements ISysInfo {
 	private npmVerCache: string = null;
 	public async getNpmVersion(): Promise<string> {
 		if (!this.npmVerCache) {
-			let procOutput = await this.exec("npm -v");
+			const procOutput = await this.exec("npm -v");
 			this.npmVerCache = procOutput ? procOutput.split("\n")[0] : null;
 		}
 
@@ -40,11 +40,11 @@ export class SysInfoBase implements ISysInfo {
 	private javaCompilerVerCache: string = null;
 	public async getJavaCompilerVersion(): Promise<string> {
 		if (!this.javaCompilerVerCache) {
-			let javaCompileExecutableName = "javac";
-			let javaHome = process.env.JAVA_HOME;
-			let pathToJavaCompilerExecutable = javaHome ? path.join(javaHome, "bin", javaCompileExecutableName) : javaCompileExecutableName;
+			const javaCompileExecutableName = "javac";
+			const javaHome = process.env.JAVA_HOME;
+			const pathToJavaCompilerExecutable = javaHome ? path.join(javaHome, "bin", javaCompileExecutableName) : javaCompileExecutableName;
 			try {
-				let output = await this.exec(`"${pathToJavaCompilerExecutable}" -version`, { showStderr: true });
+				const output = await this.exec(`"${pathToJavaCompilerExecutable}" -version`, { showStderr: true });
 				// for other versions of java javac version output is not on first line
 				// thus can't use ^ for starts with in regex
 				this.javaCompilerVerCache = output ? /javac (.*)/i.exec(output.stderr)[1] : null;
@@ -113,7 +113,7 @@ export class SysInfoBase implements ISysInfo {
 					let cocoapodVersion = await this.exec("pod --version");
 					if (cocoapodVersion) {
 						// Output of pod --version could contain some warnings. Find the version in it.
-						let cocoapodVersionMatch = cocoapodVersion.match(/^((?:\d+\.){2}\d+.*?)$/gm);
+						const cocoapodVersionMatch = cocoapodVersion.match(/^((?:\d+\.){2}\d+.*?)$/gm);
 						if (cocoapodVersionMatch && cocoapodVersionMatch[0]) {
 							cocoapodVersion = cocoapodVersionMatch[0].trim();
 						}
@@ -132,10 +132,10 @@ export class SysInfoBase implements ISysInfo {
 
 	public async getSysInfo(pathToPackageJson: string, androidToolsInfo?: { pathToAdb: string }): Promise<ISysInfoData> {
 		if (!this.sysInfoCache) {
-			let res: ISysInfoData = Object.create(null);
+			const res: ISysInfoData = Object.create(null);
 			let procOutput: string;
 
-			let packageJson = require(pathToPackageJson);
+			const packageJson = require(pathToPackageJson);
 			res.procInfo = packageJson.name + "/" + packageJson.version;
 
 			// os stuff
@@ -162,7 +162,7 @@ export class SysInfoBase implements ISysInfo {
 			res.itunesInstalled = this.getITunesInstalled();
 
 			res.cocoapodVer = await this.getCocoapodVersion();
-			let pathToAdb = androidToolsInfo ? androidToolsInfo.pathToAdb : "adb";
+			const pathToAdb = androidToolsInfo ? androidToolsInfo.pathToAdb : "adb";
 
 			if (!androidToolsInfo) {
 				this.$logger.trace("'adb' and 'android' will be checked from PATH environment variable.");
@@ -175,7 +175,7 @@ export class SysInfoBase implements ISysInfo {
 
 			procOutput = await this.exec("mono --version");
 			if (!!procOutput) {
-				let match = this.monoVerRegExp.exec(procOutput);
+				const match = this.monoVerRegExp.exec(procOutput);
 				res.monoVer = match ? match[1] : null;
 			} else {
 				res.monoVer = null;

--- a/test/unit-tests/analytics-service.ts
+++ b/test/unit-tests/analytics-service.ts
@@ -5,7 +5,7 @@ import * as os from "os";
 import helpersLib = require("../../helpers");
 import { HostInfo } from "../../host-info";
 import { OsInfo } from "../../os-info";
-let assert = require("chai").assert;
+const assert = require("chai").assert;
 
 let trackedFeatureNamesAndValues = "";
 let savedSettingNamesAndValues = "";
@@ -15,7 +15,7 @@ let isEqatecStopCalled = false;
 require("../../vendor/EqatecMonitor.min"); // note - it modifies global scope!
 
 const cliGlobal = <ICliGlobal>global;
-let originalEqatec = cliGlobal._eqatec;
+const originalEqatec = cliGlobal._eqatec;
 
 function setGlobalEqatec(shouldSetUserThrowException: boolean, shouldStartThrow: boolean): void {
 	cliGlobal._eqatec = {
@@ -57,7 +57,7 @@ class UserSettingsServiceStub {
 		public testInjector: IInjector) { }
 
 	async getSettingValue<T>(settingName: string): Promise<T | string> {
-		let $staticConfig: Config.IStaticConfig = this.testInjector.resolve("staticConfig");
+		const $staticConfig: Config.IStaticConfig = this.testInjector.resolve("staticConfig");
 
 		if (settingName === $staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME) {
 			return this.featureTracking !== undefined ? this.featureTracking.toString() : undefined;
@@ -86,7 +86,7 @@ interface ITestScenario {
 function createTestInjector(testScenario: ITestScenario): IInjector {
 	setGlobalEqatec(testScenario.shouldSetUserThrowException, testScenario.shouldStartThrow);
 
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("logger", CommonLoggerStub);
 	testInjector.register("errors", ErrorsStub);
 	testInjector.register("analyticsService", AnalyticsServiceBase);
@@ -138,7 +138,7 @@ function createTestInjector(testScenario: ITestScenario): IInjector {
 
 describe("analytics-service", () => {
 	let baseTestScenario: ITestScenario;
-	let featureName = "unit tests feature";
+	const featureName = "unit tests feature";
 	let service: IAnalyticsService = null;
 
 	beforeEach(() => {
@@ -172,7 +172,7 @@ describe("analytics-service", () => {
 
 	describe("trackFeature", () => {
 		it("tracks feature when console is interactive", async () => {
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.trackFeature(featureName);
 			assert.isTrue(trackedFeatureNamesAndValues.indexOf(`CLI.${featureName}`) !== -1);
@@ -181,7 +181,7 @@ describe("analytics-service", () => {
 
 		it("tracks feature when console is not interactive", async () => {
 			baseTestScenario.isInteractive = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.trackFeature(featureName);
 			assert.isTrue(trackedFeatureNamesAndValues.indexOf(`Non-interactive.${featureName}`) !== -1);
@@ -190,7 +190,7 @@ describe("analytics-service", () => {
 
 		it("does not track feature when console is interactive and feature tracking is disabled", async () => {
 			baseTestScenario.featureTracking = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.trackFeature(featureName);
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
@@ -198,7 +198,7 @@ describe("analytics-service", () => {
 
 		it("does not track feature when console is not interactive and feature tracking is disabled", async () => {
 			baseTestScenario.featureTracking = baseTestScenario.isInteractive = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.trackFeature(featureName);
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
@@ -206,7 +206,7 @@ describe("analytics-service", () => {
 
 		it("does not track feature when console is interactive and feature tracking is enabled, but cannot make request", async () => {
 			baseTestScenario.canDoRequest = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.trackFeature(featureName);
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
@@ -214,7 +214,7 @@ describe("analytics-service", () => {
 
 		it("does not track feature when console is not interactive and feature tracking is enabled, but cannot make request", async () => {
 			baseTestScenario.canDoRequest = baseTestScenario.isInteractive = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.trackFeature(featureName);
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
@@ -222,7 +222,7 @@ describe("analytics-service", () => {
 
 		it("does not throw exception when eqatec start throws", async () => {
 			baseTestScenario.shouldStartThrow = true;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.trackFeature(featureName);
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
@@ -230,10 +230,10 @@ describe("analytics-service", () => {
 	});
 
 	describe("trackException", () => {
-		let exception = "Exception";
-		let message = "Track Exception Msg";
+		const exception = "Exception";
+		const message = "Track Exception Msg";
 		it("tracks when all conditions are correct", async () => {
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.trackException(exception, message);
 			assert.isTrue(lastTrackedExceptionMsg.indexOf(message) !== -1);
@@ -241,7 +241,7 @@ describe("analytics-service", () => {
 
 		it("does not track when exception tracking is disabled", async () => {
 			baseTestScenario.exceptionsTracking = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.trackException(exception, message);
 			assert.deepEqual(lastTrackedExceptionMsg, "");
@@ -249,7 +249,7 @@ describe("analytics-service", () => {
 
 		it("does not track when feature tracking is enabled, but cannot make request", async () => {
 			baseTestScenario.canDoRequest = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.trackException(exception, message);
 			assert.deepEqual(lastTrackedExceptionMsg, "");
@@ -257,7 +257,7 @@ describe("analytics-service", () => {
 
 		it("does not throw exception when eqatec start throws", async () => {
 			baseTestScenario.shouldStartThrow = true;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.trackException(exception, message);
 			assert.deepEqual(lastTrackedExceptionMsg, "");
@@ -265,9 +265,9 @@ describe("analytics-service", () => {
 	});
 
 	describe("track", () => {
-		let name = "unitTests";
+		const name = "unitTests";
 		it("tracks when all conditions are correct", async () => {
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.track(name, featureName);
 			assert.isTrue(trackedFeatureNamesAndValues.indexOf(`${name}.${featureName}`) !== -1);
@@ -275,7 +275,7 @@ describe("analytics-service", () => {
 
 		it("does not track when feature tracking is disabled", async () => {
 			baseTestScenario.featureTracking = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.track(name, featureName);
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
@@ -283,7 +283,7 @@ describe("analytics-service", () => {
 
 		it("does not track when feature tracking is enabled, but cannot make request", async () => {
 			baseTestScenario.canDoRequest = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.track(name, featureName);
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
@@ -291,7 +291,7 @@ describe("analytics-service", () => {
 
 		it("does not throw exception when eqatec start throws", async () => {
 			baseTestScenario.shouldStartThrow = true;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.track(name, featureName);
 			assert.deepEqual(trackedFeatureNamesAndValues, "");
@@ -300,27 +300,27 @@ describe("analytics-service", () => {
 
 	describe("isEnabled", () => {
 		it("returns true when analytics status is enabled", async () => {
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(await service.isEnabled(staticConfig.ERROR_REPORT_SETTING_NAME));
 			assert.isTrue(await service.isEnabled(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME));
 		});
 
 		it("returns false when analytics status is disabled", async () => {
 			baseTestScenario.exceptionsTracking = baseTestScenario.featureTracking = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isFalse(await service.isEnabled(staticConfig.ERROR_REPORT_SETTING_NAME));
 			assert.isFalse(await service.isEnabled(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME));
 		});
 
 		it("returns false when analytics status is notConfirmed", async () => {
 			baseTestScenario.exceptionsTracking = baseTestScenario.featureTracking = undefined;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isFalse(await service.isEnabled(staticConfig.ERROR_REPORT_SETTING_NAME));
 			assert.isFalse(await service.isEnabled(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME));
 		});
@@ -328,18 +328,18 @@ describe("analytics-service", () => {
 
 	describe("setStatus", () => {
 		it("sets correct status", async () => {
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			await service.setStatus(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, false);
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME}.false`) !== -1);
 		});
 
 		it("calls eqatec stop when all analytics trackings are disabled", async () => {
 			baseTestScenario.exceptionsTracking = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			// start eqatec
 			await service.trackFeature(featureName);
 			assert.isTrue(trackedFeatureNamesAndValues.indexOf(`CLI.${featureName}`) !== -1);
@@ -352,51 +352,51 @@ describe("analytics-service", () => {
 
 	describe("getStatusMessage", () => {
 		it("returns correct string results when status is enabled", async () => {
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
-			let expectedMsg = "Expected result";
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const expectedMsg = "Expected result";
 			assert.equal(`${expectedMsg} is enabled.`, await service.getStatusMessage(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, false, expectedMsg));
 		});
 
 		it("returns correct string results when status is disabled", async () => {
 			baseTestScenario.featureTracking = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
-			let expectedMsg = "Expected result";
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const expectedMsg = "Expected result";
 			assert.equal(`${expectedMsg} is disabled.`, await service.getStatusMessage(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, false, expectedMsg));
 		});
 
 		it("returns correct string results when status is not confirmed", async () => {
 			baseTestScenario.featureTracking = undefined;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
-			let expectedMsg = "Expected result";
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const expectedMsg = "Expected result";
 			assert.equal(`${expectedMsg} is disabled until confirmed.`, await service.getStatusMessage(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, false, expectedMsg));
 		});
 
 		it("returns correct json results when status is enabled", async () => {
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.deepEqual(JSON.stringify({ "enabled": true }), await service.getStatusMessage(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, true, ""));
 		});
 
 		it("returns correct json results when status is disabled", async () => {
 			baseTestScenario.featureTracking = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.deepEqual(JSON.stringify({ "enabled": false }), await service.getStatusMessage(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, true, ""));
 		});
 
 		it("returns correct json results when status is not confirmed", async () => {
 			baseTestScenario.featureTracking = undefined;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.deepEqual(JSON.stringify({ "enabled": null }), await service.getStatusMessage(staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME, true, ""));
 		});
 	});
@@ -405,10 +405,10 @@ describe("analytics-service", () => {
 		it("enables feature tracking when user confirms", async () => {
 			baseTestScenario.featureTracking = undefined;
 			baseTestScenario.exceptionsTracking = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.checkConsent();
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME}.true`) !== -1);
 		});
 
@@ -416,10 +416,10 @@ describe("analytics-service", () => {
 			baseTestScenario.featureTracking = undefined;
 			baseTestScenario.exceptionsTracking = undefined;
 			baseTestScenario.prompterConfirmResult = true;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.checkConsent();
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.ERROR_REPORT_SETTING_NAME}.true`) !== -1);
 		});
 
@@ -427,10 +427,10 @@ describe("analytics-service", () => {
 			baseTestScenario.featureTracking = undefined;
 			baseTestScenario.prompterConfirmResult = false;
 			baseTestScenario.exceptionsTracking = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.checkConsent();
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME}.false`) !== -1);
 		});
 
@@ -439,10 +439,10 @@ describe("analytics-service", () => {
 			baseTestScenario.exceptionsTracking = undefined;
 			baseTestScenario.prompterConfirmResult = false;
 
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.checkConsent();
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.ERROR_REPORT_SETTING_NAME}.false`) !== -1);
 		});
 
@@ -450,17 +450,17 @@ describe("analytics-service", () => {
 			it(`sets exception tracking to feature tracking's value when the first one is not set, but feature tracking is set to ${featureTrackingValue}`, async () => {
 				baseTestScenario.featureTracking = featureTrackingValue;
 				baseTestScenario.exceptionsTracking = undefined;
-				let testInjector = createTestInjector(baseTestScenario);
+				const testInjector = createTestInjector(baseTestScenario);
 				service = testInjector.resolve("analyticsService");
 				await service.checkConsent();
-				let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+				const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 				assert.isTrue(savedSettingNamesAndValues.indexOf(`${staticConfig.ERROR_REPORT_SETTING_NAME}.${featureTrackingValue}`) !== -1);
 			});
 		});
 
 		it("does nothing when exception and feature tracking are already set", async () => {
 			baseTestScenario.featureTracking = baseTestScenario.exceptionsTracking = true;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.checkConsent();
 			assert.deepEqual(savedSettingNamesAndValues, "");
@@ -469,7 +469,7 @@ describe("analytics-service", () => {
 		it("does nothing when cannot make request", async () => {
 			baseTestScenario.canDoRequest = false;
 			baseTestScenario.featureTracking = baseTestScenario.exceptionsTracking = undefined;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.checkConsent();
 			assert.deepEqual(savedSettingNamesAndValues, "");
@@ -478,7 +478,7 @@ describe("analytics-service", () => {
 		it("does nothing when values are not set and console is not interactive", async () => {
 			baseTestScenario.isInteractive = false;
 			baseTestScenario.featureTracking = baseTestScenario.exceptionsTracking = undefined;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.checkConsent();
 			assert.deepEqual(savedSettingNamesAndValues, "");
@@ -487,10 +487,10 @@ describe("analytics-service", () => {
 		it("sends information that user had accepted feature tracking", async () => {
 			baseTestScenario.featureTracking = undefined;
 			baseTestScenario.exceptionsTracking = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.checkConsent();
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(trackedFeatureNamesAndValues.indexOf(`Accept${staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME}.true`) !== -1);
 		});
 
@@ -498,21 +498,21 @@ describe("analytics-service", () => {
 			baseTestScenario.featureTracking = undefined;
 			baseTestScenario.prompterConfirmResult = false;
 			baseTestScenario.exceptionsTracking = false;
-			let testInjector = createTestInjector(baseTestScenario);
+			const testInjector = createTestInjector(baseTestScenario);
 			service = testInjector.resolve("analyticsService");
 			await service.checkConsent();
-			let staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
+			const staticConfig: Config.IStaticConfig = testInjector.resolve("staticConfig");
 			assert.isTrue(trackedFeatureNamesAndValues.indexOf(`Accept${staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME}.false`) !== -1);
 		});
 	});
 
 	describe("uses correct settings on different os-es", () => {
-		let name = "unitTests";
+		const name = "unitTests";
 		let testInjector: IInjector;
 		let osInfo: IOsInfo;
 		let osType: () => string;
 		let osRelease: () => string;
-		let release = "1.0";
+		const release = "1.0";
 
 		beforeEach(() => {
 			testInjector = createTestInjector(baseTestScenario);

--- a/test/unit-tests/android-application-manager.ts
+++ b/test/unit-tests/android-application-manager.ts
@@ -9,20 +9,20 @@ class AndroidDebugBridgeStub {
 	public validIdentifierPassed: Boolean = false;
 	public static methodCallCount: number = 0;
 	private expectedValidTestInput: string[] = [
-			"org.nativescript.testApp/com.tns.TestClass",
-			"org.nativescript.testApp/com.tns.$TestClass",
-			"org.nativescript.testApp/com.tns._TestClass",
-			"org.nativescript.testApp/com.tns.$_TestClass",
-			"org.nativescript.testApp/com.tns._$TestClass",
-			"org.nativescript.testApp/com.tns.NativeScriptActivity"
-		];
+		"org.nativescript.testApp/com.tns.TestClass",
+		"org.nativescript.testApp/com.tns.$TestClass",
+		"org.nativescript.testApp/com.tns._TestClass",
+		"org.nativescript.testApp/com.tns.$_TestClass",
+		"org.nativescript.testApp/com.tns._$TestClass",
+		"org.nativescript.testApp/com.tns.NativeScriptActivity"
+	];
 	private validTestInput: string[] = [
-			"other.stuff/ org.nativescript.testApp/com.tns.TestClass asdaas.dasdh2",
-			"other.stuff.the.regex.might.fail.on org.nativescript.testApp/com.tns.$TestClass other.stuff.the.regex.might.fail.on",
-			"/might.fail.on  org.nativescript.testApp/com.tns._TestClass /might.fail.on",
-			"might.fail.on/ org.nativescript.testApp/com.tns.$_TestClass might.fail.on//",
-			"/might.fail org.nativescript.testApp/com.tns._$TestClass something/might.fail.on/",
-			"android.intent.action.MAIN: \
+		"other.stuff/ org.nativescript.testApp/com.tns.TestClass asdaas.dasdh2",
+		"other.stuff.the.regex.might.fail.on org.nativescript.testApp/com.tns.$TestClass other.stuff.the.regex.might.fail.on",
+		"/might.fail.on  org.nativescript.testApp/com.tns._TestClass /might.fail.on",
+		"might.fail.on/ org.nativescript.testApp/com.tns.$_TestClass might.fail.on//",
+		"/might.fail org.nativescript.testApp/com.tns._$TestClass something/might.fail.on/",
+		"android.intent.action.MAIN: \
 			3b2df03 org.nativescript.testApp/com.tns.NativeScriptActivity filter 50dd82e \
 			Action: \"android.intent.action.MAIN\" \
 			Category: \"android.intent.category.LAUNCHER\" \
@@ -32,7 +32,7 @@ class AndroidDebugBridgeStub {
 			-- \
 			Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=org.nativescript.testApp/com.tns.NativeScriptActivity } \
 			frontOfTask=true task=TaskRecord{fe592ac #449 A=org.nativescript.testApp U=0 StackId=1 sz=1}"
-		];
+	];
 
 	public async executeShellCommand(args: string[]): Promise<any> {
 		if (args && args.length > 0) {
@@ -79,7 +79,7 @@ class AndroidDebugBridgeStub {
 }
 
 function createTestInjector(): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("androidApplicationManager", AndroidApplicationManager);
 	testInjector.register("adb", AndroidDebugBridgeStub);
 	testInjector.register('childProcess', {});
@@ -87,7 +87,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("config", {});
 	testInjector.register("staticConfig", {});
 	testInjector.register("androidDebugBridgeResultHandler", {});
-	testInjector.register("options", {justlaunch: true});
+	testInjector.register("options", { justlaunch: true });
 	testInjector.register("errors", {});
 	testInjector.register("identifier", {});
 	testInjector.register("logcatHelper", {});
@@ -100,9 +100,9 @@ function createTestInjector(): IInjector {
 
 describe("android-application-manager", () => {
 
-	let testInjector: IInjector,
-		androidApplicationManager:AndroidApplicationManager,
-		androidDebugBridge:AndroidDebugBridgeStub;
+	let testInjector: IInjector;
+	let androidApplicationManager: AndroidApplicationManager;
+	let androidDebugBridge: AndroidDebugBridgeStub;
 
 	beforeEach(() => {
 		testInjector = createTestInjector();

--- a/test/unit-tests/android-log-filter.ts
+++ b/test/unit-tests/android-log-filter.ts
@@ -4,7 +4,7 @@ import { Yok } from "../../yok";
 import * as assert from "assert";
 import { EOL } from "os";
 
-let androidApiLevel23TestData = [
+const androidApiLevel23TestData = [
 	{ input: '12-28 10:14:15.977    99    99 D Genymotion: Received Set Clipboard', output: null },
 	{ input: '12-28 10:14:31.303   779   790 I ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=com.telerik.app1/.TelerikCallbackActivity (has extras)} from uid 10008 on display 0', output: 'ActivityManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=com.telerik.app1/.TelerikCallbackActivity (has extras)} from uid 10008 on display 0' },
 	{ input: '--------- beginning of main', output: null },
@@ -37,7 +37,7 @@ let androidApiLevel23TestData = [
 	}
 ];
 
-let androidApiLevel22TestData = [
+const androidApiLevel22TestData = [
 	{ input: '--------- beginning of system', output: null },
 	{ input: 'D/Genymotion(   82): Received Ping', output: null },
 	{ input: '--------- beginning of main', output: null },
@@ -92,7 +92,7 @@ let androidApiLevel22TestData = [
 	}
 ];
 
-let androidApiLevel23MapForPid8141 = [
+const androidApiLevel23MapForPid8141 = [
 	{ input: "--------- beginning of main", output: null },
 	{ input: "07-25 06:36:22.590  8141  8141 D TNS.Native: lenNodes=71568, lenNames=824195, lenValues=963214", output: null },
 	{ input: "07-25 06:36:22.590  8141  8141 D TNS.Native: time=1", output: null },
@@ -207,11 +207,11 @@ let androidApiLevel23MapForPid8141 = [
 
 describe("androidLogFilter", () => {
 
-	let assertFiltering = (inputData: string, expectedOutput: string, logLevel?: string, pid?: string) => {
-		let testInjector = new Yok();
+	const assertFiltering = (inputData: string, expectedOutput: string, logLevel?: string, pid?: string) => {
+		const testInjector = new Yok();
 		testInjector.register("loggingLevels", LoggingLevels);
-		let androidLogFilter = testInjector.resolve(AndroidLogFilter);
-		let filteredData = androidLogFilter.filterData(inputData, logLevel, pid);
+		const androidLogFilter = testInjector.resolve(AndroidLogFilter);
+		const filteredData = androidLogFilter.filterData(inputData, logLevel, pid);
 		assert.deepEqual(filteredData, expectedOutput, `The actual result '${filteredData}' did NOT match expected output '${expectedOutput}'.`);
 	};
 

--- a/test/unit-tests/appbuilder/device-emitter.ts
+++ b/test/unit-tests/appbuilder/device-emitter.ts
@@ -10,7 +10,7 @@ class CustomEventEmitter extends EventEmitter {
 	constructor() { super(); }
 }
 
-let companionAppIdentifiers = {
+const companionAppIdentifiers = {
 	"cordova": {
 		"android": "cordova-android",
 		"ios": "cordova-ios",
@@ -24,7 +24,7 @@ let companionAppIdentifiers = {
 };
 
 function createTestInjector(): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("devicesService", CustomEventEmitter);
 	testInjector.register("deviceLogProvider", CustomEventEmitter);
 	testInjector.register("companionAppsService", {
@@ -39,9 +39,9 @@ function createTestInjector(): IInjector {
 }
 
 describe("deviceEmitter", () => {
-	let testInjector: IInjector,
-		deviceEmitter: DeviceEmitter,
-		isOpenDeviceLogStreamCalled = false;
+	let testInjector: IInjector;
+	let deviceEmitter: DeviceEmitter;
+	let isOpenDeviceLogStreamCalled = false;
 
 	beforeEach(() => {
 		testInjector = createTestInjector();
@@ -50,8 +50,8 @@ describe("deviceEmitter", () => {
 	});
 
 	describe("raises correct events after initialize is called:", () => {
-		let devicesService: EventEmitter,
-			deviceInstance: any;
+		let devicesService: EventEmitter;
+		let deviceInstance: any;
 
 		beforeEach(async () => {
 			devicesService = testInjector.resolve("devicesService");
@@ -68,7 +68,7 @@ describe("deviceEmitter", () => {
 
 		_.each([DeviceDiscoveryEventNames.DEVICE_FOUND, DeviceDiscoveryEventNames.DEVICE_LOST], deviceEvent => {
 			describe(deviceEvent, () => {
-				let attachDeviceEventVerificationHandler = (expectedDeviceInfo: any, done: mocha.Done) => {
+				const attachDeviceEventVerificationHandler = (expectedDeviceInfo: any, done: mocha.Done) => {
 					deviceEmitter.on(deviceEvent, (deviceInfo: Mobile.IDeviceInfo) => {
 						assert.deepEqual(deviceInfo, expectedDeviceInfo);
 						// Wait for all operations to be completed and call done after that.
@@ -84,7 +84,7 @@ describe("deviceEmitter", () => {
 		});
 
 		describe("openDeviceLogStream", () => {
-			let attachDeviceEventVerificationHandler = (expectedDeviceInfo: any, done: mocha.Done) => {
+			const attachDeviceEventVerificationHandler = (expectedDeviceInfo: any, done: mocha.Done) => {
 				deviceEmitter.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (deviceInfo: Mobile.IDeviceInfo) => {
 					assert.deepEqual(deviceInfo, expectedDeviceInfo);
 
@@ -110,9 +110,9 @@ describe("deviceEmitter", () => {
 			});
 
 			describe("raises deviceLogData with correct identifier and data", () => {
-				let expectedDeviceLogData = "This is some log data from device.";
+				const expectedDeviceLogData = "This is some log data from device.";
 
-				let attachDeviceLogDataVerificationHandler = (expectedDeviceIdentifier: string, done: mocha.Done) => {
+				const attachDeviceLogDataVerificationHandler = (expectedDeviceIdentifier: string, done: mocha.Done) => {
 					deviceEmitter.on("deviceLogData", (identifier: string, data: any) => {
 						assert.deepEqual(identifier, expectedDeviceIdentifier);
 						assert.deepEqual(data, expectedDeviceLogData);
@@ -131,9 +131,9 @@ describe("deviceEmitter", () => {
 
 		_.each(["applicationInstalled", "applicationUninstalled"], (applicationEvent: string) => {
 			describe(applicationEvent, () => {
-				let expectedApplicationIdentifier = "application identifier";
+				const expectedApplicationIdentifier = "application identifier";
 
-				let attachApplicationEventVerificationHandler = (expectedDeviceIdentifier: string, done: mocha.Done) => {
+				const attachApplicationEventVerificationHandler = (expectedDeviceIdentifier: string, done: mocha.Done) => {
 					deviceEmitter.on(applicationEvent, (deviceIdentifier: string, appIdentifier: string) => {
 						assert.deepEqual(deviceIdentifier, expectedDeviceIdentifier);
 						assert.deepEqual(appIdentifier, expectedApplicationIdentifier);
@@ -154,7 +154,7 @@ describe("deviceEmitter", () => {
 		_.each(["debuggableAppFound", "debuggableAppLost"], (applicationEvent: string) => {
 			describe(applicationEvent, () => {
 
-				let attachDebuggableEventVerificationHandler = (expectedDebuggableAppInfo: Mobile.IDeviceApplicationInformation, done: mocha.Done) => {
+				const attachDebuggableEventVerificationHandler = (expectedDebuggableAppInfo: Mobile.IDeviceApplicationInformation, done: mocha.Done) => {
 					deviceEmitter.on(applicationEvent, (debuggableAppInfo: Mobile.IDeviceApplicationInformation) => {
 						assert.deepEqual(debuggableAppInfo, expectedDebuggableAppInfo);
 
@@ -164,7 +164,7 @@ describe("deviceEmitter", () => {
 				};
 
 				it("is raised when working with device", (done: mocha.Done) => {
-					let debuggableAppInfo: Mobile.IDeviceApplicationInformation = {
+					const debuggableAppInfo: Mobile.IDeviceApplicationInformation = {
 						appIdentifier: "app identifier",
 						deviceIdentifier: deviceInstance.deviceInfo.identifier,
 						framework: "cordova"
@@ -180,7 +180,7 @@ describe("deviceEmitter", () => {
 		_.each(["debuggableViewFound", "debuggableViewLost", "debuggableViewChanged"], (applicationEvent: string) => {
 			describe(applicationEvent, () => {
 
-				let createDebuggableWebView = (uniqueId: string) => {
+				const createDebuggableWebView = (uniqueId: string) => {
 					return {
 						description: `description_${uniqueId}`,
 						devtoolsFrontendUrl: `devtoolsFrontendUrl_${uniqueId}`,
@@ -192,9 +192,9 @@ describe("deviceEmitter", () => {
 					};
 				};
 
-				let appId = "appId";
+				const appId = "appId";
 
-				let attachDebuggableEventVerificationHandler = (expectedDeviceIdentifier: string, expectedAppIdentifier: string, expectedDebuggableViewInfo: Mobile.IDebugWebViewInfo, done: mocha.Done) => {
+				const attachDebuggableEventVerificationHandler = (expectedDeviceIdentifier: string, expectedAppIdentifier: string, expectedDebuggableViewInfo: Mobile.IDebugWebViewInfo, done: mocha.Done) => {
 					deviceEmitter.on(applicationEvent, (deviceIdentifier: string, appIdentifier: string, debuggableViewInfo: Mobile.IDebugWebViewInfo) => {
 						assert.deepEqual(deviceIdentifier, expectedDeviceIdentifier);
 
@@ -208,7 +208,7 @@ describe("deviceEmitter", () => {
 				};
 
 				it("is raised when working with device", (done: mocha.Done) => {
-					let expectedDebuggableViewInfo: Mobile.IDebugWebViewInfo = createDebuggableWebView("test1");
+					const expectedDebuggableViewInfo: Mobile.IDebugWebViewInfo = createDebuggableWebView("test1");
 
 					attachDebuggableEventVerificationHandler(deviceInstance.deviceInfo.identifier, appId, expectedDebuggableViewInfo, done);
 					devicesService.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, deviceInstance);
@@ -221,7 +221,7 @@ describe("deviceEmitter", () => {
 			describe(applicationEvent, () => {
 				_.each(companionAppIdentifiers, (companionAppIdentifersForPlatform: any, applicationFramework: string) => {
 					describe(`is raised for ${applicationFramework}`, () => {
-						let attachCompanionEventVerificationHandler = (expectedDeviceIdentifier: string, done: mocha.Done) => {
+						const attachCompanionEventVerificationHandler = (expectedDeviceIdentifier: string, done: mocha.Done) => {
 							deviceEmitter.on(applicationEvent, (deviceIdentifier: string, framework: string) => {
 								assert.deepEqual(deviceIdentifier, expectedDeviceIdentifier);
 								assert.deepEqual(framework, applicationFramework);

--- a/test/unit-tests/appbuilder/device-log-provider.ts
+++ b/test/unit-tests/appbuilder/device-log-provider.ts
@@ -4,7 +4,7 @@ import { DeviceLogProvider } from "../../../appbuilder/device-log-provider";
 import { CommonLoggerStub } from "../stubs";
 
 function createTestInjector(loggingLevel: string, emptyFilteredData?: boolean) {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("logFilter", {
 		loggingLevel: loggingLevel,
 		filterData: (platform: string, data: string, pid?: string, logLevel?: string) => {
@@ -18,13 +18,13 @@ function createTestInjector(loggingLevel: string, emptyFilteredData?: boolean) {
 }
 
 describe("proton deviceLogProvider", () => {
-	let testInjector: IInjector,
-		deviceLogProvider: any = null,
-		testData = "testData",
-		infoLogLevel = "INFO",
-		fullLogLevel = "FULL",
-		filteredInfoData = `${infoLogLevel} ${testData}`,
-		filteredFullData = `${fullLogLevel} ${testData}`;
+	let testInjector: IInjector;
+	let deviceLogProvider: any = null;
+	const testData = "testData";
+	const infoLogLevel = "INFO";
+	const fullLogLevel = "FULL";
+	const filteredInfoData = `${infoLogLevel} ${testData}`;
+	const filteredFullData = `${fullLogLevel} ${testData}`;
 
 	describe("logData", () => {
 		describe("when device identifier is not specified", () => {
@@ -87,7 +87,7 @@ describe("proton deviceLogProvider", () => {
 			testInjector = createTestInjector(infoLogLevel);
 			deviceLogProvider = testInjector.resolve(DeviceLogProvider);
 			deviceLogProvider.setLogLevel(fullLogLevel);
-			let logFilter = testInjector.resolve("logFilter");
+			const logFilter = testInjector.resolve("logFilter");
 			assert.deepEqual(logFilter.loggingLevel, fullLogLevel);
 		});
 
@@ -95,7 +95,7 @@ describe("proton deviceLogProvider", () => {
 			testInjector = createTestInjector(infoLogLevel);
 			deviceLogProvider = testInjector.resolve(DeviceLogProvider);
 			deviceLogProvider.setLogLevel(fullLogLevel, "deviceID");
-			let logFilter = testInjector.resolve("logFilter");
+			const logFilter = testInjector.resolve("logFilter");
 			assert.deepEqual(logFilter.loggingLevel, infoLogLevel);
 		});
 	});

--- a/test/unit-tests/common-options.ts
+++ b/test/unit-tests/common-options.ts
@@ -5,7 +5,7 @@ import { OptionType, OptionsBase } from "../../options";
 
 let isExecutionStopped = false;
 
-let knownOpts = {
+const knownOpts = {
 	"path1": { type: OptionType.String },
 	"help": { type: OptionType.Boolean },
 	"verbose": { type: OptionType.Boolean, alias: "v" },
@@ -17,7 +17,7 @@ let knownOpts = {
 };
 
 function createTestInjector(): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("options", {});
 	testInjector.register("staticConfig", {
 		CLIENT_NAME: ""
@@ -28,7 +28,7 @@ function createTestInjector(): IInjector {
 }
 
 function createOptions(testInjector: IInjector): ICommonOptions {
-	let options = testInjector.resolve(OptionsBase, { options: knownOpts, defaultProfileDir: "1" }); // Validation is triggered in options's constructor
+	const options = testInjector.resolve(OptionsBase, { options: knownOpts, defaultProfileDir: "1" }); // Validation is triggered in options's constructor
 	return options;
 }
 
@@ -37,7 +37,7 @@ describe("common options", () => {
 	beforeEach(() => {
 		testInjector = createTestInjector();
 
-		let errors = new Errors(testInjector);
+		const errors = new Errors(testInjector);
 		errors.failWithoutHelp = (message: string, ...args: any[]): void => {
 			isExecutionStopped = true;
 		};
@@ -53,7 +53,7 @@ describe("common options", () => {
 		it("breaks execution when option is not valid", () => {
 			process.argv.push('--pathr');
 			process.argv.push("incorrect argument");
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			options.validateOptions();
 			process.argv.pop();
 			process.argv.pop();
@@ -63,7 +63,7 @@ describe("common options", () => {
 		it("breaks execution when valid option does not have value", () => {
 			process.argv.push('--path1');
 			// If you do not pass value to an option, it's automatically set as true.
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			process.argv.pop();
 			options.validateOptions();
 			assert.isTrue(isExecutionStopped);
@@ -72,7 +72,7 @@ describe("common options", () => {
 		it("breaks execution when valid dashed option passed without dashes does not have value", () => {
 			process.argv.push('--someDashedValue');
 			// If you do not pass value to a string option, it's automatically set to "".
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			process.argv.pop();
 			options.validateOptions();
 			assert.isTrue(isExecutionStopped);
@@ -81,7 +81,7 @@ describe("common options", () => {
 		it("breaks execution when valid dashed option does not have value", () => {
 			process.argv.push('--some-dashed-value');
 			// If you do not pass value to an option, it's automatically set as true.
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			process.argv.pop();
 			options.validateOptions();
 			assert.isTrue(isExecutionStopped);
@@ -90,7 +90,7 @@ describe("common options", () => {
 		it("does not break execution when valid option has correct value", () => {
 			process.argv.push('--path1');
 			process.argv.push("SomeDir");
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			options.validateOptions();
 			process.argv.pop();
 			process.argv.pop();
@@ -99,7 +99,7 @@ describe("common options", () => {
 
 		it("breaks execution when valid option has empty string value", () => {
 			process.argv.push('--path');
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			options.validateOptions();
 			process.argv.pop();
 			assert.isTrue(isExecutionStopped);
@@ -108,7 +108,7 @@ describe("common options", () => {
 		it("breaks execution when valid option has value with spaces only", () => {
 			process.argv.push('--path');
 			process.argv.push('  ');
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			options.validateOptions();
 			process.argv.pop();
 			process.argv.pop();
@@ -118,7 +118,7 @@ describe("common options", () => {
 		it("breaks execution when shorthand option is not valid", () => {
 			process.argv.push('-j');
 			process.argv.push('incorrect shorthand');
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			options.validateOptions();
 			process.argv.pop();
 			process.argv.pop();
@@ -127,7 +127,7 @@ describe("common options", () => {
 
 		it("does not break execution when valid shorthand option has correct value", () => {
 			process.argv.push('-v');
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			options.validateOptions();
 			process.argv.pop();
 			assert.isFalse(isExecutionStopped);
@@ -138,7 +138,7 @@ describe("common options", () => {
 		it("does not break execution when valid option has number value", () => {
 			process.argv.push('--path');
 			process.argv.push('1');
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			options.validateOptions();
 			process.argv.pop();
 			process.argv.pop();
@@ -150,7 +150,7 @@ describe("common options", () => {
 			process.argv.push("value 1");
 			process.argv.push('--path');
 			process.argv.push("value 2");
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			options.validateOptions();
 			process.argv.pop();
 			process.argv.pop();
@@ -160,7 +160,7 @@ describe("common options", () => {
 		});
 
 		it("converts string value to array when option type is array", () => {
-			let options: any = createOptions(testInjector);
+			const options: any = createOptions(testInjector);
 			process.argv.push("--test1");
 			process.argv.push("value");
 			options.validateOptions({ test1: { type: OptionType.Array } });
@@ -173,7 +173,7 @@ describe("common options", () => {
 		it("does not break execution when valid commandSpecificOptions are passed", () => {
 			process.argv.push("--test1");
 			process.argv.push("value");
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			options.validateOptions({ test1: { type: OptionType.String } });
 			process.argv.pop();
 			process.argv.pop();
@@ -181,7 +181,7 @@ describe("common options", () => {
 		});
 
 		it("does not break execution when valid commandSpecificOptions are passed and user specifies globally valid option", () => {
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			process.argv.push("--version");
 			options.validateOptions({ test1: { type: OptionType.String } });
 			process.argv.pop();
@@ -190,7 +190,7 @@ describe("common options", () => {
 
 		it("breaks execution when valid array option has value with length 0", () => {
 			process.argv.push('--arr');
-			let options = createOptions(testInjector);
+			const options = createOptions(testInjector);
 			options.validateOptions();
 			process.argv.pop();
 			assert.isTrue(isExecutionStopped);
@@ -199,7 +199,7 @@ describe("common options", () => {
 		describe("when commandSpecificOptions are passed", () => {
 			it("breaks execution when commandSpecificOptions are passed and user tries to use invalid option", () => {
 				process.argv.push("--invalidOption");
-				let options = testInjector.resolve(OptionsBase, { options: knownOpts, defaultProfileDir: "1" });
+				const options = testInjector.resolve(OptionsBase, { options: knownOpts, defaultProfileDir: "1" });
 				options.validateOptions({ test1: { type: OptionType.String } });
 				process.argv.pop();
 				assert.isTrue(isExecutionStopped);
@@ -207,17 +207,17 @@ describe("common options", () => {
 
 			it("breaks execution when commandSpecificOptions are passed and user tries to use option valid for CLI, but not for this command", () => {
 				process.argv.push("--json");
-				let options = testInjector.resolve(OptionsBase, { options: knownOpts, defaultProfileDir: "1" });
+				const options = testInjector.resolve(OptionsBase, { options: knownOpts, defaultProfileDir: "1" });
 				options.validateOptions({ test1: { type: OptionType.String } });
 				process.argv.pop();
 				assert.isTrue(isExecutionStopped);
 			});
 
 			it("uses profile-dir from yargs when it exists and commandSpecificOptions are passed", () => {
-				let expectedProfileDir = "TestDir";
+				const expectedProfileDir = "TestDir";
 				process.argv.push("--profile-dir");
 				process.argv.push(expectedProfileDir);
-				let options = testInjector.resolve(OptionsBase, { options: knownOpts, defaultProfileDir: "1" });
+				const options = testInjector.resolve(OptionsBase, { options: knownOpts, defaultProfileDir: "1" });
 				options.validateOptions({ test1: { type: OptionType.String } });
 				assert.equal(options.profileDir, expectedProfileDir);
 				process.argv.pop();
@@ -232,7 +232,7 @@ describe("common options", () => {
 			it("does not break execution when dashed option with single dash is passed", () => {
 				process.argv.push("profile-dir");
 				process.argv.push("some dir");
-				let options = createOptions(testInjector);
+				const options = createOptions(testInjector);
 				options.validateOptions();
 				process.argv.pop();
 				process.argv.pop();
@@ -243,7 +243,7 @@ describe("common options", () => {
 			it("does not break execution when dashed option with two dashes is passed", () => {
 				process.argv.push("some-dashed-value");
 				process.argv.push("some dir");
-				let options = createOptions(testInjector);
+				const options = createOptions(testInjector);
 				options.validateOptions();
 				process.argv.pop();
 				process.argv.pop();
@@ -254,7 +254,7 @@ describe("common options", () => {
 			it("does not break execution when dashed option with a lot of dashes is passed", () => {
 				process.argv.push("a-b-c-d-e-f-g");
 				process.argv.push("some dir");
-				let options = createOptions(testInjector);
+				const options = createOptions(testInjector);
 				options.validateOptions();
 
 				process.argv.pop();
@@ -265,7 +265,7 @@ describe("common options", () => {
 
 			it("does not break execution when dashed option with two dashes is passed", () => {
 				process.argv.push("--special-dashed-v");
-				let options = createOptions(testInjector);
+				const options = createOptions(testInjector);
 				options.validateOptions();
 				process.argv.pop();
 				assert.isFalse(isExecutionStopped, "Dashed options should be validated in specific way. Make sure validation allows yargs specific behavior:" +
@@ -277,11 +277,11 @@ describe("common options", () => {
 });
 
 function createOptionsWithProfileDir(profileDir: string): ICommonOptions {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("errors", {});
 	testInjector.register("staticConfig", {});
 
-	let options = testInjector.resolve(OptionsBase, { options: {}, defaultProfileDir: profileDir });
+	const options = testInjector.resolve(OptionsBase, { options: {}, defaultProfileDir: profileDir });
 	return options;
 }
 
@@ -289,10 +289,10 @@ describe("common options profile-dir tests", () => {
 	describe("setProfileDir", () => {
 
 		it("uses profile-dir from yargs when it exists", () => {
-			let expectedProfileDir = "TestDir";
+			const expectedProfileDir = "TestDir";
 			process.argv.push("--profile-dir");
 			process.argv.push(expectedProfileDir);
-			let options = createOptionsWithProfileDir("");
+			const options = createOptionsWithProfileDir("");
 			options.validateOptions();
 			process.argv.pop();
 			process.argv.pop();
@@ -300,17 +300,17 @@ describe("common options profile-dir tests", () => {
 		});
 
 		it("sets default profile-dir when it is not passed on command line", () => {
-			let profileDir = "TestDir";
-			let options = createOptionsWithProfileDir("TestDir");
+			const profileDir = "TestDir";
+			const options = createOptionsWithProfileDir("TestDir");
 			options.validateOptions();
 			assert.equal(options.profileDir, profileDir);
 		});
 
 		it("uses profile-dir from yargs when it exists even if default one has non-empty value", () => {
-			let expectedProfileDir = "TestDir";
+			const expectedProfileDir = "TestDir";
 			process.argv.push("--profile-dir");
 			process.argv.push(expectedProfileDir);
-			let options = createOptionsWithProfileDir("TestDir123");
+			const options = createOptionsWithProfileDir("TestDir123");
 			options.validateOptions();
 			process.argv.pop();
 			process.argv.pop();
@@ -318,10 +318,10 @@ describe("common options profile-dir tests", () => {
 		});
 
 		it("uses profileDir from yargs when it exists", () => {
-			let expectedProfileDir = "TestDir";
+			const expectedProfileDir = "TestDir";
 			process.argv.push("--profileDir");
 			process.argv.push(expectedProfileDir);
-			let options = createOptionsWithProfileDir("");
+			const options = createOptionsWithProfileDir("");
 			options.validateOptions();
 			process.argv.pop();
 			process.argv.pop();

--- a/test/unit-tests/decorators.ts
+++ b/test/unit-tests/decorators.ts
@@ -6,7 +6,7 @@ import { InvokeBeforeDecoratorsTest } from "./mocks/decorators-invoke-before";
 import { isPromise } from "../../helpers";
 
 describe("decorators", () => {
-	let moduleName = "moduleName", // This is the name of the injected dependency that will be resolved, for example fs, devicesService, etc.
+	const moduleName = "moduleName", // This is the name of the injected dependency that will be resolved, for example fs, devicesService, etc.
 		propertyName = "propertyName"; // This is the name of the method/property from the resolved module
 
 	beforeEach(() => {
@@ -19,7 +19,7 @@ describe("decorators", () => {
 	});
 
 	describe("exported", () => {
-		let expectedResults: any[] = [
+		const expectedResults: any[] = [
 			"string result",
 			1,
 			{ a: 1, b: "2" },
@@ -29,22 +29,22 @@ describe("decorators", () => {
 			null
 		];
 
-		let generatePublicApiFromExportedDecorator = () => {
+		const generatePublicApiFromExportedDecorator = () => {
 			assert.deepEqual($injector.publicApi.__modules__[moduleName], undefined);
-			let resultFunction: any = decoratorsLib.exported(moduleName);
+			const resultFunction: any = decoratorsLib.exported(moduleName);
 			// Call this line in order to generate publicApi and get the real result
 			resultFunction({}, propertyName, {});
 		};
 
 		it("returns function", () => {
-			let result: any = decoratorsLib.exported("test");
+			const result: any = decoratorsLib.exported("test");
 			assert.equal(typeof (result), "function");
 		});
 
 		it("does not change original method", () => {
-			let exportedFunctionResult: any = decoratorsLib.exported(moduleName);
-			let expectedResult = { "originalObject": "originalValue" };
-			let actualResult = exportedFunctionResult({}, "myTest1", expectedResult);
+			const exportedFunctionResult: any = decoratorsLib.exported(moduleName);
+			const expectedResult = { "originalObject": "originalValue" };
+			const actualResult = exportedFunctionResult({}, "myTest1", expectedResult);
 			assert.deepEqual(actualResult, expectedResult);
 		});
 
@@ -52,68 +52,68 @@ describe("decorators", () => {
 			it(`returns correct result when function returns ${_.isArray(expectedResult) ? "array" : typeof (expectedResult)}`, () => {
 				$injector.register(moduleName, { propertyName: () => expectedResult });
 				generatePublicApiFromExportedDecorator();
-				let actualResult: any = $injector.publicApi.__modules__[moduleName][propertyName]();
+				const actualResult: any = $injector.publicApi.__modules__[moduleName][propertyName]();
 				assert.deepEqual(actualResult, expectedResult);
 		});
 
 			it(`passes correct arguments to original function, when argument type is: ${_.isArray(expectedResult) ? "array" : typeof (expectedResult)}`, () => {
 				$injector.register(moduleName, { propertyName: (arg: any) => arg });
 				generatePublicApiFromExportedDecorator();
-				let actualResult: any = $injector.publicApi.__modules__[moduleName][propertyName](expectedResult);
+				const actualResult: any = $injector.publicApi.__modules__[moduleName][propertyName](expectedResult);
 				assert.deepEqual(actualResult, expectedResult);
 		});
 		});
 
 		it("returns Promise, which is resolved to correct value (function without arguments)", (done: mocha.Done) => {
-			let expectedResult = "result";
+			const expectedResult = "result";
 			$injector.register(moduleName, { propertyName: async () => expectedResult });
 			generatePublicApiFromExportedDecorator();
 
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
+			const promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
 			promise.then((val: string) => {
 				assert.deepEqual(val, expectedResult);
 			}).then(done).catch(done);
 		});
 
 		it("returns Promise, which is resolved to correct value (function with arguments)", (done: mocha.Done) => {
-			let expectedArgs = ["result", "result1", "result2"];
+			const expectedArgs = ["result", "result1", "result2"];
 			$injector.register(moduleName, { propertyName: async (functionArgs: string[]) => functionArgs });
 			generatePublicApiFromExportedDecorator();
 
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName](expectedArgs);
+			const promise: any = $injector.publicApi.__modules__[moduleName][propertyName](expectedArgs);
 			promise.then((val: string[]) => {
 				assert.deepEqual(val, expectedArgs);
 			}).then(done).catch(done);
 		});
 
 		it("returns Promise, which is resolved to correct value (function returning Promise without arguments)", (done: mocha.Done) => {
-			let expectedResult = "result";
+			const expectedResult = "result";
 			$injector.register(moduleName, { propertyName: async () => expectedResult });
 			generatePublicApiFromExportedDecorator();
 
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
+			const promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
 			promise.then((val: string) => {
 				assert.deepEqual(val, expectedResult);
 			}).then(done).catch(done);
 		});
 
 		it("returns Promise, which is resolved to correct value (function returning Promise with arguments)", (done: mocha.Done) => {
-			let expectedArgs = ["result", "result1", "result2"];
+			const expectedArgs = ["result", "result1", "result2"];
 			$injector.register(moduleName, { propertyName: async (args: string[]) => args });
 			generatePublicApiFromExportedDecorator();
 
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName](expectedArgs);
+			const promise: any = $injector.publicApi.__modules__[moduleName][propertyName](expectedArgs);
 			promise.then((val: string[]) => {
 				assert.deepEqual(val, expectedArgs);
 			}).then(done).catch(done);
 		});
 
 		it("rejects Promise, which is resolved to correct error (function without arguments throws)", (done: mocha.Done) => {
-			let expectedError = new Error("Test msg");
+			const expectedError = new Error("Test msg");
 			$injector.register(moduleName, { propertyName: async () => { throw expectedError; } });
 			generatePublicApiFromExportedDecorator();
 
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
+			const promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
 			promise.then((result: any) => {
 				throw new Error("Then method MUST not be called when promise is rejected!");
 			}, (err: Error) => {
@@ -122,11 +122,11 @@ describe("decorators", () => {
 		});
 
 		it("rejects Promise, which is resolved to correct error (function returning Promise without arguments throws)", (done: mocha.Done) => {
-			let expectedError = new Error("Test msg");
+			const expectedError = new Error("Test msg");
 			$injector.register(moduleName, { propertyName: async () => { throw expectedError; } });
 			generatePublicApiFromExportedDecorator();
 
-			let promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
+			const promise: any = $injector.publicApi.__modules__[moduleName][propertyName]();
 			promise.then((result: any) => {
 				throw new Error("Then method MUST not be called when promise is rejected!");
 			}, (err: Error) => {
@@ -135,11 +135,11 @@ describe("decorators", () => {
 		});
 
 		it("returns Promises, which are resolved to correct value (function returning Promise<T>[] without arguments)", (done: mocha.Done) => {
-			let expectedResultsArr = ["result1", "result2", "result3"];
+			const expectedResultsArr = ["result1", "result2", "result3"];
 			$injector.register(moduleName, { propertyName: () => _.map(expectedResultsArr, async expectedResult => expectedResult) });
 			generatePublicApiFromExportedDecorator();
 
-			let promises: Promise<string>[] = $injector.publicApi.__modules__[moduleName][propertyName]();
+			const promises: Promise<string>[] = $injector.publicApi.__modules__[moduleName][propertyName]();
 			Promise.all<string>(promises)
 				.then((promiseResults: string[]) => {
 					_.each(promiseResults, (val: string, index: number) => {
@@ -151,12 +151,12 @@ describe("decorators", () => {
 		});
 
 		it("rejects Promises, which are resolved to correct error (function returning Promise<T>[] without arguments throws)", (done: mocha.Done) => {
-			let expectedErrors = [new Error("result1"), new Error("result2"), new Error("result3")];
+			const expectedErrors = [new Error("result1"), new Error("result2"), new Error("result3")];
 			$injector.register(moduleName, { propertyName: () => _.map(expectedErrors, async expectedError => { throw expectedError; }) });
 			generatePublicApiFromExportedDecorator();
 
 			new Promise((onFulfilled: Function, onRejected: Function) => {
-				let promises: Promise<string>[] = $injector.publicApi.__modules__[moduleName][propertyName]();
+				const promises: Promise<string>[] = $injector.publicApi.__modules__[moduleName][propertyName]();
 				_.each(promises, (promise, index) => promise.then((result: any) => {
 					onRejected(new Error(`Then method MUST not be called when promise is rejected!. Result of promise is: ${result}`));
 				}, (err: Error) => {
@@ -172,12 +172,12 @@ describe("decorators", () => {
 		});
 
 		it("rejects only Promises which throw, resolves the others correctly (function returning Promise<T>[] without arguments)", (done: mocha.Done) => {
-			let expectedResultsArr: any[] = ["result1", new Error("result2")];
+			const expectedResultsArr: any[] = ["result1", new Error("result2")];
 			$injector.register(moduleName, { propertyName: () => _.map(expectedResultsArr, async expectedResult => expectedResult) });
 			generatePublicApiFromExportedDecorator();
 
 			new Promise((onFulfilled: Function, onRejected: Function) => {
-				let promises: Promise<string>[] = $injector.publicApi.__modules__[moduleName][propertyName]();
+				const promises: Promise<string>[] = $injector.publicApi.__modules__[moduleName][propertyName]();
 				_.each(promises, (promise, index) => promise.then((val: string) => {
 					assert.deepEqual(val, expectedResultsArr[index]);
 					if (index + 1 === expectedResultsArr.length) {
@@ -193,7 +193,7 @@ describe("decorators", () => {
 		});
 
 		it("when function throws, raises the error only when the public API is called, not when decorator is applied", () => {
-			let errorMessage = "This is error message";
+			const errorMessage = "This is error message";
 			$injector.register(moduleName, { propertyName: () => { throw new Error(errorMessage); } });
 			generatePublicApiFromExportedDecorator();
 			assert.throws(() => $injector.publicApi.__modules__[moduleName][propertyName](), errorMessage);

--- a/test/unit-tests/file-system.ts
+++ b/test/unit-tests/file-system.ts
@@ -9,12 +9,12 @@ import { CommonLoggerStub } from "./stubs";
 
 use(require("chai-as-promised"));
 
-let sampleZipFileTest = path.join(__dirname, "../resources/sampleZipFileTest.zip");
-let unzippedFileName = "sampleZipFileTest.txt";
-let sampleZipFileTestIncorrectName = path.join(__dirname, "../resources/sampleZipfileTest.zip");
+const sampleZipFileTest = path.join(__dirname, "../resources/sampleZipFileTest.zip");
+const unzippedFileName = "sampleZipFileTest.txt";
+const sampleZipFileTestIncorrectName = path.join(__dirname, "../resources/sampleZipfileTest.zip");
 
 function isOsCaseSensitive(testInjector: IInjector): boolean {
-	let hostInfo = testInjector.resolve("hostInfo");
+	const hostInfo = testInjector.resolve("hostInfo");
 	return hostInfo.isLinux;
 }
 temp.track();
@@ -71,7 +71,7 @@ function createWriteJsonTestCases(): { exists: boolean, text: string, testCondit
 }
 
 function createTestInjector(): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 
 	testInjector.register("fs", fileSystemFile.FileSystem);
 	testInjector.register("errors", {
@@ -91,11 +91,11 @@ function createTestInjector(): IInjector {
 describe("FileSystem", () => {
 	describe("unzip", () => {
 		describe("overwriting files tests", () => {
-			let testInjector: IInjector,
-				tempDir: string,
-				fs: IFileSystem,
-				file: string,
-				msg = "data";
+			let testInjector: IInjector;
+			let tempDir: string;
+			let fs: IFileSystem;
+			let file: string;
+			const msg = "data";
 
 			beforeEach(() => {
 				testInjector = createTestInjector();
@@ -106,25 +106,25 @@ describe("FileSystem", () => {
 			});
 			it("does not overwrite files when overwriteExisitingFiles is false", async () => {
 				await fs.unzip(sampleZipFileTest, tempDir, { overwriteExisitingFiles: false }, [unzippedFileName]);
-				let data = fs.readFile(file);
+				const data = fs.readFile(file);
 				assert.strictEqual(msg, data.toString(), "When overwriteExistingFiles is false, we should not ovewrite files.");
 			});
 
 			it("overwrites files when overwriteExisitingFiles is true", async () => {
 				await fs.unzip(sampleZipFileTest, tempDir, { overwriteExisitingFiles: true }, [unzippedFileName]);
-				let data = fs.readFile(file);
+				const data = fs.readFile(file);
 				assert.notEqual(msg, data.toString(), "We must overwrite files when overwriteExisitingFiles is true.");
 			});
 
 			it("overwrites files when overwriteExisitingFiles is not set", async () => {
 				await fs.unzip(sampleZipFileTest, tempDir, {}, [unzippedFileName]);
-				let data = fs.readFile(file);
+				const data = fs.readFile(file);
 				assert.notEqual(msg, data.toString(), "We must overwrite files when overwriteExisitingFiles is not set.");
 			});
 
 			it("overwrites files when options is not set", async () => {
 				await fs.unzip(sampleZipFileTest, tempDir, undefined, [unzippedFileName]);
-				let data = fs.readFile(file);
+				const data = fs.readFile(file);
 				assert.notEqual(msg, data.toString(), "We must overwrite files when options is not defined.");
 			});
 		});
@@ -133,37 +133,37 @@ describe("FileSystem", () => {
 		describe("case sensitive tests", () => {
 			const commandUnzipFailedMessage = "Command unzip failed with exit code 9";
 			it("is case sensitive when options is not defined", async () => {
-				let testInjector = createTestInjector();
-				let tempDir = temp.mkdirSync("projectToUnzip");
-				let fs: IFileSystem = testInjector.resolve("fs");
+				const testInjector = createTestInjector();
+				const tempDir = temp.mkdirSync("projectToUnzip");
+				const fs: IFileSystem = testInjector.resolve("fs");
 				if (isOsCaseSensitive(testInjector)) {
 					await assert.isRejected(fs.unzip(sampleZipFileTestIncorrectName, tempDir, undefined, [unzippedFileName]), commandUnzipFailedMessage);
 				}
 			});
 
 			it("is case sensitive when caseSensitive option is not defined", async () => {
-				let testInjector = createTestInjector();
-				let tempDir = temp.mkdirSync("projectToUnzip");
-				let fs: IFileSystem = testInjector.resolve("fs");
+				const testInjector = createTestInjector();
+				const tempDir = temp.mkdirSync("projectToUnzip");
+				const fs: IFileSystem = testInjector.resolve("fs");
 				if (isOsCaseSensitive(testInjector)) {
 					await assert.isRejected(fs.unzip(sampleZipFileTestIncorrectName, tempDir, {}, [unzippedFileName]), commandUnzipFailedMessage);
 				}
 			});
 
 			it("is case sensitive when caseSensitive option is true", async () => {
-				let testInjector = createTestInjector();
-				let tempDir = temp.mkdirSync("projectToUnzip");
-				let fs: IFileSystem = testInjector.resolve("fs");
+				const testInjector = createTestInjector();
+				const tempDir = temp.mkdirSync("projectToUnzip");
+				const fs: IFileSystem = testInjector.resolve("fs");
 				if (isOsCaseSensitive(testInjector)) {
 					await assert.isRejected(fs.unzip(sampleZipFileTestIncorrectName, tempDir, { caseSensitive: true }, [unzippedFileName]), commandUnzipFailedMessage);
 				}
 			});
 
 			it("is case insensitive when caseSensitive option is false", async () => {
-				let testInjector = createTestInjector();
-				let tempDir = temp.mkdirSync("projectToUnzip");
-				let fs: IFileSystem = testInjector.resolve("fs");
-				let file = path.join(tempDir, unzippedFileName);
+				const testInjector = createTestInjector();
+				const tempDir = temp.mkdirSync("projectToUnzip");
+				const fs: IFileSystem = testInjector.resolve("fs");
+				const file = path.join(tempDir, unzippedFileName);
 				await fs.unzip(sampleZipFileTestIncorrectName, tempDir, { caseSensitive: false }, [unzippedFileName]);
 				// This will throw error in case file is not extracted
 				fs.readFile(file);
@@ -173,37 +173,37 @@ describe("FileSystem", () => {
 
 	describe("renameIfExists", () => {
 		it("returns true when file is renamed", () => {
-			let testInjector = createTestInjector();
-			let tempDir = temp.mkdirSync("renameIfExists");
-			let testFileName = path.join(tempDir, "testRenameIfExistsMethod");
-			let newFileName = path.join(tempDir, "newfilename");
+			const testInjector = createTestInjector();
+			const tempDir = temp.mkdirSync("renameIfExists");
+			const testFileName = path.join(tempDir, "testRenameIfExistsMethod");
+			const newFileName = path.join(tempDir, "newfilename");
 
-			let fs: IFileSystem = testInjector.resolve("fs");
+			const fs: IFileSystem = testInjector.resolve("fs");
 			fs.writeFile(testFileName, "data");
 
-			let result = fs.renameIfExists(testFileName, newFileName);
+			const result = fs.renameIfExists(testFileName, newFileName);
 			assert.isTrue(result, "On successfull rename, result must be true.");
 			assert.isTrue(fs.exists(newFileName), "Renamed file should exists.");
 			assert.isFalse(fs.exists(testFileName), "Original file should not exist.");
 		});
 
 		it("returns false when file does not exist", () => {
-			let testInjector = createTestInjector();
-			let fs: IFileSystem = testInjector.resolve("fs");
-			let newName = "tempDir2";
-			let result = fs.renameIfExists("tempDir", newName);
+			const testInjector = createTestInjector();
+			const fs: IFileSystem = testInjector.resolve("fs");
+			const newName = "tempDir2";
+			const result = fs.renameIfExists("tempDir", newName);
 			assert.isFalse(result, "When file does not exist, result must be false.");
 			assert.isFalse(fs.exists(newName), "New file should not exist.");
 		});
 	});
 
 	describe("copyFile", () => {
-		let testInjector: IInjector,
-			tempDir: string,
-			testFileName: string,
-			newFileName: string,
-			fileContent = "data",
-			fs: IFileSystem;
+		let testInjector: IInjector;
+		let tempDir: string;
+		let testFileName: string;
+		let newFileName: string;
+		const fileContent = "data";
+		let fs: IFileSystem;
 
 		beforeEach(() => {
 			testInjector = createTestInjector();
@@ -223,7 +223,7 @@ describe("FileSystem", () => {
 		});
 
 		it("copies file to non-existent directory", () => {
-			let newFileNameInSubDir = path.join(tempDir, "subDir", "newfilename");
+			const newFileNameInSubDir = path.join(tempDir, "subDir", "newfilename");
 			assert.isFalse(fs.exists(newFileNameInSubDir));
 			fs.copyFile(testFileName, newFileNameInSubDir);
 			assert.isTrue(fs.exists(newFileNameInSubDir), "Renamed file should exists.");
@@ -232,7 +232,7 @@ describe("FileSystem", () => {
 		});
 
 		it("produces correct file when source and target file are the same", () => {
-			let originalSize = fs.getFsStats(testFileName).size;
+			const originalSize = fs.getFsStats(testFileName).size;
 			fs.copyFile(testFileName, testFileName);
 			assert.isTrue(fs.exists(testFileName), "Original file should exist.");
 			assert.deepEqual(fs.getFsStats(testFileName).size, originalSize, "Original file and copied file must have the same size.");
@@ -243,7 +243,7 @@ describe("FileSystem", () => {
 	describe("removeEmptyParents", () => {
 		let testInjector: IInjector;
 		let fs: IFileSystem;
-		let notEmptyRootDirectory = path.join("not-empty");
+		const notEmptyRootDirectory = path.join("not-empty");
 		let removedDirectories: string[];
 
 		beforeEach(() => {
@@ -257,7 +257,7 @@ describe("FileSystem", () => {
 		});
 
 		it("should remove all empty parents.", () => {
-			let emptyDirectories = ["first", "second", "third"];
+			const emptyDirectories = ["first", "second", "third"];
 
 			let directory = notEmptyRootDirectory;
 
@@ -268,7 +268,7 @@ describe("FileSystem", () => {
 			// We need to add the fourth directory because this directory does not actually exist and the method will start deleting its parents.
 			directory = path.join(directory, "fourth");
 
-			let originalIsEmptyDir = fs.isEmptyDir;
+			const originalIsEmptyDir = fs.isEmptyDir;
 			fs.isEmptyDir = (dirName: string) => dirName !== notEmptyRootDirectory;
 
 			fs.deleteEmptyParents(directory);
@@ -279,9 +279,9 @@ describe("FileSystem", () => {
 	});
 
 	describe("writeJson", () => {
-		let testCases = createWriteJsonTestCases(),
-			testInjector: IInjector,
-			fs: IFileSystem;
+		const testCases = createWriteJsonTestCases();
+		let testInjector: IInjector;
+		let fs: IFileSystem;
 
 		beforeEach(() => {
 			testInjector = createTestInjector();
@@ -296,7 +296,7 @@ describe("FileSystem", () => {
 				fs.writeFile = () => null;
 
 				let actualIndentation: string;
-				let originalJsonStringify = JSON.stringify;
+				const originalJsonStringify = JSON.stringify;
 
 				(<any>JSON).stringify = (value: any, replacer: any[], space: string | number) => {
 					actualIndentation = <string>space;

--- a/test/unit-tests/helpers.ts
+++ b/test/unit-tests/helpers.ts
@@ -16,7 +16,7 @@ describe("helpers", () => {
 	};
 
 	describe("getPropertyName", () => {
-		let ES5Functions: ITestData[] = [
+		const ES5Functions: ITestData[] = [
 			{
 				input: `function (a) {
 					return a.test;
@@ -67,7 +67,7 @@ describe("helpers", () => {
 			}
 		];
 
-		let ES6Functions: ITestData[] = [
+		const ES6Functions: ITestData[] = [
 			{
 				input: `(a) => {
 					return a.test;
@@ -154,7 +154,7 @@ describe("helpers", () => {
 	});
 
 	describe("toBoolean", () => {
-		let toBooleanTestData: ITestData[] = [
+		const toBooleanTestData: ITestData[] = [
 			{
 				input: true,
 				expectedResult: true
@@ -222,13 +222,13 @@ describe("helpers", () => {
 		});
 
 		it("returns false when Object.create(null) is passed", () => {
-			let actualResult = helpers.toBoolean(Object.create(null));
+			const actualResult = helpers.toBoolean(Object.create(null));
 			assert.deepEqual(actualResult, false);
 		});
 	});
 
 	describe("isNullOrWhitespace", () => {
-		let isNullOrWhitespaceTestData: ITestData[] = [
+		const isNullOrWhitespaceTestData: ITestData[] = [
 			{
 				input: "",
 				expectedResult: true
@@ -292,7 +292,7 @@ describe("helpers", () => {
 		});
 
 		it("returns false when Object.create(null) is passed", () => {
-			let actualResult = helpers.isNullOrWhitespace(Object.create(null));
+			const actualResult = helpers.isNullOrWhitespace(Object.create(null));
 			assert.deepEqual(actualResult, false);
 		});
 	});
@@ -303,7 +303,7 @@ describe("helpers", () => {
 		};
 
 		const getRejectedPromise = (errorMessage: any): Promise<any> => {
-			let promise = Promise.reject(errorMessage);
+			const promise = Promise.reject(errorMessage);
 			promise.catch(() => {
 				// the handler is here in order to prevent warnings in Node 7+
 				// PromiseRejectionHandledWarning: Promise rejection was handled asynchronously

--- a/test/unit-tests/ios-log-filter.ts
+++ b/test/unit-tests/ios-log-filter.ts
@@ -3,7 +3,7 @@ import { LoggingLevels } from "../../mobile/logging-levels";
 import { Yok } from "../../yok";
 import * as assert from "assert";
 
-let iosTestData = [
+const iosTestData = [
 	{
 		input: 'Dec 29 08:46:04 Dragons-iPhone iaptransportd[65] <Warning>: CIapPortAppleIDBus: Auth timer timeout completed on pAIDBPort:0x135d09410, portID:01 downstream port',
 		output: null,
@@ -109,16 +109,16 @@ let iosTestData = [
 
 describe("iOSLogFilter", () => {
 
-	let assertFiltering = (inputData: string, expectedOutput: string, logLevel?: string, pid?: string) => {
-		let testInjector = new Yok();
+	const assertFiltering = (inputData: string, expectedOutput: string, logLevel?: string, pid?: string) => {
+		const testInjector = new Yok();
 		testInjector.register("loggingLevels", LoggingLevels);
-		let iOSLogFilter = testInjector.resolve(IOSLogFilter);
-		let filteredData = iOSLogFilter.filterData(inputData, logLevel, pid);
+		const iOSLogFilter = testInjector.resolve(IOSLogFilter);
+		const filteredData = iOSLogFilter.filterData(inputData, logLevel, pid);
 		assert.deepEqual(filteredData, expectedOutput, `The actual result '${filteredData}' did NOT match expected output '${expectedOutput}'.`);
 	};
 
-	let logLevel = "INFO",
-		pid = "13309";
+	let logLevel = "INFO";
+	const pid = "13309";
 
 	describe("filterData", () => {
 		describe("when PID is not provided", () => {

--- a/test/unit-tests/log-filter.ts
+++ b/test/unit-tests/log-filter.ts
@@ -5,7 +5,7 @@ import { LoggingLevels } from "../../mobile/logging-levels";
 import * as assert from "assert";
 
 function createTestInjector(): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("injector", testInjector);
 	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
 	testInjector.register("loggingLevels", LoggingLevels);
@@ -26,16 +26,16 @@ function createTestInjector(): IInjector {
 }
 
 describe("logFilter", () => {
-	let testInjector: IInjector,
-		logFilter: Mobile.ILogFilter,
-		testData = "testData",
-		infoLogLevel = "INFO",
-		fullLogLevel = "FULL",
-		androidInfoTestData = `android: ${testData} ${infoLogLevel}`,
-		androidFullTestData = `android: ${testData} ${fullLogLevel}`,
-		iosInfoTestData = `ios: ${testData} ${infoLogLevel}`,
-		iosFullTestData = `ios: ${testData} ${fullLogLevel}`,
-		logLevel: string = null;
+	let testInjector: IInjector;
+	let logFilter: Mobile.ILogFilter;
+	const testData = "testData";
+	const infoLogLevel = "INFO";
+	const fullLogLevel = "FULL";
+	const androidInfoTestData = `android: ${testData} ${infoLogLevel}`;
+	const androidFullTestData = `android: ${testData} ${fullLogLevel}`;
+	const iosInfoTestData = `ios: ${testData} ${infoLogLevel}`;
+	const iosFullTestData = `ios: ${testData} ${fullLogLevel}`;
+	let logLevel: string = null;
 
 	beforeEach(() => {
 		testInjector = createTestInjector();
@@ -67,22 +67,22 @@ describe("logFilter", () => {
 	describe("filterData", () => {
 		describe("when logLevel is not specified and default log level is not changed", () => {
 			it("returns same data when platform is not correct", () => {
-				let actualData = logFilter.filterData("invalidPlatform", testData, "");
+				const actualData = logFilter.filterData("invalidPlatform", testData, "");
 				assert.deepEqual(actualData, testData);
 			});
 
 			it("returns same data when platform is not passed", () => {
-				let actualData = logFilter.filterData(null, testData, "");
+				const actualData = logFilter.filterData(null, testData, "");
 				assert.deepEqual(actualData, testData);
 			});
 
 			it("returns correct data when platform is android", () => {
-				let actualData = logFilter.filterData("android", testData, "");
+				const actualData = logFilter.filterData("android", testData, "");
 				assert.deepEqual(actualData, androidInfoTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				let actualData = logFilter.filterData("ios", testData, "");
+				const actualData = logFilter.filterData("ios", testData, "");
 				assert.deepEqual(actualData, iosInfoTestData);
 			});
 		});
@@ -91,17 +91,17 @@ describe("logFilter", () => {
 			beforeEach(() => logFilter.loggingLevel = fullLogLevel);
 
 			it("returns same data when platform is not correct", () => {
-				let actualData = logFilter.filterData("invalidPlatform", testData, "");
+				const actualData = logFilter.filterData("invalidPlatform", testData, "");
 				assert.deepEqual(actualData, testData);
 			});
 
 			it("returns correct data when platform is android", () => {
-				let actualData = logFilter.filterData("android", testData, "");
+				const actualData = logFilter.filterData("android", testData, "");
 				assert.deepEqual(actualData, androidFullTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				let actualData = logFilter.filterData("ios", testData, "");
+				const actualData = logFilter.filterData("ios", testData, "");
 				assert.deepEqual(actualData, iosFullTestData);
 			});
 		});
@@ -110,17 +110,17 @@ describe("logFilter", () => {
 			beforeEach(() => logLevel = infoLogLevel);
 
 			it("returns same data when platform is not correct", () => {
-				let actualData = logFilter.filterData("invalidPlatform", testData, null, logLevel);
+				const actualData = logFilter.filterData("invalidPlatform", testData, null, logLevel);
 				assert.deepEqual(actualData, testData, logLevel);
 			});
 
 			it("returns correct data when platform is android", () => {
-				let actualData = logFilter.filterData("android", testData, null, logLevel);
+				const actualData = logFilter.filterData("android", testData, null, logLevel);
 				assert.deepEqual(actualData, androidInfoTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				let actualData = logFilter.filterData("ios", testData, null, logLevel);
+				const actualData = logFilter.filterData("ios", testData, null, logLevel);
 				assert.deepEqual(actualData, iosInfoTestData);
 			});
 		});
@@ -129,17 +129,17 @@ describe("logFilter", () => {
 			beforeEach(() => logLevel = fullLogLevel);
 
 			it("returns same data when platform is not correct", () => {
-				let actualData = logFilter.filterData("invalidPlatform", testData, null, logLevel);
+				const actualData = logFilter.filterData("invalidPlatform", testData, null, logLevel);
 				assert.deepEqual(actualData, testData, logLevel);
 			});
 
 			it("returns correct data when platform is android", () => {
-				let actualData = logFilter.filterData("android", testData,  null, logLevel);
+				const actualData = logFilter.filterData("android", testData,  null, logLevel);
 				assert.deepEqual(actualData, androidFullTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				let actualData = logFilter.filterData("ios", testData, null, logLevel);
+				const actualData = logFilter.filterData("ios", testData, null, logLevel);
 				assert.deepEqual(actualData, iosFullTestData);
 			});
 		});

--- a/test/unit-tests/logger.ts
+++ b/test/unit-tests/logger.ts
@@ -7,7 +7,7 @@ const debugTrace = ["debug", "trace"];
 const passwordPair = ["password", "Password"];
 
 function createTestInjector(logLevel?: string): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("injector", testInjector);
 	testInjector.register("config", {});
 	testInjector.register("options", {
@@ -19,9 +19,9 @@ function createTestInjector(logLevel?: string): IInjector {
 }
 
 describe("logger", () => {
-	let testInjector: IInjector,
-		logger: any,
-		outputs: any;
+	let testInjector: IInjector;
+	let logger: any;
+	let outputs: any;
 
 	beforeEach(() => {
 		testInjector = createTestInjector();

--- a/test/unit-tests/messages-service.ts
+++ b/test/unit-tests/messages-service.ts
@@ -6,7 +6,7 @@ import { existsSync } from "fs";
 import { assert } from "chai";
 
 function createTestInjector(jsonContents: any, options?: { useRealFsExists: boolean }): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("fs", {
 		exists: (path: string): boolean => options && options.useRealFsExists ? existsSync(path) : true,
 		readJson: (filename: string, encoding?: string): any => jsonContents
@@ -20,14 +20,14 @@ describe("messages-service", () => {
 
 	describe("pathsToMessageJsonFiles property", () => {
 		it("initializes with the default json file", () => {
-			let injector = createTestInjector({});
+			const injector = createTestInjector({});
 			service = injector.resolve("$messagesService");
 
 			assert.deepEqual(1, service.pathsToMessageJsonFiles.length, "Messages service should initialize with a default json file.");
 		});
 
 		it("appends the default json file when setting pathsToMessageJsonFiles", () => {
-			let injector = createTestInjector({}, { useRealFsExists: false });
+			const injector = createTestInjector({}, { useRealFsExists: false });
 			service = injector.resolve("$messagesService");
 			service.pathsToMessageJsonFiles = ["someHackyJsonFile.json"];
 
@@ -35,7 +35,7 @@ describe("messages-service", () => {
 		});
 
 		it("should throw if non-existent json file is provided", () => {
-			let injector = createTestInjector({}, { useRealFsExists: true });
+			const injector = createTestInjector({}, { useRealFsExists: true });
 			service = injector.resolve("$messagesService");
 			assert.throws(() => { service.pathsToMessageJsonFiles = ["someJsonFile.json"]; }, "someJsonFile.json does not exist");
 		});
@@ -43,17 +43,17 @@ describe("messages-service", () => {
 
 	describe("getMessage", () => {
 		it("returns the given message if not found as key in any json file", () => {
-			let injector = createTestInjector({});
+			const injector = createTestInjector({});
 			service = injector.resolve("$messagesService");
-			let stringMessage = "Some message",
+			const stringMessage = "Some message",
 				resultMessage = service.getMessage(stringMessage);
 			assert.deepEqual(stringMessage, resultMessage, "Messages service should return the given message if not found as key in any json file in `pathsToMessageJsonFiles` property.");
 		});
 
 		it("util.formats the given message if not found as key in any json file and contains special symbol (%s,%d, etc.)", () => {
-			let injector = createTestInjector({});
+			const injector = createTestInjector({});
 			service = injector.resolve("$messagesService");
-			let messageFormat = "Some %s message.",
+			const messageFormat = "Some %s message.",
 				formatArg = "formatted",
 				expectedMessage = format(messageFormat, formatArg),
 				resultMessage = service.getMessage(messageFormat, formatArg);
@@ -62,7 +62,7 @@ describe("messages-service", () => {
 		});
 
 		it("should return correct value from json file if found in json message files", () => {
-			let jsonContents = { KEY: "Value" },
+			const jsonContents = { KEY: "Value" },
 				injector = createTestInjector(jsonContents);
 			service = injector.resolve("$messagesService");
 
@@ -70,11 +70,11 @@ describe("messages-service", () => {
 		});
 
 		it("should util.format value from json file if found in json message files and contains special symbol (%s,%d, etc.)", () => {
-			let jsonContents = { KEY: "%s value" },
+			const jsonContents = { KEY: "%s value" },
 				injector = createTestInjector(jsonContents);
 			service = injector.resolve("$messagesService");
 
-			let formatArg = "Formatted",
+			const formatArg = "Formatted",
 				expectedMessage = format(jsonContents.KEY, formatArg),
 				actualMessage = service.getMessage(jsonContents.KEY, formatArg);
 
@@ -82,7 +82,7 @@ describe("messages-service", () => {
 		});
 
 		it("should return correct value from json file if found in json message files with complex key", () => {
-			let jsonContents = {
+			const jsonContents = {
 				KEY: {
 					NESTED_KEY: "Value"
 				}
@@ -94,7 +94,7 @@ describe("messages-service", () => {
 		});
 
 		it("should return correct value from json file if found in client json before common json", () => {
-			let commonJsonContents = {
+			const commonJsonContents = {
 				KEY: "Value"
 			},
 				clientJsonContents = {

--- a/test/unit-tests/mobile/android-device-discovery.ts
+++ b/test/unit-tests/mobile/android-device-discovery.ts
@@ -29,12 +29,12 @@ class MockEventEmitter extends EventEmitter implements IChildProcessMock {
 	public stderr: MockEventEmitter;
 }
 
-let mockStdoutEmitter: MockEventEmitter,
-	mockStderrEmitter: MockEventEmitter,
-	mockChildProcess: any;
+let mockStdoutEmitter: MockEventEmitter;
+let mockStderrEmitter: MockEventEmitter;
+let mockChildProcess: any;
 
 function createTestInjector(): IInjector {
-	let injector = new Yok();
+	const injector = new Yok();
 	injector.register("injector", injector);
 	injector.register("adb", AndroidDebugBridge);
 	injector.register("errors", {});
@@ -64,9 +64,9 @@ function createTestInjector(): IInjector {
 	});
 
 	injector.register("androidDeviceDiscovery", AndroidDeviceDiscovery);
-	let originalResolve = injector.resolve;
+	const originalResolve = injector.resolve;
 	// replace resolve as we do not want to create real AndroidDevice
-	let resolve = (param: any, ctorArguments?: IDictionary<any>) => {
+	const resolve = (param: any, ctorArguments?: IDictionary<any>) => {
 		if (ctorArguments && Object.prototype.hasOwnProperty.call(ctorArguments, "status") &&
 			Object.prototype.hasOwnProperty.call(ctorArguments, "identifier")) {
 			return new AndroidDeviceMock(ctorArguments["identifier"], ctorArguments["status"]);
@@ -80,11 +80,11 @@ function createTestInjector(): IInjector {
 }
 
 describe("androidDeviceDiscovery", () => {
-	let androidDeviceDiscovery: Mobile.IAndroidDeviceDiscovery,
-		injector: IInjector,
-		androidDeviceIdentifier = "androidDevice",
-		androidDeviceStatus = "device",
-		devicesFound: any[];
+	let androidDeviceDiscovery: Mobile.IAndroidDeviceDiscovery;
+	let injector: IInjector;
+	const androidDeviceIdentifier = "androidDevice";
+	const androidDeviceStatus = "device";
+	let devicesFound: any[];
 
 	beforeEach(() => {
 		mockChildProcess = null;
@@ -103,7 +103,7 @@ describe("androidDeviceDiscovery", () => {
 
 			// As startLookingForDevices is blocking, we should emit data on the next tick, so the future will be resolved and we'll receive the data.
 			setTimeout(() => {
-				let output = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}${EOL}`;
+				const output = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}${EOL}`;
 				mockStdoutEmitter.emit('data', output);
 				mockChildProcess.emit('close', 0);
 			}, 1);
@@ -117,7 +117,7 @@ describe("androidDeviceDiscovery", () => {
 
 	describe("ensureAdbServerStarted", () => {
 		it("should spawn adb with start-server parameter", async () => {
-			let ensureAdbServerStartedOutput = await androidDeviceDiscovery.ensureAdbServerStarted();
+			const ensureAdbServerStartedOutput = await androidDeviceDiscovery.ensureAdbServerStarted();
 			assert.isTrue(_.includes(ensureAdbServerStartedOutput, "start-server"), "start-server should be passed to adb.");
 		});
 	});
@@ -133,7 +133,7 @@ describe("androidDeviceDiscovery", () => {
 			});
 
 			setTimeout(() => {
-				let output = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}${EOL}`;
+				const output = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}${EOL}`;
 				mockStdoutEmitter.emit('data', output);
 				mockChildProcess.emit('close', 0);
 			}, 0);
@@ -157,7 +157,7 @@ describe("androidDeviceDiscovery", () => {
 			});
 
 			setTimeout(() => {
-				let output = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}secondDevice	${androidDeviceStatus}${EOL}`;
+				const output = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}secondDevice	${androidDeviceStatus}${EOL}`;
 				mockStdoutEmitter.emit('data', output);
 				mockChildProcess.emit('close', 0);
 			}, 0);
@@ -177,7 +177,7 @@ describe("androidDeviceDiscovery", () => {
 			});
 
 			setTimeout(() => {
-				let output = `List of devices attached${EOL}`;
+				const output = `List of devices attached${EOL}`;
 				mockStdoutEmitter.emit('data', output);
 				mockChildProcess.emit('close', 0);
 			}, 0);
@@ -196,7 +196,7 @@ describe("androidDeviceDiscovery", () => {
 			});
 
 			setTimeout(() => {
-				let output = `List of devices attached ${EOL}${adbMessage}${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}${EOL}`;
+				const output = `List of devices attached ${EOL}${adbMessage}${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}${EOL}`;
 				mockStdoutEmitter.emit('data', output);
 				mockChildProcess.emit('close', 0);
 			}, 0);
@@ -227,7 +227,7 @@ describe("androidDeviceDiscovery", () => {
 		});
 
 		describe("when device is already found", () => {
-			let defaultAdbOutput = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}${EOL}`;
+			const defaultAdbOutput = `List of devices attached ${EOL}${androidDeviceIdentifier}	${androidDeviceStatus}${EOL}${EOL}`;
 			beforeEach(async () => {
 				let promise: Promise<void>;
 				androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
@@ -271,12 +271,12 @@ describe("androidDeviceDiscovery", () => {
 				});
 
 				setTimeout(() => {
-					let output = `List of devices attached${EOL}`;
+					const output = `List of devices attached${EOL}`;
 					mockStdoutEmitter.emit('data', output);
 					mockChildProcess.emit('close', 0);
 				}, 0);
 				await androidDeviceDiscovery.checkForDevices();
-				let lostDevice = await promise;
+				const lostDevice = await promise;
 				assert.deepEqual(lostDevice.deviceInfo.identifier, androidDeviceIdentifier);
 				assert.deepEqual(lostDevice.deviceInfo.status, androidDeviceStatus);
 			});
@@ -288,7 +288,7 @@ describe("androidDeviceDiscovery", () => {
 					promise = Promise.resolve(device);
 				});
 
-				let output = `List of devices attached${EOL}`;
+				const output = `List of devices attached${EOL}`;
 				setTimeout(() => {
 					mockStdoutEmitter.emit('data', output);
 					mockChildProcess.emit('close', 0);
@@ -296,7 +296,7 @@ describe("androidDeviceDiscovery", () => {
 
 				await androidDeviceDiscovery.checkForDevices();
 
-				let lostDevice = await promise;
+				const lostDevice = await promise;
 				assert.deepEqual(lostDevice.deviceInfo.identifier, androidDeviceIdentifier);
 				assert.deepEqual(lostDevice.deviceInfo.status, androidDeviceStatus);
 
@@ -326,7 +326,7 @@ describe("androidDeviceDiscovery", () => {
 					deviceFoundPromise = Promise.resolve(device);
 				});
 
-				let output = `List of devices attached${EOL}${androidDeviceIdentifier}	unauthorized${EOL}${EOL}`;
+				const output = `List of devices attached${EOL}${androidDeviceIdentifier}	unauthorized${EOL}${EOL}`;
 				setTimeout(() => {
 					mockStdoutEmitter.emit('data', output);
 					mockChildProcess.emit('close', 0);
@@ -334,7 +334,7 @@ describe("androidDeviceDiscovery", () => {
 
 				await androidDeviceDiscovery.checkForDevices();
 
-				let lostDevice = await deviceLostPromise;
+				const lostDevice = await deviceLostPromise;
 				assert.deepEqual(lostDevice.deviceInfo.identifier, androidDeviceIdentifier);
 				assert.deepEqual(lostDevice.deviceInfo.status, androidDeviceStatus);
 
@@ -397,7 +397,7 @@ describe("androidDeviceDiscovery", () => {
 			androidDeviceDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (device: Mobile.IDevice) => {
 				throw new Error("Devices should not be found.");
 			});
-			let error = new Error("ADB Error");
+			const error = new Error("ADB Error");
 			try {
 				setTimeout(() => {
 					mockChildProcess.emit('error', error);

--- a/test/unit-tests/mobile/android-device-file-system.ts
+++ b/test/unit-tests/mobile/android-device-file-system.ts
@@ -9,7 +9,7 @@ import { DevicePlatformsConstants } from "../../../mobile/device-platforms-const
 import * as path from "path";
 import { assert } from "chai";
 
-let myTestAppIdentifier = "org.nativescript.myApp";
+const myTestAppIdentifier = "org.nativescript.myApp";
 let isAdbPushExecuted = false;
 
 class AndroidDebugBridgeMock {
@@ -69,7 +69,7 @@ function mockFsStats(options: { isDirectory: boolean, isFile: boolean }): (fileP
 }
 
 function createTestInjector(): IInjector {
-	let injector = new Yok();
+	const injector = new Yok();
 	injector.register("fs", FileSystem);
 	injector.register("logger", Logger);
 	injector.register("mobileHelper", MobileHelper);
@@ -83,8 +83,8 @@ function createTestInjector(): IInjector {
 }
 
 function createAndroidDeviceFileSystem(injector: IInjector) {
-	let adb = new AndroidDebugBridgeMock();
-	let androidDeviceFileSystem = injector.resolve(AndroidDeviceFileSystem, { "adb": adb, "identifier": myTestAppIdentifier });
+	const adb = new AndroidDebugBridgeMock();
+	const androidDeviceFileSystem = injector.resolve(AndroidDeviceFileSystem, { "adb": adb, "identifier": myTestAppIdentifier });
 	androidDeviceFileSystem.createFileOnDevice = () => Promise.resolve();
 	return androidDeviceFileSystem;
 }
@@ -96,21 +96,21 @@ function createDeviceAppData() {
 describe("Android device file system tests", () => {
 	describe("Transfer directory unit tests", () => {
 		it("pushes the whole directory when hash file doesn't exist on device", async () => {
-			let injector = createTestInjector();
-			let deviceAppData = createDeviceAppData();
+			const injector = createTestInjector();
+			const deviceAppData = createDeviceAppData();
 
-			let fileToShasumDictionary: IStringDictionary = {
+			const fileToShasumDictionary: IStringDictionary = {
 				"~/TestApp/app/test.js": "1",
 				"~/TestApp/app/myfile.js": "2"
 			};
-			let localToDevicePaths = _.keys(fileToShasumDictionary).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
+			const localToDevicePaths = _.keys(fileToShasumDictionary).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
 
-			let fs = injector.resolve("fs");
+			const fs = injector.resolve("fs");
 			fs.getFileShasum = async (filePath: string) => fileToShasumDictionary[filePath];
 			fs.exists = (filePath: string) => false;
 			fs.getFsStats = mockFsStats({ isDirectory: false, isFile: true });
 
-			let androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
+			const androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
 			await androidDeviceFileSystem.transferDirectory(deviceAppData, localToDevicePaths, "~/TestApp/app");
 
 			assert.isTrue(isAdbPushExecuted);
@@ -118,15 +118,15 @@ describe("Android device file system tests", () => {
 		});
 
 		it("pushes the whole directory when force option is specified", async () => {
-			let injector = createTestInjector();
+			const injector = createTestInjector();
 
-			let options = injector.resolve("options");
+			const options = injector.resolve("options");
 			options.force = true;
 
-			let fs = injector.resolve("fs");
+			const fs = injector.resolve("fs");
 			fs.getFileShasum = async (filePath: string) => "0";
 
-			let androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
+			const androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
 			await androidDeviceFileSystem.transferDirectory(createDeviceAppData(), [], "~/TestApp/app");
 
 			assert.isTrue(isAdbPushExecuted);
@@ -134,23 +134,23 @@ describe("Android device file system tests", () => {
 		});
 
 		it("pushes only changed file when hash file exists on device", async () => {
-			let injector = createTestInjector();
-			let deviceAppData = createDeviceAppData();
+			const injector = createTestInjector();
+			const deviceAppData = createDeviceAppData();
 
-			let fileToShasumDictionary: IStringDictionary = {
+			const fileToShasumDictionary: IStringDictionary = {
 				"~/TestApp/app/test.js": "1",
 				"~/TestApp/app/myfile.js": "2"
 			};
-			let localToDevicePaths = _.keys(fileToShasumDictionary).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
+			const localToDevicePaths = _.keys(fileToShasumDictionary).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
 
-			let fs = injector.resolve("fs");
+			const fs = injector.resolve("fs");
 			fs.getFileShasum = async (filePath: string) => fileToShasumDictionary[filePath];
 			fs.exists = (filePath: string) => true;
 			fs.readJson = (filePath: string) => ({ "~/TestApp/app/test.js": "0", "~/TestApp/app/myfile.js": "2" });
 			fs.getFsStats = mockFsStats({ isDirectory: false, isFile: true });
 			fs.readText = () => "";
 
-			let androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
+			const androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
 			let promise: Promise<void>;
 			androidDeviceFileSystem.transferFile = (localPath: string, devicePath: string) => {
 				assert.equal(localPath, "~/TestApp/app/test.js");
@@ -163,25 +163,25 @@ describe("Android device file system tests", () => {
 		});
 
 		it("pushes only changed files when hashes file exists on device", async () => {
-			let injector = createTestInjector();
-			let deviceAppData = createDeviceAppData();
+			const injector = createTestInjector();
+			const deviceAppData = createDeviceAppData();
 
-			let fileToShasumDictionary: IStringDictionary = {
+			const fileToShasumDictionary: IStringDictionary = {
 				"~/TestApp/app/test.js": "1",
 				"~/TestApp/app/myfile.js": "2",
 				"~/TestApp/app/notchangedFile.js": "3"
 			};
-			let localToDevicePaths = _.keys(fileToShasumDictionary).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
+			const localToDevicePaths = _.keys(fileToShasumDictionary).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
 
-			let fs = injector.resolve("fs");
+			const fs = injector.resolve("fs");
 			fs.getFileShasum = async (filePath: string) => fileToShasumDictionary[filePath];
 			fs.exists = (filePath: string) => true;
 			fs.readJson = (filePath: string) => ({ "~/TestApp/app/test.js": "0", "~/TestApp/app/myfile.js": "4", "~/TestApp/app/notchangedFile.js": "3" });
 			fs.getFsStats = mockFsStats({ isDirectory: false, isFile: true });
 			fs.readText = () => "";
 
-			let androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
-			let transferedFilesOnDevice: string[] = [];
+			const androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
+			const transferedFilesOnDevice: string[] = [];
 			androidDeviceFileSystem.transferFile = (localPath: string, devicePath: string) => {
 				transferedFilesOnDevice.push(localPath);
 				return Promise.resolve();
@@ -195,23 +195,23 @@ describe("Android device file system tests", () => {
 		});
 
 		it("pushes files which has different location when hash file exists on device", async () => {
-			let injector = createTestInjector();
-			let deviceAppData = createDeviceAppData();
+			const injector = createTestInjector();
+			const deviceAppData = createDeviceAppData();
 
-			let fileToShasumDictionary: IStringDictionary = {
+			const fileToShasumDictionary: IStringDictionary = {
 				"~/TestApp/app/newDir/test.js": "1",
 				"~/TestApp/app/myfile.js": "2"
 			};
-			let localToDevicePaths = _.keys(fileToShasumDictionary).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
+			const localToDevicePaths = _.keys(fileToShasumDictionary).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
 
-			let fs = injector.resolve("fs");
+			const fs = injector.resolve("fs");
 			fs.getFileShasum = (filePath: string) => fileToShasumDictionary[filePath];
 			fs.exists = (filePath: string) => true;
 			fs.readJson = (filePath: string) => ({ "~/TestApp/app/test.js": "0", "~/TestApp/app/myfile.js": "2" });
 			fs.getFsStats = mockFsStats({ isDirectory: false, isFile: true });
 			fs.readText = () => "";
 
-			let androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
+			const androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
 			androidDeviceFileSystem.transferFile = (localPath: string, devicePath: string) => {
 				assert.equal(localPath, "~/TestApp/app/newDir/test.js");
 				return Promise.resolve();
@@ -220,23 +220,23 @@ describe("Android device file system tests", () => {
 		});
 
 		it("pushes files which has different location and different shasum when hash file exists on device", async () => {
-			let injector = createTestInjector();
-			let deviceAppData = createDeviceAppData();
+			const injector = createTestInjector();
+			const deviceAppData = createDeviceAppData();
 
-			let fileToShasumDictionary: IStringDictionary = {
+			const fileToShasumDictionary: IStringDictionary = {
 				"~/TestApp/app/newDir/test.js": "2",
 				"~/TestApp/app/myfile.js": "2"
 			};
-			let localToDevicePaths = _.keys(fileToShasumDictionary).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
+			const localToDevicePaths = _.keys(fileToShasumDictionary).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
 
-			let fs = injector.resolve("fs");
+			const fs = injector.resolve("fs");
 			fs.getFileShasum = async (filePath: string) => fileToShasumDictionary[filePath];
 			fs.exists = (filePath: string) => true;
 			fs.readJson = (filePath: string) => ({ "~/TestApp/app/test.js": "0", "~/TestApp/app/myfile.js": "2" });
 			fs.getFsStats = mockFsStats({ isDirectory: false, isFile: true });
 			fs.readText = () => "";
 
-			let androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
+			const androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
 			androidDeviceFileSystem.transferFile = (localPath: string, devicePath: string) => {
 				assert.equal(localPath, "~/TestApp/app/newDir/test.js");
 				return Promise.resolve();

--- a/test/unit-tests/mobile/application-manager-base.ts
+++ b/test/unit-tests/mobile/application-manager-base.ts
@@ -3,9 +3,9 @@ import { assert } from "chai";
 import { CommonLoggerStub, HooksServiceStub } from "../stubs";
 import { ApplicationManagerBase } from "../../../mobile/application-manager-base";
 
-let currentlyAvailableAppsForDebugging: Mobile.IDeviceApplicationInformation[],
-	currentlyInstalledApps: string[],
-	currentlyAvailableAppWebViewsForDebugging: IDictionary<Mobile.IDebugWebViewInfo[]>;
+let currentlyAvailableAppsForDebugging: Mobile.IDeviceApplicationInformation[];
+let currentlyInstalledApps: string[];
+let currentlyAvailableAppWebViewsForDebugging: IDictionary<Mobile.IDebugWebViewInfo[]>;
 
 class ApplicationManager extends ApplicationManagerBase {
 	constructor($logger: ILogger, $hooksService: IHooksService) {
@@ -54,7 +54,7 @@ class ApplicationManager extends ApplicationManagerBase {
 }
 
 function createTestInjector(): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("logger", CommonLoggerStub);
 	testInjector.register("hooksService", HooksServiceStub);
 	testInjector.register("applicationManager", ApplicationManager);
@@ -82,7 +82,7 @@ function createDebuggableWebView(uniqueId: string) {
 }
 
 function createDebuggableWebViews(appInfos: Mobile.IDeviceApplicationInformation[], numberOfViews: number): IDictionary<Mobile.IDebugWebViewInfo[]> {
-	let result: IDictionary<Mobile.IDebugWebViewInfo[]> = {};
+	const result: IDictionary<Mobile.IDebugWebViewInfo[]> = {};
 	_.each(appInfos, (appInfo, index) => {
 		result[appInfo.appIdentifier] = _.times(numberOfViews, (currentViewIndex: number) => createDebuggableWebView(`${index}_${currentViewIndex}`));
 	});
@@ -91,8 +91,8 @@ function createDebuggableWebViews(appInfos: Mobile.IDeviceApplicationInformation
 }
 
 describe("ApplicationManagerBase", () => {
-	let applicationManager: ApplicationManager,
-		testInjector: IInjector;
+	let applicationManager: ApplicationManager;
+	let testInjector: IInjector;
 
 	beforeEach(() => {
 		testInjector = createTestInjector();
@@ -105,7 +105,7 @@ describe("ApplicationManagerBase", () => {
 		describe("debuggableApps", () => {
 			it("emits debuggableAppFound when new application is available for debugging", async () => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
-				let foundAppsForDebug: Mobile.IDeviceApplicationInformation[] = [];
+				const foundAppsForDebug: Mobile.IDeviceApplicationInformation[] = [];
 
 				applicationManager.on("debuggableAppFound", (d: Mobile.IDeviceApplicationInformation) => {
 					foundAppsForDebug.push(d);
@@ -121,8 +121,8 @@ describe("ApplicationManagerBase", () => {
 
 			it("emits debuggableAppFound when new application is available for debugging (several calls)", async () => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(1);
-				let foundAppsForDebug: Mobile.IDeviceApplicationInformation[] = [],
-					isFinalCheck = false;
+				const foundAppsForDebug: Mobile.IDeviceApplicationInformation[] = [];
+				let isFinalCheck = false;
 
 				applicationManager.on("debuggableAppFound", (d: Mobile.IDeviceApplicationInformation) => {
 					foundAppsForDebug.push(d);
@@ -147,7 +147,7 @@ describe("ApplicationManagerBase", () => {
 
 			it("emits debuggableAppLost when application cannot be debugged anymore", async () => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
-				let expectedAppsToBeLost = currentlyAvailableAppsForDebugging,
+				const expectedAppsToBeLost = currentlyAvailableAppsForDebugging,
 					lostAppsForDebug: Mobile.IDeviceApplicationInformation[] = [];
 
 				applicationManager.on("debuggableAppLost", (d: Mobile.IDeviceApplicationInformation) => {
@@ -169,9 +169,9 @@ describe("ApplicationManagerBase", () => {
 
 			it("emits debuggableAppLost when application cannot be debugged anymore (several calls)", async () => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(4);
-				let lostAppsForDebug: Mobile.IDeviceApplicationInformation[] = [],
-					isFinalCheck = false,
-					initialAppsAvailableForDebug = currentlyAvailableAppsForDebugging;
+				const lostAppsForDebug: Mobile.IDeviceApplicationInformation[] = [];
+				let isFinalCheck = false;
+				const initialAppsAvailableForDebug = currentlyAvailableAppsForDebugging;
 
 				applicationManager.on("debuggableAppLost", (d: Mobile.IDeviceApplicationInformation) => {
 					lostAppsForDebug.push(d);
@@ -193,16 +193,16 @@ describe("ApplicationManagerBase", () => {
 			});
 
 			it("emits debuggableAppFound and debuggableAppLost when applications are changed", async () => {
-				let allAppsForDebug = createAppsAvailableForDebugging(4);
+				const allAppsForDebug = createAppsAvailableForDebugging(4);
 				currentlyAvailableAppsForDebugging = _.take(allAppsForDebug, 2);
-				let remainingAppsForDebugging = _.difference(allAppsForDebug, currentlyAvailableAppsForDebugging);
+				const remainingAppsForDebugging = _.difference(allAppsForDebug, currentlyAvailableAppsForDebugging);
 
-				let foundAppsForDebug: Mobile.IDeviceApplicationInformation[] = [];
+				const foundAppsForDebug: Mobile.IDeviceApplicationInformation[] = [];
 
 				// This will raise debuggableAppFound 2 times.
 				await applicationManager.checkForApplicationUpdates();
 
-				let foundAppsPromise = new Promise<void>((resolve, reject) => {
+				const foundAppsPromise = new Promise<void>((resolve, reject) => {
 					applicationManager.on("debuggableAppFound", (d: Mobile.IDeviceApplicationInformation) => {
 						foundAppsForDebug.push(d);
 						if (foundAppsForDebug.length === remainingAppsForDebugging.length) {
@@ -215,7 +215,7 @@ describe("ApplicationManagerBase", () => {
 					});
 				});
 
-				let lostAppsPromise = new Promise<void>((resolve, reject) => {
+				const lostAppsPromise = new Promise<void>((resolve, reject) => {
 					applicationManager.on("debuggableAppLost", (d: Mobile.IDeviceApplicationInformation) => {
 						assert.deepEqual(d, allAppsForDebug[0], "Debuggable app lost does not match.");
 						resolve();
@@ -229,19 +229,19 @@ describe("ApplicationManagerBase", () => {
 
 			it("emits debuggableViewFound when new views are available for debug", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
-				let numberOfViewsPerApp = 2;
+				const numberOfViewsPerApp = 2;
 				currentlyAvailableAppWebViewsForDebugging = createDebuggableWebViews(currentlyAvailableAppsForDebugging, numberOfViewsPerApp);
-				let currentDebuggableViews: IDictionary<Mobile.IDebugWebViewInfo[]> = {};
+				const currentDebuggableViews: IDictionary<Mobile.IDebugWebViewInfo[]> = {};
 				applicationManager.on("debuggableViewFound", (appIdentifier: string, d: Mobile.IDebugWebViewInfo) => {
 					currentDebuggableViews[appIdentifier] = currentDebuggableViews[appIdentifier] || [];
 					currentDebuggableViews[appIdentifier].push(d);
-					let numberOfFoundViewsPerApp = _.uniq(_.values(currentDebuggableViews).map(arr => arr.length));
+					const numberOfFoundViewsPerApp = _.uniq(_.values(currentDebuggableViews).map(arr => arr.length));
 					if (_.keys(currentDebuggableViews).length === currentlyAvailableAppsForDebugging.length
 						&& numberOfFoundViewsPerApp.length === 1 // for all apps we've found exactly two apps.
 						&& numberOfFoundViewsPerApp[0] === numberOfViewsPerApp) {
 						_.each(currentDebuggableViews, (webViews, appId) => {
 							_.each(webViews, webView => {
-								let expectedWebView = _.find(currentlyAvailableAppWebViewsForDebugging[appId], c => c.id === webView.id);
+								const expectedWebView = _.find(currentlyAvailableAppWebViewsForDebugging[appId], c => c.id === webView.id);
 								assert.isTrue(_.isEqual(webView, expectedWebView));
 							});
 						});
@@ -254,22 +254,22 @@ describe("ApplicationManagerBase", () => {
 
 			it("emits debuggableViewLost when views for debug are removed", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
-				let numberOfViewsPerApp = 2;
+				const numberOfViewsPerApp = 2;
 				currentlyAvailableAppWebViewsForDebugging = createDebuggableWebViews(currentlyAvailableAppsForDebugging, numberOfViewsPerApp);
-				let expectedResults = _.cloneDeep(currentlyAvailableAppWebViewsForDebugging);
-				let currentDebuggableViews: IDictionary<Mobile.IDebugWebViewInfo[]> = {};
+				const expectedResults = _.cloneDeep(currentlyAvailableAppWebViewsForDebugging);
+				const currentDebuggableViews: IDictionary<Mobile.IDebugWebViewInfo[]> = {};
 
 				applicationManager.checkForApplicationUpdates().then(() => {
 					applicationManager.on("debuggableViewLost", (appIdentifier: string, d: Mobile.IDebugWebViewInfo) => {
 						currentDebuggableViews[appIdentifier] = currentDebuggableViews[appIdentifier] || [];
 						currentDebuggableViews[appIdentifier].push(d);
-						let numberOfFoundViewsPerApp = _.uniq(_.values(currentDebuggableViews).map(arr => arr.length));
+						const numberOfFoundViewsPerApp = _.uniq(_.values(currentDebuggableViews).map(arr => arr.length));
 						if (_.keys(currentDebuggableViews).length === currentlyAvailableAppsForDebugging.length
 							&& numberOfFoundViewsPerApp.length === 1 // for all apps we've found exactly two apps.
 							&& numberOfFoundViewsPerApp[0] === numberOfViewsPerApp) {
 							_.each(currentDebuggableViews, (webViews, appId) => {
 								_.each(webViews, webView => {
-									let expectedWebView = _.find(expectedResults[appId], c => c.id === webView.id);
+									const expectedWebView = _.find(expectedResults[appId], c => c.id === webView.id);
 									assert.isTrue(_.isEqual(webView, expectedWebView));
 								});
 							});
@@ -284,11 +284,11 @@ describe("ApplicationManagerBase", () => {
 
 			it("emits debuggableViewFound when new views are available for debug", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
-				let numberOfViewsPerApp = 2;
+				const numberOfViewsPerApp = 2;
 				currentlyAvailableAppWebViewsForDebugging = createDebuggableWebViews(currentlyAvailableAppsForDebugging, numberOfViewsPerApp);
-				let expectedViewToBeFound = createDebuggableWebView("uniqueId"),
-					expectedAppIdentifier = currentlyAvailableAppsForDebugging[0].appIdentifier,
-					isLastCheck = false;
+				let expectedViewToBeFound = createDebuggableWebView("uniqueId");
+				let expectedAppIdentifier = currentlyAvailableAppsForDebugging[0].appIdentifier;
+				let isLastCheck = false;
 
 				applicationManager.checkForApplicationUpdates().then(() => {
 					applicationManager.on("debuggableViewFound", (appIdentifier: string, d: Mobile.IDebugWebViewInfo) => {
@@ -318,11 +318,11 @@ describe("ApplicationManagerBase", () => {
 
 			it("emits debuggableViewLost when views for debug are not available anymore", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(2);
-				let numberOfViewsPerApp = 2;
+				const numberOfViewsPerApp = 2;
 				currentlyAvailableAppWebViewsForDebugging = createDebuggableWebViews(currentlyAvailableAppsForDebugging, numberOfViewsPerApp);
-				let expectedAppIdentifier = currentlyAvailableAppsForDebugging[0].appIdentifier,
-					expectedViewToBeLost = currentlyAvailableAppWebViewsForDebugging[expectedAppIdentifier].splice(0, 1)[0],
-					isLastCheck = false;
+				let expectedAppIdentifier = currentlyAvailableAppsForDebugging[0].appIdentifier;
+				let expectedViewToBeLost = currentlyAvailableAppWebViewsForDebugging[expectedAppIdentifier].splice(0, 1)[0];
+				let isLastCheck = false;
 
 				applicationManager.checkForApplicationUpdates().then(() => {
 					applicationManager.on("debuggableViewLost", (appIdentifier: string, d: Mobile.IDebugWebViewInfo) => {
@@ -350,8 +350,8 @@ describe("ApplicationManagerBase", () => {
 			it("emits debuggableViewChanged when view's property is modified (each one except id)", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(1);
 				currentlyAvailableAppWebViewsForDebugging = createDebuggableWebViews(currentlyAvailableAppsForDebugging, 2);
-				let viewToChange = currentlyAvailableAppWebViewsForDebugging[currentlyAvailableAppsForDebugging[0].appIdentifier][0];
-				let expectedView = _.cloneDeep(viewToChange);
+				const viewToChange = currentlyAvailableAppWebViewsForDebugging[currentlyAvailableAppsForDebugging[0].appIdentifier][0];
+				const expectedView = _.cloneDeep(viewToChange);
 				expectedView.title = "new title";
 
 				applicationManager.on("debuggableViewChanged", (appIdentifier: string, d: Mobile.IDebugWebViewInfo) => {
@@ -368,8 +368,8 @@ describe("ApplicationManagerBase", () => {
 			it("does not emit debuggableViewChanged when id is modified", (done: mocha.Done) => {
 				currentlyAvailableAppsForDebugging = createAppsAvailableForDebugging(1);
 				currentlyAvailableAppWebViewsForDebugging = createDebuggableWebViews(currentlyAvailableAppsForDebugging, 2);
-				let viewToChange = currentlyAvailableAppWebViewsForDebugging[currentlyAvailableAppsForDebugging[0].appIdentifier][0];
-				let expectedView = _.cloneDeep(viewToChange);
+				const viewToChange = currentlyAvailableAppWebViewsForDebugging[currentlyAvailableAppsForDebugging[0].appIdentifier][0];
+				const expectedView = _.cloneDeep(viewToChange);
 
 				applicationManager.checkForApplicationUpdates().then(() => {
 					applicationManager.on("debuggableViewChanged", (appIdentifier: string, d: Mobile.IDebugWebViewInfo) => {
@@ -395,7 +395,7 @@ describe("ApplicationManagerBase", () => {
 			it("reports installed applications when initially there are apps", async () => {
 				currentlyInstalledApps = ["app1", "app2", "app3"];
 
-				let reportedInstalledApps: string[] = [],
+				const reportedInstalledApps: string[] = [],
 					promise = new Promise<void>((resolve, reject) => {
 						applicationManager.on("applicationInstalled", (app: string) => {
 							reportedInstalledApps.push(app);
@@ -418,10 +418,10 @@ describe("ApplicationManagerBase", () => {
 			it("reports installed applications when apps are changed between executions", async () => {
 				currentlyInstalledApps = ["app1", "app2", "app3"];
 
-				let reportedInstalledApps: string[] = [],
-					promise: Promise<void>;
+				const reportedInstalledApps: string[] = [];
+				let promise: Promise<void>;
 
-				let testInstalledAppsResults = async () => {
+				const testInstalledAppsResults = async () => {
 					promise = new Promise<void>((resolve, reject) => {
 						applicationManager.on("applicationInstalled", (app: string) => {
 							reportedInstalledApps.push(app);
@@ -454,7 +454,7 @@ describe("ApplicationManagerBase", () => {
 				currentlyInstalledApps = ["app1", "app2", "app3"];
 				await applicationManager.checkForApplicationUpdates();
 
-				let reportedUninstalledApps: string[] = [],
+				const reportedUninstalledApps: string[] = [],
 					initiallyInstalledApps = _.cloneDeep(currentlyInstalledApps),
 					promise = new Promise<void>((resolve, reject) => {
 						currentlyInstalledApps = [];
@@ -482,11 +482,11 @@ describe("ApplicationManagerBase", () => {
 				// Initialize - all apps are marked as installed.
 				await applicationManager.checkForApplicationUpdates();
 
-				let reportedUninstalledApps: string[] = [],
-					removedApps: string[] = [],
-					promise: Promise<void>;
+				const reportedUninstalledApps: string[] = [];
+				let removedApps: string[] = [];
+				let promise: Promise<void>;
 
-				let testInstalledAppsResults = async () => {
+				const testInstalledAppsResults = async () => {
 					promise = new Promise<void>((resolve, reject) => {
 						applicationManager.on("applicationUninstalled", (app: string) => {
 							reportedUninstalledApps.push(app);
@@ -508,7 +508,7 @@ describe("ApplicationManagerBase", () => {
 				};
 
 				while (currentlyInstalledApps.length) {
-					let currentlyRemovedApps = currentlyInstalledApps.splice(0, 2);
+					const currentlyRemovedApps = currentlyInstalledApps.splice(0, 2);
 					removedApps = removedApps.concat(currentlyRemovedApps);
 					await testInstalledAppsResults();
 				}
@@ -518,14 +518,14 @@ describe("ApplicationManagerBase", () => {
 				currentlyInstalledApps = ["app1", "app2", "app3", "app4", "app5", "app6"];
 				await applicationManager.checkForApplicationUpdates();
 
-				let reportedUninstalledApps: string[] = [],
-					reportedInstalledApps: string[] = [],
-					installedApps: string[] = [],
-					removedApps: string[] = [],
-					appUninstalledPromise: Promise<void>,
-					appInstalledPromise: Promise<void>;
+				const reportedUninstalledApps: string[] = [];
+				const reportedInstalledApps: string[] = [];
+				let installedApps: string[] = [];
+				let removedApps: string[] = [];
+				let appUninstalledPromise: Promise<void>;
+				let appInstalledPromise: Promise<void>;
 
-				let testInstalledAppsResults = async () => {
+				const testInstalledAppsResults = async () => {
 					appInstalledPromise = new Promise<void>((resolve, reject) => {
 						applicationManager.on("applicationInstalled", (app: string) => {
 							reportedInstalledApps.push(app);
@@ -564,10 +564,10 @@ describe("ApplicationManagerBase", () => {
 				};
 
 				for (let index = 10; index < 13; index++) {
-					let currentlyRemovedApps = currentlyInstalledApps.splice(0, 2);
+					const currentlyRemovedApps = currentlyInstalledApps.splice(0, 2);
 					removedApps = removedApps.concat(currentlyRemovedApps);
 
-					let currentlyAddedApps = [`app${index}`];
+					const currentlyAddedApps = [`app${index}`];
 					currentlyInstalledApps = currentlyInstalledApps.concat(currentlyAddedApps);
 					installedApps = installedApps.concat(currentlyAddedApps);
 
@@ -618,8 +618,8 @@ describe("ApplicationManagerBase", () => {
 		});
 
 		it("calls stopApplication and startApplication in correct order", async () => {
-			let isStartApplicationCalled = false,
-				isStopApplicationCalled = false;
+			let isStartApplicationCalled = false;
+			let isStopApplicationCalled = false;
 
 			applicationManager.stopApplication = (appId: string) => {
 				isStopApplicationCalled = true;
@@ -668,7 +668,7 @@ describe("ApplicationManagerBase", () => {
 		});
 
 		describe("does not throw Error", () => {
-			let error = new Error("Throw!");
+			const error = new Error("Throw!");
 			let isStartApplicationCalled = false;
 			let logger: CommonLoggerStub;
 
@@ -677,7 +677,7 @@ describe("ApplicationManagerBase", () => {
 				logger = testInjector.resolve("logger");
 			});
 
-			let assertDoesNotThrow = async (opts?: { shouldStartApplicatinThrow: boolean }) => {
+			const assertDoesNotThrow = async (opts?: { shouldStartApplicatinThrow: boolean }) => {
 				assert.deepEqual(logger.traceOutput, "");
 				applicationManager.startApplication = async (appId: string) => {
 					if (opts && opts.shouldStartApplicatinThrow) {
@@ -736,8 +736,8 @@ describe("ApplicationManagerBase", () => {
 		});
 
 		it("calls uninstallApplication and installApplication in correct order", async () => {
-			let isInstallApplicationCalled = false,
-				isUninstallApplicationCalled = false;
+			let isInstallApplicationCalled = false;
+			let isUninstallApplicationCalled = false;
 
 			applicationManager.isApplicationInstalled = (appIdentifier: string) => Promise.resolve(true);
 

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from "events";
 import { assert, use } from "chai";
 import * as util from "util";
 
-let chaiAsPromised = require('chai-as-promised');
+const chaiAsPromised = require('chai-as-promised');
 use(chaiAsPromised);
 
 import { CommonLoggerStub, ErrorsStub } from "../stubs";
@@ -67,27 +67,27 @@ function getErrorMessage(injector: IInjector, message: string, ...args: string[]
 		..._.concat(args, injector.resolve("staticConfig").CLIENT_NAME.toLowerCase()));
 }
 
-let androidDeviceDiscovery: EventEmitter,
-	iOSDeviceDiscovery: EventEmitter,
-	iOSSimulatorDiscovery: EventEmitter,
-	androidEmulatorDevice: any = { deviceInfo: { identifier: "androidEmulatorDevice", platform: "android" }, isEmulator: true },
-	iOSSimulator = {
-		deviceInfo: {
-			identifier: "ios-simulator-device",
-			platform: "ios"
-		},
-		applicationManager: {
-			getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2"]),
-			canStartApplication: () => true,
-			startApplication: (packageName: string, framework: string) => Promise.resolve(),
-			tryStartApplication: (packageName: string, framework: string) => Promise.resolve(),
-			reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
-			isApplicationInstalled: (packageName: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2"], packageName)),
-			isLiveSyncSupported: (appIdentifier: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2"], appIdentifier))
-		},
-		deploy: (packageFile: string, packageName: string) => Promise.resolve(),
-		isEmulator: true
-	};
+let androidDeviceDiscovery: EventEmitter;
+let iOSDeviceDiscovery: EventEmitter;
+let iOSSimulatorDiscovery: EventEmitter;
+const androidEmulatorDevice: any = { deviceInfo: { identifier: "androidEmulatorDevice", platform: "android" }, isEmulator: true };
+const iOSSimulator = {
+	deviceInfo: {
+		identifier: "ios-simulator-device",
+		platform: "ios"
+	},
+	applicationManager: {
+		getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2"]),
+		canStartApplication: () => true,
+		startApplication: (packageName: string, framework: string) => Promise.resolve(),
+		tryStartApplication: (packageName: string, framework: string) => Promise.resolve(),
+		reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
+		isApplicationInstalled: (packageName: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2"], packageName)),
+		isLiveSyncSupported: (appIdentifier: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2"], appIdentifier))
+	},
+	deploy: (packageFile: string, packageName: string) => Promise.resolve(),
+	isEmulator: true
+};
 
 class AndroidEmulatorServices {
 	public isStartEmulatorCalled = false;
@@ -116,7 +116,7 @@ class IOSEmulatorServices {
 }
 
 function createTestInjector(): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("logger", CommonLoggerStub);
 	testInjector.register("errors", ErrorsStub);
 	testInjector.register("iOSDeviceDiscovery", IOSDeviceDiscoveryStub);
@@ -166,9 +166,9 @@ async function throwErrorFunction(): Promise<void> {
 }
 
 const getPromisesResults = async (promises: Promise<any>[]): Promise<any[]> => {
-	let results: any = [];
+	const results: any = [];
 	for (let i = 0; i < promises.length; i++) {
-		let currentResult: any = {};
+		const currentResult: any = {};
 		try {
 			currentResult.result = await promises[i];
 		} catch (err) {
@@ -182,12 +182,12 @@ const getPromisesResults = async (promises: Promise<any>[]): Promise<any[]> => {
 };
 
 let intervalId = 1;
-let nodeJsTimer = {
+const nodeJsTimer = {
 	ref: () => { /* no implementation required */ },
 	unref: () => { return intervalId++; }
 };
 
-let originalSetInterval = setInterval;
+const originalSetInterval = setInterval;
 function mockSetInterval(testCaseCallback?: Function): void {
 	global.setInterval = (callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer => {
 		const execution = async () => {
@@ -209,49 +209,50 @@ function resetDefaultSetInterval(): void {
 }
 
 describe("devicesService", () => {
-	let counter = 0,
-		iOSDevice = {
-			deviceInfo: {
-				identifier: "ios-device",
-				platform: "ios",
-				status: constants.CONNECTED_STATUS
-			},
-			applicationManager: {
-				getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2"]),
-				canStartApplication: () => true,
-				startApplication: (packageName: string, framework: string) => Promise.resolve(),
-				tryStartApplication: (packageName: string, framework: string) => Promise.resolve(),
-				reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
-				isApplicationInstalled: (packageName: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2"], packageName)),
-				isLiveSyncSupported: (appIdentifier: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2"], appIdentifier)),
-				checkForApplicationUpdates: (): Promise<void> => Promise.resolve(),
-				getDebuggableApps: (): Promise<Mobile.IDeviceApplicationInformation[]> => Promise.resolve(null),
-				getDebuggableAppViews: (appIdentifiers: string[]): Promise<IDictionary<Mobile.IDebugWebViewInfo[]>> => Promise.resolve(null)
-			}
+	let counter = 0;
+	const iOSDevice = {
+		deviceInfo: {
+			identifier: "ios-device",
+			platform: "ios",
+			status: constants.CONNECTED_STATUS
 		},
-		androidDevice = {
-			deviceInfo: {
-				identifier: "android-device",
-				platform: "android",
-				status: constants.CONNECTED_STATUS
-			},
-			applicationManager: {
-				getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"]),
-				canStartApplication: () => true,
-				startApplication: (packageName: string, framework: string) => Promise.resolve(),
-				tryStartApplication: (packageName: string, framework: string) => Promise.resolve(),
-				reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
-				isApplicationInstalled: (packageName: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"], packageName)),
-				isLiveSyncSupported: (appIdentifier: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"], appIdentifier)),
-				checkForApplicationUpdates: (): Promise<void> => Promise.resolve(),
-				getDebuggableApps: (): Promise<Mobile.IDeviceApplicationInformation[]> => Promise.resolve(null),
-				getDebuggableAppViews: (appIdentifiers: string[]): Promise<IDictionary<Mobile.IDebugWebViewInfo[]>> => Promise.resolve(null)
-			}
+		applicationManager: {
+			getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2"]),
+			canStartApplication: () => true,
+			startApplication: (packageName: string, framework: string) => Promise.resolve(),
+			tryStartApplication: (packageName: string, framework: string) => Promise.resolve(),
+			reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
+			isApplicationInstalled: (packageName: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2"], packageName)),
+			isLiveSyncSupported: (appIdentifier: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2"], appIdentifier)),
+			checkForApplicationUpdates: (): Promise<void> => Promise.resolve(),
+			getDebuggableApps: (): Promise<Mobile.IDeviceApplicationInformation[]> => Promise.resolve(null),
+			getDebuggableAppViews: (appIdentifiers: string[]): Promise<IDictionary<Mobile.IDebugWebViewInfo[]>> => Promise.resolve(null)
+		}
+	};
+
+	const androidDevice = {
+		deviceInfo: {
+			identifier: "android-device",
+			platform: "android",
+			status: constants.CONNECTED_STATUS
 		},
-		testInjector: IInjector,
-		devicesService: Mobile.IDevicesService,
-		androidEmulatorServices: any,
-		logger: CommonLoggerStub;
+		applicationManager: {
+			getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"]),
+			canStartApplication: () => true,
+			startApplication: (packageName: string, framework: string) => Promise.resolve(),
+			tryStartApplication: (packageName: string, framework: string) => Promise.resolve(),
+			reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
+			isApplicationInstalled: (packageName: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"], packageName)),
+			isLiveSyncSupported: (appIdentifier: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"], appIdentifier)),
+			checkForApplicationUpdates: (): Promise<void> => Promise.resolve(),
+			getDebuggableApps: (): Promise<Mobile.IDeviceApplicationInformation[]> => Promise.resolve(null),
+			getDebuggableAppViews: (appIdentifiers: string[]): Promise<IDictionary<Mobile.IDebugWebViewInfo[]>> => Promise.resolve(null)
+		}
+	};
+	let testInjector: IInjector;
+	let devicesService: Mobile.IDevicesService;
+	let androidEmulatorServices: any;
+	let logger: CommonLoggerStub;
 
 	beforeEach(() => {
 		testInjector = createTestInjector();
@@ -267,7 +268,7 @@ describe("devicesService", () => {
 	it("attaches to events when a new DevicesService is instantiated", () => {
 		iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
 		androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
-		let devices = devicesService.getDeviceInstances();
+		const devices = devicesService.getDeviceInstances();
 		assert.isTrue(devicesService.hasDevices, "After emitting two devices, hasDevices must be true");
 		assert.deepEqual(devices[0], iOSDevice);
 		assert.deepEqual(devices[1], androidDevice);
@@ -279,7 +280,7 @@ describe("devicesService", () => {
 		assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 		customDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
 		customDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
-		let devices = devicesService.getDeviceInstances();
+		const devices = devicesService.getDeviceInstances();
 		assert.isTrue(devicesService.hasDevices, "After emitting two devices, hasDevices must be true");
 		assert.deepEqual(devices[0], iOSDevice);
 		assert.deepEqual(devices[1], androidDevice);
@@ -402,7 +403,7 @@ describe("devicesService", () => {
 			assert.deepEqual(devicesService.getDeviceInstances(), [], "Initially getDevicesInstances must return empty array.");
 			assert.deepEqual(devicesService.getDevices(), [], "Initially getDevices must return empty array.");
 
-			let tempDevice = { deviceInfo: { identifier: "temp-device" } };
+			const tempDevice = { deviceInfo: { identifier: "temp-device" } };
 			androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
 			androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, tempDevice);
 			assert.deepEqual(devicesService.getDeviceInstances(), [androidDevice, tempDevice]);
@@ -421,13 +422,13 @@ describe("devicesService", () => {
 		});
 
 		it("returns true for each device on which the app is installed", async () => {
-			let deviceIdentifiers = [androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier],
+			const deviceIdentifiers = [androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier],
 				appId = "com.telerik.unitTest1";
-			let results = await devicesService.isAppInstalledOnDevices(deviceIdentifiers, appId, "cordova");
+			const results = await devicesService.isAppInstalledOnDevices(deviceIdentifiers, appId, "cordova");
 			assert.isTrue(results.length > 0);
 
 			for (let index = 0; index < results.length; index++) {
-				let realResult = await results[index];
+				const realResult = await results[index];
 				assert.isTrue(realResult.isInstalled);
 				assert.deepEqual(realResult.appIdentifier, appId);
 				assert.deepEqual(realResult.deviceIdentifier, deviceIdentifiers[index]);
@@ -436,21 +437,21 @@ describe("devicesService", () => {
 		});
 
 		it("returns false for each device on which the app is not installed", async () => {
-			let results = devicesService.isAppInstalledOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "com.telerik.unitTest3", "cordova");
+			const results = devicesService.isAppInstalledOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "com.telerik.unitTest3", "cordova");
 			assert.isTrue(results.length > 0);
 			const isInstalledOnDevices = (await Promise.all(results)).map(r => r.isInstalled);
 			assert.deepEqual(isInstalledOnDevices, [true, false]);
 		});
 
 		it("throws error when invalid identifier is passed", async () => {
-			let results = devicesService.isAppInstalledOnDevices(["invalidDeviceId", iOSDevice.deviceInfo.identifier], "com.telerik.unitTest1", "cordova");
+			const results = devicesService.isAppInstalledOnDevices(["invalidDeviceId", iOSDevice.deviceInfo.identifier], "com.telerik.unitTest1", "cordova");
 
-			let expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIdentifierErrorMessageWithIdentifier", "invalidDeviceId");
+			const expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIdentifierErrorMessageWithIdentifier", "invalidDeviceId");
 
 			await assert.isRejected(Promise.all(results), expectedErrorMessage);
 
 			_.each(await getPromisesResults(results), promiseResult => {
-				let error = promiseResult.error;
+				const error = promiseResult.error;
 				if (error) {
 					assert.isTrue(error.message.indexOf("invalidDeviceId") !== -1, "The message must contain the id of the invalid device.");
 				} else {
@@ -461,7 +462,7 @@ describe("devicesService", () => {
 	});
 
 	describe("initialize and other methods behavior after initialze work correctly", () => {
-		let tempDevice = {
+		const tempDevice = {
 			deviceInfo: {
 				identifier: "temp-device",
 				platform: "android"
@@ -475,7 +476,7 @@ describe("devicesService", () => {
 
 		describe("when initialize is called with platform and deviceId and device's platform is the same as passed one", () => {
 
-			let assertAllMethodsResults = async (deviceId: string) => {
+			const assertAllMethodsResults = async (deviceId: string) => {
 				assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 				androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
 				await devicesService.initialize({ platform: "android", deviceId: deviceId });
@@ -511,12 +512,12 @@ describe("devicesService", () => {
 			});
 
 			it("fails when deviceId is invalid index (less than 0)", async () => {
-				let expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIndexErrorMessage", "-2");
+				const expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIndexErrorMessage", "-2");
 				await assert.isRejected(devicesService.initialize({ platform: "android", deviceId: "-1" }), expectedErrorMessage);
 			});
 
 			it("fails when deviceId is invalid index (more than currently connected devices)", async () => {
-				let expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIndexErrorMessage", "99");
+				const expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIndexErrorMessage", "99");
 				await assert.isRejected(devicesService.initialize({ platform: "android", deviceId: "100" }), expectedErrorMessage);
 			});
 
@@ -529,14 +530,14 @@ describe("devicesService", () => {
 			it("does not fail when androidDeviceDiscovery startLookingForDevices fails", async () => {
 				(<any>androidDeviceDiscovery).startLookingForDevices = (): Promise<void> => { throw new Error("my error"); };
 				iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
-				let hostInfo = testInjector.resolve("hostInfo");
+				const hostInfo = testInjector.resolve("hostInfo");
 				hostInfo.isDarwin = true;
 				await devicesService.initialize({ platform: "ios", deviceId: iOSDevice.deviceInfo.identifier });
 				assert.isTrue(logger.traceOutput.indexOf("my error") !== -1);
 			});
 
 			it("does not fail when iosSimulatorDiscovery startLookingForDevices fails", async () => {
-				let hostInfo = testInjector.resolve("hostInfo");
+				const hostInfo = testInjector.resolve("hostInfo");
 				hostInfo.isDarwin = true;
 				(<any>iOSSimulatorDiscovery).startLookingForDevices = (): Promise<void> => { throw new Error("my error"); };
 				iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
@@ -548,7 +549,7 @@ describe("devicesService", () => {
 		it("when initialize is called with platform and deviceId and such device cannot be found", async () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 
-			let expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIdentifierErrorMessageWithIdentifier", androidDevice.deviceInfo.identifier);
+			const expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIdentifierErrorMessageWithIdentifier", androidDevice.deviceInfo.identifier);
 			await assert.isRejected(devicesService.initialize({ platform: "android", deviceId: androidDevice.deviceInfo.identifier }), expectedErrorMessage);
 		});
 
@@ -568,7 +569,7 @@ describe("devicesService", () => {
 
 		describe("when only deviceIdentifier is passed", () => {
 
-			let assertAllMethodsResults = async (deviceId: string) => {
+			const assertAllMethodsResults = async (deviceId: string) => {
 				assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 				androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
 				await devicesService.initialize({ deviceId: deviceId });
@@ -607,12 +608,12 @@ describe("devicesService", () => {
 			});
 
 			it("fails when deviceId is invalid index (less than 0)", async () => {
-				let expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIndexErrorMessage", "-2");
+				const expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIndexErrorMessage", "-2");
 				await assert.isRejected(devicesService.initialize({ deviceId: "-1" }), expectedErrorMessage);
 			});
 
 			it("fails when deviceId is invalid index (more than currently connected devices)", async () => {
-				let expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIndexErrorMessage", "99");
+				const expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIndexErrorMessage", "99");
 				await assert.isRejected(devicesService.initialize({ deviceId: "100" }), expectedErrorMessage);
 			});
 
@@ -811,9 +812,9 @@ describe("devicesService", () => {
 
 		describe("when options.emulator is true on non-Darwin OS", () => {
 			beforeEach(() => {
-				let options = testInjector.resolve("options");
+				const options = testInjector.resolve("options");
 				options.emulator = true;
-				let hostInfo = testInjector.resolve("hostInfo");
+				const hostInfo = testInjector.resolve("hostInfo");
 				hostInfo.isDarwin = false;
 			});
 
@@ -849,9 +850,9 @@ describe("devicesService", () => {
 
 		describe("does not fail on Darwin when trying to use iOS simulator", () => {
 			beforeEach(() => {
-				let options = testInjector.resolve("options");
+				const options = testInjector.resolve("options");
 				options.emulator = true;
-				let hostInfo = testInjector.resolve("hostInfo");
+				const hostInfo = testInjector.resolve("hostInfo");
 				hostInfo.isDarwin = true;
 			});
 
@@ -897,16 +898,16 @@ describe("devicesService", () => {
 
 	describe("setLogLevel", () => {
 		it("calls deviceLogProvider's setLogLevel with correct arguments", () => {
-			let deviceLogProvider = testInjector.resolve("deviceLogProvider");
-			let actualLogLevel: string = null,
-				actualDeviceIdentifier: string = null;
+			const deviceLogProvider = testInjector.resolve("deviceLogProvider");
+			let actualLogLevel: string = null;
+			let actualDeviceIdentifier: string = null;
 
 			deviceLogProvider.setLogLevel = (logLevel: string, deviceIdentifier?: string) => {
 				actualLogLevel = logLevel;
 				actualDeviceIdentifier = deviceIdentifier;
 			};
 
-			let expectedLogLevel = "expectedLogLevel",
+			const expectedLogLevel = "expectedLogLevel",
 				expectedDeviceId = "expcetedDeviceId";
 
 			devicesService.setLogLevel(expectedLogLevel, expectedDeviceId);
@@ -926,10 +927,10 @@ describe("devicesService", () => {
 		});
 
 		it("returns undefined for each device on which the app is installed", async () => {
-			let results = devicesService.deployOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "path", "packageName", "cordova");
+			const results = devicesService.deployOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "path", "packageName", "cordova");
 			assert.isTrue(results.length > 0);
 			_.each(await Promise.all(results), deployOnDevicesResult => {
-				let realResult = deployOnDevicesResult;
+				const realResult = deployOnDevicesResult;
 				assert.isTrue(realResult === undefined, "On success, undefined should be returned.");
 			});
 		});
@@ -940,19 +941,19 @@ describe("devicesService", () => {
 				throw new Error("Start application must not be called for iOSDevice when canStartApplication returns false.");
 			};
 
-			let results = devicesService.deployOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "path", "packageName", "cordova");
+			const results = devicesService.deployOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "path", "packageName", "cordova");
 			assert.isTrue(results.length > 0);
 			const deployOnDevicesResults = await Promise.all(results);
 			assert.deepEqual(deployOnDevicesResults, [undefined, undefined]);
 		});
 
 		it("throws error when invalid identifier is passed", async () => {
-			let results = devicesService.deployOnDevices(["invalidDeviceId", iOSDevice.deviceInfo.identifier], "path", "packageName", "cordova");
-			let expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIdentifierErrorMessageWithIdentifier", "invalidDeviceId");
+			const results = devicesService.deployOnDevices(["invalidDeviceId", iOSDevice.deviceInfo.identifier], "path", "packageName", "cordova");
+			const expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIdentifierErrorMessageWithIdentifier", "invalidDeviceId");
 			await assert.isRejected(Promise.all(results), expectedErrorMessage);
-			let realResults = await getPromisesResults(results);
+			const realResults = await getPromisesResults(results);
 			_.each(realResults, singlePromiseResult => {
-				let error = singlePromiseResult.error;
+				const error = singlePromiseResult.error;
 				if (error) {
 					assert.isTrue(error.message.indexOf("invalidDeviceId") !== -1, "The message must contain the id of the invalid device.");
 				} else {
@@ -974,7 +975,7 @@ describe("devicesService", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 			androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
 			iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
-			let tempDeviceInstance = { deviceInfo: { identifier: "temp-device", platform: "android" } };
+			const tempDeviceInstance = { deviceInfo: { identifier: "temp-device", platform: "android" } };
 			androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, tempDeviceInstance);
 			assert.deepEqual(devicesService.getDevicesForPlatform("android"), [androidDevice, tempDeviceInstance]);
 			assert.deepEqual(devicesService.getDevicesForPlatform("ios"), [iOSDevice]);
@@ -985,7 +986,7 @@ describe("devicesService", () => {
 			assert.isFalse(devicesService.hasDevices, "Initially devicesService hasDevices must be false.");
 			androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
 			iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
-			let tempDeviceInstance = { deviceInfo: { identifier: "temp-device", platform: "AndroId" } };
+			const tempDeviceInstance = { deviceInfo: { identifier: "temp-device", platform: "AndroId" } };
 			androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, tempDeviceInstance);
 			assert.deepEqual(devicesService.getDevicesForPlatform("android"), [androidDevice, tempDeviceInstance]);
 			assert.deepEqual(devicesService.getDevicesForPlatform("ios"), [iOSDevice]);
@@ -1114,7 +1115,7 @@ describe("devicesService", () => {
 
 	describe("isCompanionAppInstalledOnAllDevices", () => {
 		let $companionAppsService: ICompanionAppsService;
-		let deviceIdentifiers = [iOSDevice.deviceInfo.identifier, androidDevice.deviceInfo.identifier];
+		const deviceIdentifiers = [iOSDevice.deviceInfo.identifier, androidDevice.deviceInfo.identifier];
 
 		beforeEach(() => {
 			$companionAppsService = testInjector.resolve("companionAppsService");
@@ -1126,40 +1127,40 @@ describe("devicesService", () => {
 		});
 
 		it("should return correct result for all of the devices passed as argument.", async () => {
-			let expectedResult = [true, true];
+			const expectedResult = [true, true];
 			mockIsAppInstalled([iOSDevice, androidDevice], expectedResult);
-			let isAppInstalledOnDevices = await Promise.all(devicesService.isCompanionAppInstalledOnDevices(deviceIdentifiers, constants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova));
-			let result = _.map(isAppInstalledOnDevices, (appInstalledInfo: IAppInstalledInfo) => appInstalledInfo.isInstalled);
+			const isAppInstalledOnDevices = await Promise.all(devicesService.isCompanionAppInstalledOnDevices(deviceIdentifiers, constants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova));
+			const result = _.map(isAppInstalledOnDevices, (appInstalledInfo: IAppInstalledInfo) => appInstalledInfo.isInstalled);
 
 			assert.deepEqual(result.length, deviceIdentifiers.length);
 		});
 
 		it("should return correct result when all of the devices have the companion app installed.", async () => {
-			let expectedResult = [true, true];
+			const expectedResult = [true, true];
 			mockIsAppInstalled([iOSDevice, androidDevice], expectedResult);
 
-			let isAppInstalledOnDevices = await Promise.all(devicesService.isCompanionAppInstalledOnDevices(deviceIdentifiers, constants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova));
-			let result = _.map(isAppInstalledOnDevices, (appInstalledInfo: IAppInstalledInfo) => appInstalledInfo.isInstalled);
+			const isAppInstalledOnDevices = await Promise.all(devicesService.isCompanionAppInstalledOnDevices(deviceIdentifiers, constants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova));
+			const result = _.map(isAppInstalledOnDevices, (appInstalledInfo: IAppInstalledInfo) => appInstalledInfo.isInstalled);
 
 			assert.deepEqual(result, expectedResult);
 		});
 
 		it("should return correct result when some of the devices have the companion app installed.", async () => {
-			let expectedResult = [true, false];
+			const expectedResult = [true, false];
 			mockIsAppInstalled([iOSDevice, androidDevice], expectedResult);
 
-			let isAppInstalledOnDevices = await Promise.all(devicesService.isCompanionAppInstalledOnDevices(deviceIdentifiers, constants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova));
-			let result = _.map(isAppInstalledOnDevices, (appInstalledInfo: IAppInstalledInfo) => appInstalledInfo.isInstalled);
+			const isAppInstalledOnDevices = await Promise.all(devicesService.isCompanionAppInstalledOnDevices(deviceIdentifiers, constants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova));
+			const result = _.map(isAppInstalledOnDevices, (appInstalledInfo: IAppInstalledInfo) => appInstalledInfo.isInstalled);
 
 			assert.deepEqual(result, expectedResult);
 		});
 
 		it("should return correct result when none of the devices have the companion app installed.", async () => {
-			let expectedResult = [false, false];
+			const expectedResult = [false, false];
 			mockIsAppInstalled([iOSDevice, androidDevice], expectedResult);
 
-			let isAppInstalledOnDevices = await Promise.all(devicesService.isCompanionAppInstalledOnDevices(deviceIdentifiers, constants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova));
-			let result = _.map(isAppInstalledOnDevices, (appInstalledInfo: IAppInstalledInfo) => appInstalledInfo.isInstalled);
+			const isAppInstalledOnDevices = await Promise.all(devicesService.isCompanionAppInstalledOnDevices(deviceIdentifiers, constants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova));
+			const result = _.map(isAppInstalledOnDevices, (appInstalledInfo: IAppInstalledInfo) => appInstalledInfo.isInstalled);
 
 			assert.deepEqual(result, expectedResult);
 		});
@@ -1368,7 +1369,7 @@ describe("devicesService", () => {
 				iOSDevice.applicationManager.checkForApplicationUpdates = throwErrorFunction;
 				androidDevice.applicationManager.checkForApplicationUpdates = throwErrorFunction;
 
-				let callback = () => {
+				const callback = () => {
 					devicesService.startDeviceDetectionInterval.call(devicesService);
 				};
 
@@ -1457,13 +1458,13 @@ describe("devicesService", () => {
 	});
 
 	it("should call mapAbstractToTcpPort of android process service with the same parameters.", async () => {
-		let expectedDeviceIdentifier = "123456789";
-		let expectedAppIdentifier = "com.telerik.myapp";
-		let expectedFramework = constants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova;
+		const expectedDeviceIdentifier = "123456789";
+		const expectedAppIdentifier = "com.telerik.myapp";
+		const expectedFramework = constants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova;
 		let actualDeviceIdentifier: string;
 		let actualAppIdentifier: string;
 		let actualFramework: string;
-		let $androidProcessService: Mobile.IAndroidProcessService = testInjector.resolve("androidProcessService");
+		const $androidProcessService: Mobile.IAndroidProcessService = testInjector.resolve("androidProcessService");
 		$androidProcessService.mapAbstractToTcpPort = async (deviceIdentifier: string, appIdentifier: string, framework: string): Promise<string> => {
 			actualDeviceIdentifier = deviceIdentifier;
 			actualAppIdentifier = appIdentifier;
@@ -1479,13 +1480,13 @@ describe("devicesService", () => {
 	});
 
 	it("should get debuggable apps correctly for multiple devices.", async () => {
-		let $iOSDeviceDiscovery: Mobile.IDeviceDiscovery = testInjector.resolve("iOSDeviceDiscovery");
-		let $androidDeviceDiscovery: Mobile.IAndroidDeviceDiscovery = testInjector.resolve("androidDeviceDiscovery");
+		const $iOSDeviceDiscovery: Mobile.IDeviceDiscovery = testInjector.resolve("iOSDeviceDiscovery");
+		const $androidDeviceDiscovery: Mobile.IAndroidDeviceDiscovery = testInjector.resolve("androidDeviceDiscovery");
 
 		$androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
 		$iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
 
-		let androidDebuggableApps = [{
+		const androidDebuggableApps = [{
 			appIdentifier: "com.telerik.myapp",
 			deviceIdentifier: androidDevice.deviceInfo.identifier,
 			framework: constants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova
@@ -1495,7 +1496,7 @@ describe("devicesService", () => {
 			framework: constants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript
 		}];
 
-		let iosDebuggableApps = [{
+		const iosDebuggableApps = [{
 			appIdentifier: "com.telerik.myapp2",
 			deviceIdentifier: iOSDevice.deviceInfo.identifier,
 			framework: constants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova
@@ -1522,7 +1523,7 @@ describe("devicesService", () => {
 
 	describe("getDebuggableViews", () => {
 		let $androidDeviceDiscovery: Mobile.IAndroidDeviceDiscovery;
-		let debuggableViews: Mobile.IDebugWebViewInfo[] = [{
+		const debuggableViews: Mobile.IDebugWebViewInfo[] = [{
 			description: "descrition",
 			webSocketDebuggerUrl: "debugurl",
 			url: "url",
@@ -1548,24 +1549,24 @@ describe("devicesService", () => {
 
 		it("should get the correct debuggable views.", async () => {
 			androidDevice.applicationManager.getDebuggableAppViews = async (appIdentifiers: string[]): Promise<IDictionary<Mobile.IDebugWebViewInfo[]>> => {
-				let result: any = {};
+				const result: any = {};
 				result[appIdentifiers[0]] = debuggableViews;
 				return result;
 			};
 
-			let actualDebuggableViews = await devicesService.getDebuggableViews(androidDevice.deviceInfo.identifier, "com.telerik.myapp");
+			const actualDebuggableViews = await devicesService.getDebuggableViews(androidDevice.deviceInfo.identifier, "com.telerik.myapp");
 
 			assert.deepEqual(actualDebuggableViews, debuggableViews);
 		});
 
 		it("should return undefined if debuggable views are found for otheer app but not for the specified.", async () => {
 			androidDevice.applicationManager.getDebuggableAppViews = async (appIdentifiers: string[]): Promise<IDictionary<Mobile.IDebugWebViewInfo[]>> => {
-				let result: any = {};
+				const result: any = {};
 				result["com.telerik.otherApp"] = debuggableViews;
 				return result;
 			};
 
-			let actualDebuggableViews = await devicesService.getDebuggableViews(androidDevice.deviceInfo.identifier, "com.telerik.myapp");
+			const actualDebuggableViews = await devicesService.getDebuggableViews(androidDevice.deviceInfo.identifier, "com.telerik.myapp");
 
 			assert.deepEqual(actualDebuggableViews, undefined);
 		});

--- a/test/unit-tests/mobile/ios-simulator-discovery.ts
+++ b/test/unit-tests/mobile/ios-simulator-discovery.ts
@@ -5,11 +5,11 @@ import { assert } from "chai";
 import { DeviceDiscoveryEventNames } from "../../../constants";
 import { DevicePlatformsConstants } from "../../../mobile/device-platforms-constants";
 
-let currentlyRunningSimulator: any,
-	isCurrentlyRunning: boolean;
+let currentlyRunningSimulator: any;
+let isCurrentlyRunning: boolean;
 
 function createTestInjector(): IInjector {
-	let injector = new Yok();
+	const injector = new Yok();
 	injector.register("childProcess", {
 		exec: (command: string) => Promise.resolve(isCurrentlyRunning ? 'launchd_sim' : '')
 	});
@@ -39,12 +39,12 @@ function createTestInjector(): IInjector {
 }
 
 describe("ios-simulator-discovery", () => {
-	let testInjector: IInjector,
-		iOSSimulatorDiscovery: Mobile.IDeviceDiscovery,
-		defaultRunningSimulator: any,
-		expectedDeviceInfo: Mobile.IDeviceInfo = null;
+	let testInjector: IInjector;
+	let iOSSimulatorDiscovery: Mobile.IDeviceDiscovery;
+	let defaultRunningSimulator: any;
+	let expectedDeviceInfo: Mobile.IDeviceInfo = null;
 
-	let detectNewSimulatorAttached = async (runningSimulator: any): Promise<Mobile.IiOSSimulator> => {
+	const detectNewSimulatorAttached = async (runningSimulator: any): Promise<Mobile.IiOSSimulator> => {
 		return new Promise<Mobile.IiOSSimulator>((resolve, reject) => {
 
 			isCurrentlyRunning = true;
@@ -57,7 +57,7 @@ describe("ios-simulator-discovery", () => {
 		});
 	};
 
-	let detectSimulatorDetached = async (): Promise<Mobile.IiOSSimulator> => {
+	const detectSimulatorDetached = async (): Promise<Mobile.IiOSSimulator> => {
 		isCurrentlyRunning = false;
 		currentlyRunningSimulator = null;
 		return new Promise<Mobile.IDevice>((resolve, reject) => {
@@ -70,10 +70,10 @@ describe("ios-simulator-discovery", () => {
 		});
 	};
 
-	let detectSimulatorChanged = async (newId: string): Promise<any> => {
+	const detectSimulatorChanged = async (newId: string): Promise<any> => {
 		currentlyRunningSimulator.id = newId;
-		let lostDevicePromise: Promise<Mobile.IDevice>,
-			foundDevicePromise: Promise<Mobile.IDevice>;
+		let lostDevicePromise: Promise<Mobile.IDevice>;
+		let foundDevicePromise: Promise<Mobile.IDevice>;
 
 		iOSSimulatorDiscovery.on(DeviceDiscoveryEventNames.DEVICE_LOST, (device: Mobile.IDevice) => {
 			lostDevicePromise = Promise.resolve(device);
@@ -85,8 +85,8 @@ describe("ios-simulator-discovery", () => {
 
 		await iOSSimulatorDiscovery.startLookingForDevices();
 
-		let deviceLost = await lostDevicePromise;
-		let deviceFound = await foundDevicePromise;
+		const deviceLost = await lostDevicePromise;
+		const deviceFound = await foundDevicePromise;
 		return { deviceLost, deviceFound };
 	};
 
@@ -117,23 +117,23 @@ describe("ios-simulator-discovery", () => {
 	});
 
 	it("finds new device when it is attached", async () => {
-		let device = await detectNewSimulatorAttached(defaultRunningSimulator);
+		const device = await detectNewSimulatorAttached(defaultRunningSimulator);
 		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
 	});
 
 	it("raises deviceLost when device is detached", async () => {
-		let device = await detectNewSimulatorAttached(defaultRunningSimulator);
+		const device = await detectNewSimulatorAttached(defaultRunningSimulator);
 		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
-		let lostDevice = await detectSimulatorDetached();
+		const lostDevice = await detectSimulatorDetached();
 		assert.deepEqual(lostDevice, device);
 	});
 
 	it("raises deviceLost and deviceFound when device's id has changed (change simulator type)", async () => {
-		let device = await detectNewSimulatorAttached(defaultRunningSimulator),
+		const device = await detectNewSimulatorAttached(defaultRunningSimulator),
 			newId = "newId";
 		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
 
-		let devices = await detectSimulatorChanged(newId);
+		const devices = await detectSimulatorChanged(newId);
 		assert.deepEqual(devices.deviceLost, device);
 		expectedDeviceInfo.identifier = newId;
 		assert.deepEqual(devices.deviceFound.deviceInfo, expectedDeviceInfo);
@@ -142,7 +142,7 @@ describe("ios-simulator-discovery", () => {
 	it("raises events in correct order when simulator is started, closed and started again", async () => {
 		let device = await detectNewSimulatorAttached(defaultRunningSimulator);
 		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
-		let lostDevice = await detectSimulatorDetached();
+		const lostDevice = await detectSimulatorDetached();
 		assert.deepEqual(lostDevice, device);
 
 		device = await detectNewSimulatorAttached(defaultRunningSimulator);
@@ -150,7 +150,7 @@ describe("ios-simulator-discovery", () => {
 	});
 
 	it("finds new device when it is attached and reports it as new only once", async () => {
-		let device = await detectNewSimulatorAttached(defaultRunningSimulator);
+		const device = await detectNewSimulatorAttached(defaultRunningSimulator);
 		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
 		iOSSimulatorDiscovery.on(DeviceDiscoveryEventNames.DEVICE_FOUND, (d: Mobile.IDevice) => {
 			throw new Error("Device found should not be raised for the same device.");

--- a/test/unit-tests/mobile/project-files-manager.ts
+++ b/test/unit-tests/mobile/project-files-manager.ts
@@ -16,10 +16,10 @@ import { ProjectFilesProviderBase } from "../../../services/project-files-provid
 import temp = require("temp");
 temp.track();
 
-let testedApplicationIdentifier = "com.telerik.myApp";
-let iOSDeviceProjectRootPath = "/Documents/AppBuilder/LiveSync/app";
-let iOSDeviceSyncZipPath = "/Documents/AppBuilder/LiveSync/sync.zip";
-let androidDeviceProjectRootPath = "/data/local/tmp/sync";
+const testedApplicationIdentifier = "com.telerik.myApp";
+const iOSDeviceProjectRootPath = "/Documents/AppBuilder/LiveSync/app";
+const iOSDeviceSyncZipPath = "/Documents/AppBuilder/LiveSync/sync.zip";
+const androidDeviceProjectRootPath = "/data/local/tmp/sync";
 
 class IOSAppIdentifierMock implements Mobile.IDeviceAppData {
 	public platform = "iOS";
@@ -81,7 +81,7 @@ class MobilePlatformsCapabilitiesMock implements Mobile.IPlatformsCapabilities {
 }
 
 function createTestInjector(): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 
 	testInjector.register("deviceAppDataFactory", DeviceAppDataFactory);
 	testInjector.register("deviceAppDataProvider", DeviceAppDataProvider);
@@ -104,7 +104,7 @@ function createTestInjector(): IInjector {
 }
 
 async function createFiles(testInjector: IInjector, filesToCreate: string[]): Promise<string> {
-	let directoryPath = temp.mkdirSync("Project Files Manager Tests");
+	const directoryPath = temp.mkdirSync("Project Files Manager Tests");
 
 	_.each(filesToCreate, file => createFile(testInjector, file, "", directoryPath));
 
@@ -112,7 +112,7 @@ async function createFiles(testInjector: IInjector, filesToCreate: string[]): Pr
 }
 
 function createFile(testInjector: IInjector, fileToCreate: string, fileContent: string, directoryPath?: string): string {
-	let fs = testInjector.resolve("fs");
+	const fs = testInjector.resolve("fs");
 	directoryPath = !directoryPath ? temp.mkdirSync("Project Files Manager Tests") : directoryPath;
 
 	fs.writeFile(path.join(directoryPath, fileToCreate), fileContent);
@@ -121,8 +121,9 @@ function createFile(testInjector: IInjector, fileToCreate: string, fileContent: 
 }
 
 describe("Project Files Manager Tests", () => {
-	let testInjector: IInjector, projectFilesManager: IProjectFilesManager, deviceAppDataFactory: Mobile.IDeviceAppDataFactory,
-		mobileHelper: Mobile.IMobileHelper;
+	let testInjector: IInjector, projectFilesManager: IProjectFilesManager, deviceAppDataFactory: Mobile.IDeviceAppDataFactory;
+	let mobileHelper: Mobile.IMobileHelper;
+
 	beforeEach(() => {
 		testInjector = createTestInjector();
 		projectFilesManager = testInjector.resolve("projectFilesManager");
@@ -131,9 +132,9 @@ describe("Project Files Manager Tests", () => {
 	});
 
 	it("maps non-platform specific files to device file paths for ios platform", async () => {
-		let deviceAppData = deviceAppDataFactory.create(testedApplicationIdentifier, "iOS", null);
-		let files = ["~/TestApp/app/test.js", "~/TestApp/app/myfile.js"];
-		let localToDevicePaths = await projectFilesManager.createLocalToDevicePaths(deviceAppData, "~/TestApp/app", files, []);
+		const deviceAppData = deviceAppDataFactory.create(testedApplicationIdentifier, "iOS", null);
+		const files = ["~/TestApp/app/test.js", "~/TestApp/app/myfile.js"];
+		const localToDevicePaths = await projectFilesManager.createLocalToDevicePaths(deviceAppData, "~/TestApp/app", files, []);
 
 		_.each(localToDevicePaths, (localToDevicePathData, index) => {
 			assert.equal(files[index], localToDevicePathData.getLocalPath());
@@ -143,9 +144,9 @@ describe("Project Files Manager Tests", () => {
 	});
 
 	it("maps non-platform specific files to device file paths for android platform", async () => {
-		let deviceAppData = deviceAppDataFactory.create(testedApplicationIdentifier, "Android", null);
-		let files = ["~/TestApp/app/test.js", "~/TestApp/app/myfile.js"];
-		let localToDevicePaths = await projectFilesManager.createLocalToDevicePaths(deviceAppData, "~/TestApp/app", files, []);
+		const deviceAppData = deviceAppDataFactory.create(testedApplicationIdentifier, "Android", null);
+		const files = ["~/TestApp/app/test.js", "~/TestApp/app/myfile.js"];
+		const localToDevicePaths = await projectFilesManager.createLocalToDevicePaths(deviceAppData, "~/TestApp/app", files, []);
 
 		_.each(localToDevicePaths, (localToDevicePathData, index) => {
 			assert.equal(files[index], localToDevicePathData.getLocalPath());
@@ -155,9 +156,9 @@ describe("Project Files Manager Tests", () => {
 	});
 
 	it("maps ios platform specific file to device file path", async () => {
-		let deviceAppData = deviceAppDataFactory.create(testedApplicationIdentifier, "iOS", null);
-		let filePath = "~/TestApp/app/test.ios.js";
-		let localToDevicePathData = (await projectFilesManager.createLocalToDevicePaths(deviceAppData, "~/TestApp/app", [filePath], []))[0];
+		const deviceAppData = deviceAppDataFactory.create(testedApplicationIdentifier, "iOS", null);
+		const filePath = "~/TestApp/app/test.ios.js";
+		const localToDevicePathData = (await projectFilesManager.createLocalToDevicePaths(deviceAppData, "~/TestApp/app", [filePath], []))[0];
 
 		assert.equal(filePath, localToDevicePathData.getLocalPath());
 		assert.equal(mobileHelper.buildDevicePath(iOSDeviceProjectRootPath, "test.js"), localToDevicePathData.getDevicePath());
@@ -165,9 +166,9 @@ describe("Project Files Manager Tests", () => {
 	});
 
 	it("maps android platform specific file to device file path", async () => {
-		let deviceAppData = deviceAppDataFactory.create(testedApplicationIdentifier, "Android", null);
-		let filePath = "~/TestApp/app/test.android.js";
-		let localToDevicePathData = (await projectFilesManager.createLocalToDevicePaths(deviceAppData, "~/TestApp/app", [filePath], []))[0];
+		const deviceAppData = deviceAppDataFactory.create(testedApplicationIdentifier, "Android", null);
+		const filePath = "~/TestApp/app/test.android.js";
+		const localToDevicePathData = (await projectFilesManager.createLocalToDevicePaths(deviceAppData, "~/TestApp/app", [filePath], []))[0];
 
 		assert.equal(filePath, localToDevicePathData.getLocalPath());
 		assert.equal(mobileHelper.buildDevicePath(androidDeviceProjectRootPath, "test.js"), localToDevicePathData.getDevicePath());
@@ -175,24 +176,24 @@ describe("Project Files Manager Tests", () => {
 	});
 
 	it("filters android specific files", async () => {
-		let files = ["test.ios.x", "test.android.x"];
-		let directoryPath = await createFiles(testInjector, files);
+		const files = ["test.ios.x", "test.android.x"];
+		const directoryPath = await createFiles(testInjector, files);
 
 		projectFilesManager.processPlatformSpecificFiles(directoryPath, "android", {});
 
-		let fs = testInjector.resolve("fs");
+		const fs = testInjector.resolve("fs");
 		assert.isFalse(fs.exists(path.join(directoryPath, "test.ios.x")));
 		assert.isTrue(fs.exists(path.join(directoryPath, "test.x")));
 		assert.isFalse(fs.exists(path.join(directoryPath, "test.android.x")));
 	});
 
 	it("filters ios specific files", async () => {
-		let files = ["index.ios.html", "index1.android.html", "a.test"];
-		let directoryPath = await createFiles(testInjector, files);
+		const files = ["index.ios.html", "index1.android.html", "a.test"];
+		const directoryPath = await createFiles(testInjector, files);
 
 		projectFilesManager.processPlatformSpecificFiles(directoryPath, "ios", {});
 
-		let fs = testInjector.resolve("fs");
+		const fs = testInjector.resolve("fs");
 		assert.isFalse(fs.exists(path.join(directoryPath, "index1.android.html")));
 		assert.isFalse(fs.exists(path.join(directoryPath, "index1.html")));
 		assert.isTrue(fs.exists(path.join(directoryPath, "index.html")));
@@ -228,12 +229,12 @@ describe("Project Files Manager Tests", () => {
 	});
 
 	it("doesn't filter non platform specific files", async () => {
-		let files = ["index1.js", "index2.js", "index3.js"];
-		let directoryPath = await createFiles(testInjector, files);
+		const files = ["index1.js", "index2.js", "index3.js"];
+		const directoryPath = await createFiles(testInjector, files);
 
 		projectFilesManager.processPlatformSpecificFiles(directoryPath, "ios", {});
 
-		let fs = testInjector.resolve("fs");
+		const fs = testInjector.resolve("fs");
 		assert.isTrue(fs.exists(path.join(directoryPath, "index1.js")));
 		assert.isTrue(fs.exists(path.join(directoryPath, "index2.js")));
 		assert.isTrue(fs.exists(path.join(directoryPath, "index3.js")));

--- a/test/unit-tests/process-service.ts
+++ b/test/unit-tests/process-service.ts
@@ -2,10 +2,10 @@ import { Yok } from "../../yok";
 import { ProcessService } from "../../services/process-service";
 import { assert } from "chai";
 
-let processExitSignals = ["exit", "SIGINT", "SIGTERM"];
-let emptyFunction = () => { /* no implementation required */ };
+const processExitSignals = ["exit", "SIGINT", "SIGTERM"];
+const emptyFunction = () => { /* no implementation required */ };
 function createTestInjector(): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 
 	testInjector.register("processService", ProcessService);
 
@@ -27,14 +27,14 @@ describe("Process service", () => {
 
 		_.each(processExitSignals, (signal: string) => {
 			// We need to search only for our listener because each exit signal have different listeners added to it.
-			let actualListeners = _.filter(process.listeners(signal), (listener: Function) => listener.toString().indexOf("executeAllCallbacks") >= 0);
+			const actualListeners = _.filter(process.listeners(signal), (listener: Function) => listener.toString().indexOf("executeAllCallbacks") >= 0);
 			assert.deepEqual(actualListeners.length, 1);
 		});
 	});
 
 	it("should add listener with context only once if there already is callback with the same context.", () => {
-		let context = { test: "test" };
-		let listener = () => 42;
+		const context = { test: "test" };
+		const listener = () => 42;
 
 		$processService.attachToProcessExitSignals(context, listener);
 		$processService.attachToProcessExitSignals(context, listener);
@@ -43,9 +43,9 @@ describe("Process service", () => {
 	});
 
 	it("should add two different listeners for one context.", () => {
-		let context = { test: "test" };
-		let numberListener = () => 42;
-		let booleanListener = () => true;
+		const context = { test: "test" };
+		const numberListener = () => 42;
+		const booleanListener = () => true;
 
 		$processService.attachToProcessExitSignals(context, numberListener);
 		$processService.attachToProcessExitSignals(context, booleanListener);
@@ -54,7 +54,7 @@ describe("Process service", () => {
 	});
 
 	it("should add one listener with different context twice.", () => {
-		let listener = () => 42;
+		const listener = () => 42;
 
 		$processService.attachToProcessExitSignals({}, listener);
 		$processService.attachToProcessExitSignals({}, listener);
@@ -67,15 +67,15 @@ describe("Process service", () => {
 		let hasCalledSecondListener = false;
 		let hasCalledThirdListener = false;
 
-		let firstListener = () => {
+		const firstListener = () => {
 			hasCalledFirstListener = true;
 		};
 
-		let secondListener = () => {
+		const secondListener = () => {
 			hasCalledSecondListener = true;
 		};
 
-		let thirdListener = () => {
+		const thirdListener = () => {
 			hasCalledThirdListener = true;
 		};
 

--- a/test/unit-tests/project-files-provider-base.ts
+++ b/test/unit-tests/project-files-provider-base.ts
@@ -19,7 +19,7 @@ class ProjectFilesProvider extends ProjectFilesProviderBase {
 }
 
 function createTestInjector(): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("mobileHelper", {
 		platformNames: ["Android", "iOS"]
 	});
@@ -30,9 +30,9 @@ function createTestInjector(): IInjector {
 }
 
 describe("ProjectFilesProviderBase", () => {
-	let testInjector: IInjector,
-		projectFilesProviderBase: IProjectFilesProvider,
-		expectedFilePath = path.join("/test", "filePath.ts");
+	let testInjector: IInjector;
+	let projectFilesProviderBase: IProjectFilesProvider;
+	const expectedFilePath = path.join("/test", "filePath.ts");
 
 	beforeEach(() => {
 		testInjector = createTestInjector();
@@ -41,49 +41,49 @@ describe("ProjectFilesProviderBase", () => {
 
 	describe("getPreparedFilePath", () => {
 		it("returns correct path, when fileName does not contain platforms", () => {
-			let filePath = "/test/filePath.ts",
+			const filePath = "/test/filePath.ts",
 				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath, {});
 
 			assert.deepEqual(preparedPath, expectedFilePath);
 		});
 
 		it("returns correct path, when fileName contains android platform", () => {
-			let filePath = "/test/filePath.android.ts",
+			const filePath = "/test/filePath.android.ts",
 				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath, {});
 
 			assert.deepEqual(preparedPath, expectedFilePath);
 		});
 
 		it("returns correct path, when fileName contains ios platform", () => {
-			let filePath = "/test/filePath.iOS.ts",
+			const filePath = "/test/filePath.iOS.ts",
 				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath, {});
 
 			assert.deepEqual(preparedPath, expectedFilePath);
 		});
 
 		it("returns correct path, when fileName contains platform (case insensitive test)", () => {
-			let filePath = "/test/filePath.AnDroId.ts",
+			const filePath = "/test/filePath.AnDroId.ts",
 				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath, {});
 
 			assert.deepEqual(preparedPath, expectedFilePath);
 		});
 
 		it("returns correct path, when fileName contains debug configuration", () => {
-			let filePath = "/test/filePath.debug.ts",
+			const filePath = "/test/filePath.debug.ts",
 				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath, {});
 
 			assert.deepEqual(preparedPath, expectedFilePath);
 		});
 
 		it("returns correct path, when fileName contains debug configuration (case insensitive test)", () => {
-			let filePath = "/test/filePath.DebUG.ts",
+			const filePath = "/test/filePath.DebUG.ts",
 				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath, {});
 
 			assert.deepEqual(preparedPath, expectedFilePath);
 		});
 
 		it("returns correct path, when fileName contains release configuration", () => {
-			let filePath = "/test/filePath.release.ts",
+			const filePath = "/test/filePath.release.ts",
 				preparedPath = projectFilesProviderBase.getPreparedFilePath(filePath, {});
 
 			assert.deepEqual(preparedPath, expectedFilePath);
@@ -91,7 +91,7 @@ describe("ProjectFilesProviderBase", () => {
 	});
 
 	describe("getProjectFileInfo", () => {
-		let getExpectedProjectFileInfo = (filePath: string, shouldIncludeFile: boolean) => {
+		const getExpectedProjectFileInfo = (filePath: string, shouldIncludeFile: boolean) => {
 			return {
 				filePath: filePath,
 				onDeviceFileName: path.basename(expectedFilePath),
@@ -100,51 +100,51 @@ describe("ProjectFilesProviderBase", () => {
 		};
 
 		it("process file without platforms in the name", () => {
-			let filePath = "/test/filePath.ts",
+			const filePath = "/test/filePath.ts",
 				projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "", {});
 
 			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, true));
 		});
 
 		it("process file with android platform in the name", () => {
-			let filePath = "/test/filePath.android.ts",
+			const filePath = "/test/filePath.android.ts",
 				projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android", {});
 
 			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, true));
 		});
 
 		it("process file with android platform in the name (case insensitive test)", () => {
-			let filePath = "/test/filePath.AndRoID.ts",
+			const filePath = "/test/filePath.AndRoID.ts",
 				projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android", {});
 
 			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, true));
 		});
 
 		it("process file with iOS platform in the name", () => {
-			let filePath = "/test/filePath.ios.ts",
+			const filePath = "/test/filePath.ios.ts",
 				projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android", {});
 
 			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, false));
 		});
 
 		it("process file with debug configuration in the name", () => {
-			let filePath = "/test/filePath.debug.ts",
+			const filePath = "/test/filePath.debug.ts",
 				projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android", {});
 
 			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, true));
 		});
 
 		it("process file with release configuration in the name", () => {
-			let filePath = "/test/filePath.release.ts",
+			const filePath = "/test/filePath.release.ts",
 				projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android", {});
 
 			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, false));
 		});
 
 		it("process file with release configuration in the name, shouldIncludeFile must be true when options.release is true", () => {
-			let filePath = "/test/filePath.release.ts";
+			const filePath = "/test/filePath.release.ts";
 			testInjector.resolve("options").release = true;
-			let projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android", { configuration: "release" });
+			const projectFileInfo = projectFilesProviderBase.getProjectFileInfo(filePath, "android", { configuration: "release" });
 
 			assert.deepEqual(projectFileInfo, getExpectedProjectFileInfo(filePath, true));
 		});

--- a/test/unit-tests/sys-info-base.ts
+++ b/test/unit-tests/sys-info-base.ts
@@ -7,8 +7,8 @@ import { writeFileSync } from "fs";
 import * as path from "path";
 temp.track();
 
-let toolsPackageJsonDir = temp.mkdirSync("dirWithPackageJson");
-let toolsPackageJson = path.join(toolsPackageJsonDir, "package.json");
+const toolsPackageJsonDir = temp.mkdirSync("dirWithPackageJson");
+const toolsPackageJson = path.join(toolsPackageJsonDir, "package.json");
 writeFileSync(toolsPackageJson, '{ "name": "unit-testing-doctor-service", "version": "1.0.0" }');
 
 interface IChildProcessResultDescription {
@@ -66,8 +66,8 @@ function createChildProcessResults(childProcessResult: IChildProcessResults): ID
 }
 
 function createTestInjector(childProcessResult: IChildProcessResults, hostInfoData: { isWindows: boolean, dotNetVersion: string, isDarwin: boolean }, itunesError: string): IInjector {
-	let injector = new Yok();
-	let childProcessResultDictionary = createChildProcessResults(childProcessResult);
+	const injector = new Yok();
+	const childProcessResultDictionary = createChildProcessResults(childProcessResult);
 	injector.register("childProcess", {
 		exec: async (command: string, options?: any, execOptions?: IExecOptions) => {
 			return getResultFromChildProcess(childProcessResultDictionary[command]);
@@ -110,14 +110,14 @@ function createTestInjector(childProcessResult: IChildProcessResults, hostInfoDa
 
 describe("sysInfoBase", () => {
 	// TODO: Add tests when JAVA_HOME is set and when it is not
-	let originalJavaHome = process.env.JAVA_HOME;
+	const originalJavaHome = process.env.JAVA_HOME;
 	process.env.JAVA_HOME = '';
 
 	after(() => process.env.JAVA_HOME = originalJavaHome);
 
-	let childProcessResult: IChildProcessResults,
-		testInjector: IInjector,
-		sysInfoBase: ISysInfo;
+	let childProcessResult: IChildProcessResults;
+	let testInjector: IInjector;
+	let sysInfoBase: ISysInfo;
 
 	beforeEach(() => {
 		childProcessResult = {
@@ -140,7 +140,7 @@ describe("sysInfoBase", () => {
 	});
 	describe("getSysInfo", () => {
 		describe("returns correct results when everything is installed", () => {
-			let assertCommonValues = (result: ISysInfoData) => {
+			const assertCommonValues = (result: ISysInfoData) => {
 				assert.deepEqual(result.npmVer, childProcessResult.npmV.result);
 				assert.deepEqual(result.javaVer, "1.8.0");
 				assert.deepEqual(result.javacVersion, "1.8.0_60");
@@ -155,7 +155,7 @@ describe("sysInfoBase", () => {
 			it("on Windows", async () => {
 				testInjector = createTestInjector(childProcessResult, { isWindows: true, isDarwin: false, dotNetVersion: "4.5.1" }, null);
 				sysInfoBase = testInjector.resolve("sysInfoBase");
-				let result = await sysInfoBase.getSysInfo(toolsPackageJson);
+				const result = await sysInfoBase.getSysInfo(toolsPackageJson);
 				assertCommonValues(result);
 				assert.deepEqual(result.xcodeVer, null);
 				assert.deepEqual(result.cocoapodVer, null);
@@ -164,7 +164,7 @@ describe("sysInfoBase", () => {
 			it("on Mac", async () => {
 				testInjector = createTestInjector(childProcessResult, { isWindows: false, isDarwin: true, dotNetVersion: "4.5.1" }, null);
 				sysInfoBase = testInjector.resolve("sysInfoBase");
-				let result = await sysInfoBase.getSysInfo(toolsPackageJson);
+				const result = await sysInfoBase.getSysInfo(toolsPackageJson);
 				assertCommonValues(result);
 				assert.deepEqual(result.xcodeVer, childProcessResult.xCodeVersion.result);
 				assert.deepEqual(result.cocoapodVer, childProcessResult.podVersion.result);
@@ -173,7 +173,7 @@ describe("sysInfoBase", () => {
 			it("on Linux", async () => {
 				testInjector = createTestInjector(childProcessResult, { isWindows: false, isDarwin: false, dotNetVersion: "4.5.1" }, null);
 				sysInfoBase = testInjector.resolve("sysInfoBase");
-				let result = await sysInfoBase.getSysInfo(toolsPackageJson);
+				const result = await sysInfoBase.getSysInfo(toolsPackageJson);
 				assertCommonValues(result);
 				assert.deepEqual(result.xcodeVer, null);
 				assert.deepEqual(result.cocoapodVer, null);
@@ -186,14 +186,14 @@ describe("sysInfoBase", () => {
 				childProcessResult.podVersion = { shouldThrowError: true };
 				testInjector = createTestInjector(childProcessResult, { isWindows: false, isDarwin: true, dotNetVersion: "4.5.1" }, null);
 				sysInfoBase = testInjector.resolve("sysInfoBase");
-				let result = await sysInfoBase.getSysInfo(toolsPackageJson);
+				const result = await sysInfoBase.getSysInfo(toolsPackageJson);
 				assert.deepEqual(result.cocoapodVer, null);
 			});
 
 			it("is null when OS is not Mac", async () => {
 				testInjector = createTestInjector(childProcessResult, { isWindows: true, isDarwin: false, dotNetVersion: "4.5.1" }, null);
 				sysInfoBase = testInjector.resolve("sysInfoBase");
-				let result = await sysInfoBase.getSysInfo(toolsPackageJson);
+				const result = await sysInfoBase.getSysInfo(toolsPackageJson);
 				assert.deepEqual(result.cocoapodVer, null);
 			});
 
@@ -201,7 +201,7 @@ describe("sysInfoBase", () => {
 				childProcessResult.podVersion = { result: "0.38.2\nWARNING:\n" };
 				testInjector = createTestInjector(childProcessResult, { isWindows: false, isDarwin: true, dotNetVersion: "4.5.1" }, null);
 				sysInfoBase = testInjector.resolve("sysInfoBase");
-				let result = await sysInfoBase.getSysInfo(toolsPackageJson);
+				const result = await sysInfoBase.getSysInfo(toolsPackageJson);
 				assert.deepEqual(result.cocoapodVer, "0.38.2");
 			});
 
@@ -209,7 +209,7 @@ describe("sysInfoBase", () => {
 				childProcessResult.podVersion = { result: "WARNING\nWARNING2\n0.38.2" };
 				testInjector = createTestInjector(childProcessResult, { isWindows: false, isDarwin: true, dotNetVersion: "4.5.1" }, null);
 				sysInfoBase = testInjector.resolve("sysInfoBase");
-				let result = await sysInfoBase.getSysInfo(toolsPackageJson);
+				const result = await sysInfoBase.getSysInfo(toolsPackageJson);
 				assert.deepEqual(result.cocoapodVer, "0.38.2");
 			});
 		});
@@ -242,16 +242,16 @@ describe("sysInfoBase", () => {
 					};
 					testInjector = createTestInjector(childProcessResult, { isWindows: false, isDarwin: false, dotNetVersion: "4.5.1" }, null);
 					sysInfoBase = testInjector.resolve("sysInfoBase");
-					let result = await sysInfoBase.getSysInfo(toolsPackageJson, { pathToAdb: null });
+					const result = await sysInfoBase.getSysInfo(toolsPackageJson, { pathToAdb: null });
 					assert.deepEqual(result.adbVer, null);
 					assert.deepEqual(result.emulatorInstalled, false);
 				});
 			});
 
 			describe("when all of calls throw", () => {
-				let assertAllValuesAreNull = async () => {
+				const assertAllValuesAreNull = async () => {
 					sysInfoBase = testInjector.resolve("sysInfoBase");
-					let result = await sysInfoBase.getSysInfo(toolsPackageJson);
+					const result = await sysInfoBase.getSysInfo(toolsPackageJson);
 					assert.deepEqual(result.npmVer, null);
 					assert.deepEqual(result.javaVer, null);
 					assert.deepEqual(result.javacVersion, null);

--- a/test/unit-tests/xcode-select-service.ts
+++ b/test/unit-tests/xcode-select-service.ts
@@ -6,7 +6,7 @@ import * as path from "path";
 let executionStopped = false;
 
 function createTestInjector(config: { xcodeSelectStdout: string, isDarwin: boolean, xcodeVersionOutput?: string }): IInjector {
-	let testInjector = new Yok();
+	const testInjector = new Yok();
 	testInjector.register("childProcess", {
 		spawnFromEvent: (command: string, args: string[], event: string): Promise<any> => Promise.resolve({
 			stdout: config.xcodeSelectStdout
@@ -34,9 +34,9 @@ function createTestInjector(config: { xcodeSelectStdout: string, isDarwin: boole
 	return testInjector;
 }
 describe("xcode-select-service", () => {
-	let injector: IInjector,
-		service: IXcodeSelectService,
-		defaultXcodeSelectStdout = "/Applications/Xcode.app/Contents/Developer/";
+	let injector: IInjector;
+	let service: IXcodeSelectService;
+	const defaultXcodeSelectStdout = "/Applications/Xcode.app/Contents/Developer/";
 
 	beforeEach(() => {
 		executionStopped = false;
@@ -60,7 +60,7 @@ describe("xcode-select-service", () => {
 		injector = createTestInjector({ xcodeSelectStdout: null, isDarwin: true, xcodeVersionOutput: "Xcode 7.3\nBuild version 7D175" });
 		service = injector.resolve("$xcodeSelectService");
 
-		let xcodeVersion = await service.getXcodeVersion();
+		const xcodeVersion = await service.getXcodeVersion();
 
 		assert.strictEqual(xcodeVersion.major, "7", "xcodeSelectService should get correct Xcode version");
 		assert.strictEqual(xcodeVersion.minor, "3", "xcodeSelectService should get correct Xcode version");
@@ -75,7 +75,7 @@ describe("xcode-select-service", () => {
 
 	it("gets correct path to Contents directory on Mac OS X", async () => {
 		// This path is constructed with path.join so that the tests are OS-agnostic
-		let expected = path.join("/Applications", "Xcode.app", "Contents");
+		const expected = path.join("/Applications", "Xcode.app", "Contents");
 		injector = createTestInjector({ xcodeSelectStdout: defaultXcodeSelectStdout, isDarwin: true });
 		service = injector.resolve("$xcodeSelectService");
 

--- a/test/unit-tests/yok.ts
+++ b/test/unit-tests/yok.ts
@@ -17,60 +17,60 @@ class MyClass {
 describe("yok", () => {
 	describe("functions", () => {
 		it("resolves pre-constructed singleton", () => {
-			let injector = new Yok();
-			let obj = {};
+			const injector = new Yok();
+			const obj = {};
 			injector.register("foo", obj);
 
-			let resolved = injector.resolve("foo");
+			const resolved = injector.resolve("foo");
 
 			assert.strictEqual(obj, resolved);
 		});
 
 		it("resolves given constructor", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 			let obj: any;
 			injector.register("foo", () => {
 				obj = { foo: "foo" };
 				return obj;
 			});
 
-			let resolved = injector.resolve("foo");
+			const resolved = injector.resolve("foo");
 
 			assert.strictEqual(resolved, obj);
 		});
 
 		it("resolves constructed singleton", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 			injector.register("foo", { foo: "foo" });
 
-			let r1 = injector.resolve("foo");
-			let r2 = injector.resolve("foo");
+			const r1 = injector.resolve("foo");
+			const r2 = injector.resolve("foo");
 
 			assert.strictEqual(r1, r2);
 		});
 
 		it("injects directly into passed constructor", () => {
-			let injector = new Yok();
-			let obj = {};
+			const injector = new Yok();
+			const obj = {};
 			injector.register("foo", obj);
 
 			function Test(foo: any) {
 				this.foo = foo;
 			}
 
-			let result = injector.resolve(Test);
+			const result = injector.resolve(Test);
 
 			assert.strictEqual(obj, result.foo);
 		});
 
 		it("injects directly into passed constructor, ES6 lambda", () => {
-			let injector = new Yok();
-			let obj = {};
+			const injector = new Yok();
+			const obj = {};
 			let resultFoo: any = null;
 
 			injector.register("foo", obj);
 
-			let Test = (foo: any) => {
+			const Test = (foo: any) => {
 				resultFoo = foo;
 			};
 
@@ -84,12 +84,12 @@ describe("yok", () => {
 			const obj = {};
 			const expectedBar = {};
 
-			let resultFoo: any = null,
-				resultBar: any = null;
+			let resultFoo: any = null;
+			let resultBar: any = null;
 
 			injector.register("foo", obj);
 
-			let Test = (foo: any, bar: any) => {
+			const Test = (foo: any, bar: any) => {
 				resultFoo = foo;
 				resultBar = bar;
 			};
@@ -101,8 +101,8 @@ describe("yok", () => {
 		});
 
 		it("inject dependency into registered constructor", () => {
-			let injector = new Yok();
-			let obj = {};
+			const injector = new Yok();
+			const obj = {};
 			injector.register("foo", obj);
 
 			function Test(foo: any) {
@@ -111,19 +111,19 @@ describe("yok", () => {
 
 			injector.register("test", Test);
 
-			let result = injector.resolve("test");
+			const result = injector.resolve("test");
 
 			assert.strictEqual(obj, result.foo);
 		});
 
 		it("inject dependency into registered constructor, ES6 lambda", () => {
-			let injector = new Yok();
-			let obj = {};
+			const injector = new Yok();
+			const obj = {};
 			let resultFoo: any = null;
 
 			injector.register("foo", obj);
 
-			let Test = (foo: any) => {
+			const Test = (foo: any) => {
 				resultFoo = foo;
 			};
 
@@ -139,12 +139,12 @@ describe("yok", () => {
 			const obj = {};
 			const expectedBar = {};
 
-			let resultFoo: any = null,
-				resultBar: any = null;
+			let resultFoo: any = null;
+			let resultBar: any = null;
 
 			injector.register("foo", obj);
 
-			let Test = (foo: any, bar: any) => {
+			const Test = (foo: any, bar: any) => {
 				resultFoo = foo;
 				resultBar = bar;
 			};
@@ -158,51 +158,51 @@ describe("yok", () => {
 		});
 
 		it("inject dependency with $ prefix", () => {
-			let injector = new Yok();
-			let obj = {};
+			const injector = new Yok();
+			const obj = {};
 			injector.register("foo", obj);
 
 			function Test($foo: any) {
 				this.foo = $foo;
 			}
 
-			let result = injector.resolve(Test);
+			const result = injector.resolve(Test);
 
 			assert.strictEqual(obj, result.foo);
 		});
 
 		it("inject into TS constructor", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 
 			injector.register("x", "foo");
 			injector.register("y", 123);
 
-			let result = <MyClass>injector.resolve(MyClass);
+			const result = <MyClass>injector.resolve(MyClass);
 
 			assert.strictEqual(result.y, 123);
 			result.checkX();
 		});
 
 		it("resolves a parameterless constructor", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 
 			function Test() {
 				this.foo = "foo";
 			}
 
-			let result = injector.resolve(Test);
+			const result = injector.resolve(Test);
 
 			assert.equal(result.foo, "foo");
 		});
 
 		it("returns null when it can't resolve a command", () => {
-			let injector = new Yok();
-			let command = injector.resolveCommand("command");
+			const injector = new Yok();
+			const command = injector.resolveCommand("command");
 			assert.isNull(command);
 		});
 
 		it("throws when it can't resolve a registered command", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 
 			function Command(whatever: any) { /* intentionally left blank */ }
 
@@ -212,7 +212,7 @@ describe("yok", () => {
 		});
 
 		it("disposes", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 
 			function Thing() { /* intentionally left blank */ }
 
@@ -221,7 +221,7 @@ describe("yok", () => {
 			};
 
 			injector.register("thing", Thing);
-			let thing = injector.resolve("thing");
+			const thing = injector.resolve("thing");
 			injector.dispose();
 
 			assert.isTrue(thing.disposed);
@@ -231,41 +231,41 @@ describe("yok", () => {
 
 	describe("classes", () => {
 		it("resolves pre-constructed singleton", () => {
-			let injector = new Yok();
-			let obj = {};
+			const injector = new Yok();
+			const obj = {};
 			injector.register("foo", obj);
 
-			let resolved = injector.resolve("foo");
+			const resolved = injector.resolve("foo");
 
 			assert.strictEqual(obj, resolved);
 		});
 
 		it("resolves given constructor", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 			let obj: any;
 			injector.register("foo", () => {
 				obj = { foo: "foo" };
 				return obj;
 			});
 
-			let resolved = injector.resolve("foo");
+			const resolved = injector.resolve("foo");
 
 			assert.strictEqual(resolved, obj);
 		});
 
 		it("resolves constructed singleton", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 			injector.register("foo", { foo: "foo" });
 
-			let r1 = injector.resolve("foo");
-			let r2 = injector.resolve("foo");
+			const r1 = injector.resolve("foo");
+			const r2 = injector.resolve("foo");
 
 			assert.strictEqual(r1, r2);
 		});
 
 		it("injects directly into passed constructor", () => {
-			let injector = new Yok();
-			let obj = {};
+			const injector = new Yok();
+			const obj = {};
 			injector.register("foo", obj);
 
 			class Test {
@@ -276,7 +276,7 @@ describe("yok", () => {
 				}
 			}
 
-			let result = injector.resolve(Test);
+			const result = injector.resolve(Test);
 			assert.strictEqual(obj, result.foo);
 		});
 
@@ -297,15 +297,15 @@ describe("yok", () => {
 				}
 			}
 
-			let result = injector.resolve(Test, { bar: expectedBar });
+			const result = injector.resolve(Test, { bar: expectedBar });
 
 			assert.strictEqual(obj, result.foo);
 			assert.strictEqual(expectedBar, result.bar);
 		});
 
 		it("inject dependency into registered constructor", () => {
-			let injector = new Yok();
-			let obj = {};
+			const injector = new Yok();
+			const obj = {};
 			injector.register("foo", obj);
 
 			class Test {
@@ -318,7 +318,7 @@ describe("yok", () => {
 
 			injector.register("test", Test);
 
-			let result = injector.resolve("test");
+			const result = injector.resolve("test");
 
 			assert.strictEqual(obj, result.foo);
 		});
@@ -342,15 +342,15 @@ describe("yok", () => {
 
 			injector.register("test", Test);
 
-			let result = injector.resolve("test", { bar: expectedBar });
+			const result = injector.resolve("test", { bar: expectedBar });
 
 			assert.strictEqual(obj, result.foo);
 			assert.strictEqual(expectedBar, result.bar);
 		});
 
 		it("inject dependency with $ prefix", () => {
-			let injector = new Yok();
-			let obj = {};
+			const injector = new Yok();
+			const obj = {};
 			injector.register("foo", obj);
 
 			class Test {
@@ -360,25 +360,25 @@ describe("yok", () => {
 				}
 			}
 
-			let result = injector.resolve(Test);
+			const result = injector.resolve(Test);
 
 			assert.strictEqual(obj, result.foo);
 		});
 
 		it("inject into TS constructor", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 
 			injector.register("x", "foo");
 			injector.register("y", 123);
 
-			let result = <MyClass>injector.resolve(MyClass);
+			const result = <MyClass>injector.resolve(MyClass);
 
 			assert.strictEqual(result.y, 123);
 			result.checkX();
 		});
 
 		it("resolves a parameterless constructor", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 
 			class Test {
 				private foo: any;
@@ -387,19 +387,19 @@ describe("yok", () => {
 				}
 			}
 
-			let result = injector.resolve(Test);
+			const result = injector.resolve(Test);
 
 			assert.equal(result.foo, "foo");
 		});
 
 		it("returns null when it can't resolve a command", () => {
-			let injector = new Yok();
-			let command = injector.resolveCommand("command");
+			const injector = new Yok();
+			const command = injector.resolveCommand("command");
 			assert.isNull(command);
 		});
 
 		it("throws when it can't resolve a registered command", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 
 			class Command {
 				constructor(whatever: any) { /* intentionally left blank */ }
@@ -411,7 +411,7 @@ describe("yok", () => {
 		});
 
 		it("disposes", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 
 			class Thing {
 				public disposed = false;
@@ -422,7 +422,7 @@ describe("yok", () => {
 			}
 
 			injector.register("thing", Thing);
-			let thing = injector.resolve("thing");
+			const thing = injector.resolve("thing");
 			injector.dispose();
 
 			assert.isTrue(thing.disposed);
@@ -430,7 +430,7 @@ describe("yok", () => {
 	});
 
 	it("throws error when module is required more than once and overrideAlreadyRequiredModule is false", () => {
-		let injector = new Yok();
+		const injector = new Yok();
 		injector.require("foo", "test");
 		injector.overrideAlreadyRequiredModule = false;
 		assert.throws(() => injector.require("foo", "test2"));
@@ -478,7 +478,7 @@ $injector.register("a", A);
 
 	describe("requirePublic", () => {
 		it("adds module to public api when requirePublic is used", () => {
-			let injector = new Yok();
+			const injector = new Yok();
 			injector.requirePublic("foo", "test");
 			assert.isTrue(_.includes(Object.getOwnPropertyNames(injector.publicApi), "foo"));
 		});
@@ -543,44 +543,44 @@ $injector.register("a", A);
 
 		describe("returns correct command and arguments when command name has one pipe (|)", () => {
 			it("when only command is passed, no arguments are returned", () => {
-				let commandName = "sample|command";
+				const commandName = "sample|command";
 				injector.requireCommand(commandName, "sampleFileName");
-				let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command"]);
+				const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command"]);
 				assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 				assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, [], "There shouldn't be any arguments left.");
 			});
 
 			it("when command is passed, correct arguments are returned", () => {
-				let commandName = "sample|command";
+				const commandName = "sample|command";
 				injector.requireCommand(commandName, "sampleFileName");
-				let sampleArguments = ["sample", "arguments", "passed", "to", "command"];
-				let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command"].concat(sampleArguments));
+				const sampleArguments = ["sample", "arguments", "passed", "to", "command"];
+				const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command"].concat(sampleArguments));
 				assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 				assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, sampleArguments, "All arguments except first one should be returned.");
 			});
 
 			it("when command is passed, correct arguments are returned when command argument has uppercase letters", () => {
-				let commandName = "sample|command";
+				const commandName = "sample|command";
 				injector.requireCommand(commandName, "sampleFileName");
-				let sampleArguments = ["sample", "arguments", "passed", "to", "command"];
-				let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["CoMmanD"].concat(sampleArguments));
+				const sampleArguments = ["sample", "arguments", "passed", "to", "command"];
+				const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["CoMmanD"].concat(sampleArguments));
 				assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 				assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, sampleArguments, "All arguments except first one should be returned.");
 			});
 
 			it("when only default command is passed, no arguments are returned", () => {
-				let commandName = "sample|*command";
+				const commandName = "sample|*command";
 				injector.requireCommand(commandName, "sampleFileName");
-				let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command"]);
+				const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command"]);
 				assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 				assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, [], "There shouldn't be any arguments left.");
 			});
 
 			it("when default command is passed, correct arguments are returned", () => {
-				let commandName = "sample|*command";
+				const commandName = "sample|*command";
 				injector.requireCommand(commandName, "sampleFileName");
-				let sampleArguments = ["sample", "arguments", "passed", "to", "command"];
-				let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command"].concat(sampleArguments));
+				const sampleArguments = ["sample", "arguments", "passed", "to", "command"];
+				const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command"].concat(sampleArguments));
 				assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 				assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, sampleArguments, "All arguments except first one should be returned.");
 			});
@@ -588,41 +588,41 @@ $injector.register("a", A);
 
 		describe("returns correct command and arguments when command name has more than one pipe (|)", () => {
 			it("when only command is passed, no arguments are returned", () => {
-				let commandName = "sample|command|with|more|pipes";
+				const commandName = "sample|command|with|more|pipes";
 				injector.requireCommand(commandName, "sampleFileName");
-				let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "with", "more", "pipes"]);
+				const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "with", "more", "pipes"]);
 				assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 				assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, [], "There shouldn't be any arguments left.");
 			});
 
 			it("when command is passed, correct arguments are returned", () => {
-				let commandName = "sample|command|pipes";
+				const commandName = "sample|command|pipes";
 				injector.requireCommand(commandName, "sampleFileName");
-				let sampleArguments = ["sample", "arguments", "passed", "to", "command"];
-				let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "pipes"].concat(sampleArguments));
+				const sampleArguments = ["sample", "arguments", "passed", "to", "command"];
+				const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "pipes"].concat(sampleArguments));
 				assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 				assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, sampleArguments, "All arguments except the ones used for commandName should be returned.");
 			});
 
 			it("when only default command is passed, no arguments are returned", () => {
-				let commandName = "sample|*command|pipes";
+				const commandName = "sample|*command|pipes";
 				injector.requireCommand(commandName, "sampleFileName");
-				let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "pipes"]);
+				const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "pipes"]);
 				assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 				assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, [], "There shouldn't be any arguments left.");
 			});
 
 			it("when default command is passed, correct arguments are returned", () => {
-				let commandName = "sample|*command|pipes";
+				const commandName = "sample|*command|pipes";
 				injector.requireCommand(commandName, "sampleFileName");
-				let sampleArguments = ["sample", "arguments", "passed", "to", "command"];
-				let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "pipes"].concat(sampleArguments));
+				const sampleArguments = ["sample", "arguments", "passed", "to", "command"];
+				const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "pipes"].concat(sampleArguments));
 				assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 				assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, sampleArguments, "All arguments except the ones used for commandName should be returned.");
 			});
 
 			describe("returns most applicable hierarchical command", () => {
-				let sampleArguments = ["sample", "arguments", "passed", "to", "command"];
+				const sampleArguments = ["sample", "arguments", "passed", "to", "command"];
 				beforeEach(() => {
 					injector.requireCommand("sample|command", "sampleFileName");
 					injector.requireCommand("sample|command|with", "sampleFileName");
@@ -630,43 +630,43 @@ $injector.register("a", A);
 					injector.requireCommand("sample|command|with|more|pipes", "sampleFileName");
 				});
 				it("when subcommand of subcommand is called", () => {
-					let commandName = "sample|command|with|more|pipes";
-					let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "with", "more", "pipes"]);
+					const commandName = "sample|command|with|more|pipes";
+					const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "with", "more", "pipes"]);
 					assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 					assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, [], "There shouldn't be any arguments left.");
 				});
 
 				it("and correct arguments, when subcommand of subcommand is called", () => {
-					let commandName = "sample|command|with|more|pipes";
-					let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "with", "more", "pipes"].concat(sampleArguments));
+					const commandName = "sample|command|with|more|pipes";
+					const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "with", "more", "pipes"].concat(sampleArguments));
 					assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 					assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, sampleArguments, "All arguments except the ones used for commandName should be returned.");
 				});
 
 				it("when top subcommand is called and it has its own subcommand", () => {
-					let commandName = "sample|command";
-					let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command"]);
+					const commandName = "sample|command";
+					const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command"]);
 					assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 					assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, [], "There shouldn't be any arguments left.");
 				});
 
 				it("and correct arguments, when top subcommand is called and it has its own subcommand", () => {
-					let commandName = "sample|command";
-					let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command"].concat(sampleArguments));
+					const commandName = "sample|command";
+					const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command"].concat(sampleArguments));
 					assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 					assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, sampleArguments, "All arguments except the ones used for commandName should be returned.");
 				});
 
 				it("when subcommand of subcommand is called and it has its own subcommand", () => {
-					let commandName = "sample|command|with";
-					let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "with"]);
+					const commandName = "sample|command|with";
+					const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "with"]);
 					assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 					assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, [], "There shouldn't be any arguments left.");
 				});
 
 				it("and correct arguments, when subcommand of subcommand is called and it has its own subcommand", () => {
-					let commandName = "sample|command|with";
-					let buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "with"].concat(sampleArguments));
+					const commandName = "sample|command|with";
+					const buildHierarchicalCommandResult = injector.buildHierarchicalCommand("sample", ["command", "with"].concat(sampleArguments));
 					assert.deepEqual(buildHierarchicalCommandResult.commandName, commandName, `The expected command name is ${commandName}`);
 					assert.deepEqual(buildHierarchicalCommandResult.remainingArguments, sampleArguments, "All arguments except the ones used for commandName should be returned.");
 				});
@@ -675,15 +675,15 @@ $injector.register("a", A);
 	});
 
 	it("adds whole class to public api when requirePublicClass is used", () => {
-		let injector = new Yok();
-		let dataObject = {
+		const injector = new Yok();
+		const dataObject = {
 			a: "testA",
 			b: {
 				c: "testC"
 			}
 		};
 
-		let filepath = path.join(__dirname, "..", "..", "temp.js");
+		const filepath = path.join(__dirname, "..", "..", "temp.js");
 		fs.writeFileSync(filepath, "");
 
 		// Call to requirePublicClass will add the class to publicApi object.
@@ -691,7 +691,7 @@ $injector.register("a", A);
 		injector.register("foo", dataObject);
 		// Get the real instance here, so we can delete the file before asserts.
 		// This way we'll keep the directory clean, even if assert fails.
-		let resultFooObject = injector.publicApi.foo;
+		const resultFooObject = injector.publicApi.foo;
 		fs.unlinkSync(filepath);
 		assert.isTrue(_.includes(Object.getOwnPropertyNames(injector.publicApi), "foo"));
 		assert.deepEqual(resultFooObject, dataObject);

--- a/tslint.json
+++ b/tslint.json
@@ -13,6 +13,7 @@
 			false,
 			140
 		],
+		"prefer-const": true,
 		"no-consecutive-blank-lines": true,
 		"no-construct": true,
 		"no-debugger": true,

--- a/utils.ts
+++ b/utils.ts
@@ -5,7 +5,7 @@ export class Utils implements IUtils {
 	public getParsedTimeout(defaultTimeout: number): number {
 		let timeout = defaultTimeout;
 		if (this.$options.timeout) {
-			let parsedValue = parseInt(this.$options.timeout);
+			const parsedValue = parseInt(this.$options.timeout);
 			if (!isNaN(parsedValue) && parsedValue >= 0) {
 				timeout = parsedValue;
 			} else {
@@ -17,7 +17,7 @@ export class Utils implements IUtils {
 	}
 
 	public getMilliSecondsTimeout(defaultTimeout: number): number {
-		let timeout = this.getParsedTimeout(defaultTimeout);
+		const timeout = this.getParsedTimeout(defaultTimeout);
 		return timeout * 1000;
 	}
 }

--- a/validators/iTunes-validator.ts
+++ b/validators/iTunes-validator.ts
@@ -11,7 +11,7 @@ export class ITunesValidator implements Mobile.IiTunesValidator {
 	public getError(): string {
 		if (this.$hostInfo.isWindows) {
 			let commonProgramFiles = "";
-			let isNode64 = process.arch === "x64";
+			const isNode64 = process.arch === "x64";
 
 			if (isNode64) { //x64-windows
 				commonProgramFiles = process.env.CommonProgramFiles;
@@ -37,8 +37,8 @@ export class ITunesValidator implements Mobile.IiTunesValidator {
 
 			return null;
 		} else if (this.$hostInfo.isDarwin) {
-			let coreFoundationDir = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
-			let mobileDeviceDir = "/System/Library/PrivateFrameworks/MobileDevice.framework/MobileDevice";
+			const coreFoundationDir = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+			const mobileDeviceDir = "/System/Library/PrivateFrameworks/MobileDevice.framework/MobileDevice";
 
 			if (!this.isiTunesInstalledCore(coreFoundationDir, mobileDeviceDir)) {
 				return ITunesValidator.NOT_INSTALLED_iTUNES_ERROR_MESSAGE;
@@ -51,8 +51,8 @@ export class ITunesValidator implements Mobile.IiTunesValidator {
 	}
 
 	private isiTunesInstalledOnWindows(commonProgramFiles: string): boolean {
-		let coreFoundationDir = path.join(commonProgramFiles, "Apple", "Apple Application Support");
-		let mobileDeviceDir = path.join(commonProgramFiles, "Apple", "Mobile Device Support");
+		const coreFoundationDir = path.join(commonProgramFiles, "Apple", "Apple Application Support");
+		const mobileDeviceDir = path.join(commonProgramFiles, "Apple", "Mobile Device Support");
 
 		return this.isiTunesInstalledCore(coreFoundationDir, mobileDeviceDir);
 	}

--- a/validators/project-name-validator.ts
+++ b/validators/project-name-validator.ts
@@ -18,8 +18,8 @@ export class ProjectNameValidator implements IProjectNameValidator {
 	constructor(private $errors: IErrors) { }
 
 	private validateName(name: string): ValidationResult.ValidationResult {
-		let validNameRegex = /^[a-zA-Z0-9_.\- ]*$/g;
-		let ext = path.extname(name);
+		const validNameRegex = /^[a-zA-Z0-9_.\- ]*$/g;
+		const ext = path.extname(name);
 
 		if (helpers.isNullOrWhitespace(name)) {
 			return new ValidationResult.ValidationResult(ProjectNameValidator.EMPTY_FILENAME_ERROR_MESSAGE);
@@ -50,8 +50,8 @@ export class ProjectNameValidator implements IProjectNameValidator {
 	}
 
 	public validate(name: string): boolean {
-		let validationResult: ValidationResult.ValidationResult = this.validateName(name);
-		let isSuccessful = validationResult.isSuccessful;
+		const validationResult: ValidationResult.ValidationResult = this.validateName(name);
+		const isSuccessful = validationResult.isSuccessful;
 
 		if (!isSuccessful) {
 			this.$errors.fail(validationResult.error);

--- a/verify-node-version.ts
+++ b/verify-node-version.ts
@@ -2,7 +2,7 @@
 // This function must be separate to avoid dependencies on C++ modules - it must execute precisely when other functions cannot
 
 // Use only ES5 code here - pure JavaScript can be executed with any Node.js version (even 0.10, 0.12).
-/* tslint:disable:no-var-keyword no-var-requires */
+/* tslint:disable:no-var-keyword no-var-requires prefer-const*/
 var os = require("os"),
 	semver = require("semver"),
 	util = require("util");

--- a/winreg.ts
+++ b/winreg.ts
@@ -1,4 +1,4 @@
-let Registry = require("winreg");
+const Registry = require("winreg");
 
 export class WinReg implements IWinReg {
 	public registryKeys: IHiveIds = {
@@ -12,7 +12,7 @@ export class WinReg implements IWinReg {
 	public async getRegistryValue(valueName: string, hive?: IHiveId, key?: string, host?: string): Promise<IWinRegResult> {
 		return new Promise<IWinRegResult>((resolve, reject) => {
 			try {
-				let regKey = new Registry({
+				const regKey = new Registry({
 					hive: (hive && hive.registry) ? hive.registry : null,
 					key: key,
 					host: host

--- a/yok.ts
+++ b/yok.ts
@@ -60,14 +60,14 @@ export class Yok implements IInjector {
 
 	public requireCommand(names: any, file: string): void {
 		forEachName(names, (commandName) => {
-			let commands = commandName.split("|");
+			const commands = commandName.split("|");
 
 			if (commands.length > 1) {
 				if (_.startsWith(commands[1], '*') && this.modules[this.createCommandName(commands[0])]) {
 					throw new Error("Default commands should be required before child commands");
 				}
 
-				let parentCommandName = commands[0];
+				const parentCommandName = commands[0];
 
 				if (!this.hierarchicalCommands[parentCommandName]) {
 					this.hierarchicalCommands[parentCommandName] = [];
@@ -136,8 +136,8 @@ export class Yok implements IInjector {
 	}
 
 	private requireOne(name: string, file: string): void {
-		let relativePath = path.join("../", file);
-		let dependency: IDependency = {
+		const relativePath = path.join("../", file);
+		const dependency: IDependency = {
 			require: require("fs").existsSync(path.join(__dirname, relativePath + ".js")) ? relativePath : file,
 			shared: true
 		};
@@ -151,7 +151,7 @@ export class Yok implements IInjector {
 
 	public registerCommand(names: any, resolver: any): void {
 		forEachName(names, (name) => {
-			let commands = name.split("|");
+			const commands = name.split("|");
 			this.register(this.createCommandName(name), resolver);
 
 			if (commands.length > 1) {
@@ -161,14 +161,14 @@ export class Yok implements IInjector {
 	}
 
 	private getDefaultCommand(name: string) {
-		let subCommands = this.hierarchicalCommands[name];
-		let defaultCommand = _.find(subCommands, (command) => _.startsWith(command, "*"));
+		const subCommands = this.hierarchicalCommands[name];
+		const defaultCommand = _.find(subCommands, (command) => _.startsWith(command, "*"));
 		return defaultCommand;
 	}
 
 	public buildHierarchicalCommand(parentCommandName: string, commandLineArguments: string[]): any {
 		let currentSubCommandName: string, finalSubCommandName: string, matchingSubCommandName: string;
-		let subCommands = this.hierarchicalCommands[parentCommandName];
+		const subCommands = this.hierarchicalCommands[parentCommandName];
 		let remainingArguments = commandLineArguments;
 		let finalRemainingArguments = commandLineArguments;
 		let foundSubCommand = false;
@@ -191,17 +191,17 @@ export class Yok implements IInjector {
 	}
 
 	private createHierarchicalCommand(name: string) {
-		let factory = () => {
+		const factory = () => {
 			return {
 				disableAnalytics: true,
 				execute: async (args: string[]): Promise<void> => {
-					let commandsService = $injector.resolve("commandsService");
+					const commandsService = $injector.resolve("commandsService");
 					let commandName: string = null;
-					let defaultCommand = this.getDefaultCommand(name);
+					const defaultCommand = this.getDefaultCommand(name);
 					let commandArguments: ICommandArgument[] = [];
 
 					if (args.length > 0) {
-						let hierarchicalCommand = this.buildHierarchicalCommand(name, args);
+						const hierarchicalCommand = this.buildHierarchicalCommand(name, args);
 						if (hierarchicalCommand) {
 							commandName = hierarchicalCommand.commandName;
 							commandArguments = hierarchicalCommand.remainingArguments;
@@ -223,7 +223,7 @@ export class Yok implements IInjector {
 							commandName = "help";
 
 							// Show command-line help
-							let options = this.resolve("options");
+							const options = this.resolve("options");
 							options.help = true;
 						}
 					}
@@ -242,20 +242,20 @@ export class Yok implements IInjector {
 
 	public async isValidHierarchicalCommand(commandName: string, commandArguments: string[]): Promise<boolean> {
 		if (_.includes(Object.keys(this.hierarchicalCommands), commandName)) {
-			let defaultCommandName = this.getDefaultCommand(commandName);
+			const defaultCommandName = this.getDefaultCommand(commandName);
 			if (defaultCommandName && (!commandArguments || commandArguments.length === 0)) {
 				// Will execute default command as there aren't passed arguments.
 				return true;
 			}
 
-			let subCommands = this.hierarchicalCommands[commandName];
+			const subCommands = this.hierarchicalCommands[commandName];
 			if (subCommands) {
-				let fullCommandName = this.buildHierarchicalCommand(commandName, commandArguments);
+				const fullCommandName = this.buildHierarchicalCommand(commandName, commandArguments);
 				if (!fullCommandName) {
 					// The passed arguments are not one of the subCommands.
 					// Check if the default command accepts arguments - if no, return false;
 
-					let defaultCommand = this.resolveCommand(`${commandName}|${defaultCommandName}`);
+					const defaultCommand = this.resolveCommand(`${commandName}|${defaultCommandName}`);
 					if (defaultCommand) {
 						if (defaultCommand.canExecute) {
 							return await defaultCommand.canExecute(commandArguments);
@@ -266,7 +266,7 @@ export class Yok implements IInjector {
 						}
 					}
 
-					let errors = $injector.resolve("errors");
+					const errors = $injector.resolve("errors");
 					errors.fail(ERROR_NO_VALID_SUBCOMMAND_FORMAT, commandName);
 				}
 
@@ -285,7 +285,7 @@ export class Yok implements IInjector {
 		shared = shared === undefined ? true : shared;
 		trace("registered '%s'", name);
 
-		let dependency: any = this.modules[name] || {};
+		const dependency: any = this.modules[name] || {};
 		dependency.shared = shared;
 
 		if (_.isFunction(resolver)) {
@@ -299,7 +299,7 @@ export class Yok implements IInjector {
 
 	public resolveCommand(name: string): ICommand {
 		let command: ICommand;
-		let commandModuleName = this.createCommandName(name);
+		const commandModuleName = this.createCommandName(name);
 		if (!this.modules[commandModuleName]) {
 			return null;
 		}
@@ -327,8 +327,8 @@ export class Yok implements IInjector {
 	}
 
 	public getDynamicCallData(call: string, args?: any[]): any {
-		let parsed = call.match(this.dynamicCallRegex);
-		let module = this.resolve(parsed[1]);
+		const parsed = call.match(this.dynamicCallRegex);
+		const module = this.resolve(parsed[1]);
 		if (!args && parsed[3]) {
 			args = _.map(parsed[4].split(","), arg => arg.trim());
 		}
@@ -349,7 +349,7 @@ export class Yok implements IInjector {
 	private resolveConstructor(ctor: Function, ctorArguments?: { [key: string]: any }): any {
 		annotate(ctor);
 
-		let resolvedArgs = ctor.$inject.args.map(paramName => {
+		const resolvedArgs = ctor.$inject.args.map(paramName => {
 			if (ctorArguments && ctorArguments.hasOwnProperty(paramName)) {
 				return ctorArguments[paramName];
 			} else {
@@ -357,7 +357,7 @@ export class Yok implements IInjector {
 			}
 		});
 
-		let name = ctor.$inject.name;
+		const name = ctor.$inject.name;
 		if (name && name[0] === name[0].toUpperCase()) {
 			return new (<any>ctor)(...resolvedArgs);
 		} else {
@@ -402,7 +402,7 @@ export class Yok implements IInjector {
 	}
 
 	private resolveDependency(name: string): IDependency {
-		let module = this.modules[name];
+		const module = this.modules[name];
 		if (!module) {
 			throw new Error("unable to resolve " + name);
 		}
@@ -414,8 +414,8 @@ export class Yok implements IInjector {
 	}
 
 	public getRegisteredCommandsNames(includeDev: boolean): string[] {
-		let modulesNames: string[] = _.keys(this.modules);
-		let commandsNames: string[] = _.filter(modulesNames, moduleName => _.startsWith(moduleName, `${this.COMMANDS_NAMESPACE}.`));
+		const modulesNames: string[] = _.keys(this.modules);
+		const commandsNames: string[] = _.filter(modulesNames, moduleName => _.startsWith(moduleName, `${this.COMMANDS_NAMESPACE}.`));
 		let commands = _.map(commandsNames, (commandName: string) => commandName.substr(this.COMMANDS_NAMESPACE.length + 1));
 		if (!includeDev) {
 			commands = _.reject(commands, (command) => _.startsWith(command, "dev-"));
@@ -433,7 +433,7 @@ export class Yok implements IInjector {
 
 	public dispose(): void {
 		Object.keys(this.modules).forEach((moduleName) => {
-			let instance = this.modules[moduleName].instance;
+			const instance = this.modules[moduleName].instance;
 			if (instance && instance.dispose && instance !== this) {
 				instance.dispose();
 			}


### PR DESCRIPTION
Enable `prefer-const` rule in tslint and fix the errors:
The rule requires that variable declarations use const instead of let and var if possible.

If a variable is only assigned to once when it is declared, it should be declared using `const`

The prefer-const rule checks the code and verifies the usage of let and const