### PR TITLE
fixed lineStream getting data before application is restarted and pid reset

### DIFF
--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -65,10 +65,10 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		const possibleIdentifier = match && match[0];
 
 		if (possibleIdentifier) {
-			await this.adb.executeShellCommand(["am", "start", "-n", possibleIdentifier]);
+			await this.adb.executeShellCommand(["am", "start", "-n", possibleIdentifier], { returnChildProcess: true });
 		} else {
 			this.$logger.trace(`Tried starting activity for: ${appIdentifier}, using activity manager but failed.`);
-			await this.adb.executeShellCommand(["monkey", "-p", appIdentifier, "-c", "android.intent.category.LAUNCHER", "1"]);
+			await this.adb.executeShellCommand(["monkey", "-p", appIdentifier, "-c", "android.intent.category.LAUNCHER", "1"], { returnChildProcess: true });
 		}
 
 		if (!this.$options.justlaunch) {


### PR DESCRIPTION
_problem_:
On emulator, API level 19, we don't log `console.log()` set in `app.js` because [this event](https://github.com/telerik/mobile-cli-lib/blob/master/mobile/android/logcat-helper.ts#L40) fires before [new pid is set on restart of application](https://github.com/telerik/mobile-cli-lib/blob/master/mobile/android/android-application-manager.ts#L78). This happens because we don't use [the same process](https://github.com/telerik/mobile-cli-lib/blob/master/mobile/android/android-debug-bridge.ts#L24).

_how to reproduce_:
linux, emulator x86 API level 19 in a regular application created with `tns create app` in `app.js`
```
...
var application = require("application");
console.log("### I should appear during livesync");
...
```

_solution_:
Add option `returnChildProcess` when starting the application.

Theoretically, this should happen on other emulators too if the application is not started fast enough.