### PR TITLE
Add lockfile service and lock operation for writing user settings file

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -119,3 +119,5 @@ $injector.require("net", "./services/net-service");
 $injector.require("qr", "./services/qr");
 $injector.require("printPluginsService", "./services/plugins/print-plugins-service");
 $injector.require("npmPluginsService", "./services/plugins/npm-plugins-service");
+
+$injector.require("lockfile", "./services/lockfile");

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1893,3 +1893,64 @@ interface IiOSNotificationService {
 	 */
 	postNotification(deviceIdentifier: string, notification: string, commandType?: string): Promise<number>;
 }
+
+/**
+ * Copied from @types/lockfile
+ * Describes the options that can be passed to lockfile methods.
+ */
+interface ILockFileOptions {
+	/**
+	 * A number of milliseconds to wait for locks to expire before giving up.
+	 * Only used by lockFile.lock. Poll for opts.wait ms.
+	 * If the lock is not cleared by the time the wait expires, then it returns with the original error.
+	 */
+	wait?: number;
+
+	/**
+	 * When using opts.wait, this is the period in ms in which it polls to check if the lock has expired. Defaults to 100.
+	 */
+	pollPeriod?: number;
+
+	/**
+	 * A number of milliseconds before locks are considered to have expired.
+	 */
+	stale?: number;
+
+	/**
+	 * Used by lock and lockSync. Retry n number of times before giving up.
+	 */
+	retries?: number;
+
+	/**
+	 * Used by lock. Wait n milliseconds before retrying.
+	 */
+	retryWait?: number;
+}
+
+/**
+ * Describes methods that can be used to use file locking.
+ */
+interface ILockFile {
+	/**
+	 * Acquire a file lock on the specified path.
+	 * @param {string} lockFilePath Path to lockfile that has to be created. Defaults to `<profile dir>/lockfile.lock`
+	 * @param {ILockFileOptions} lockFileOpts Options used for creating the lockfile.
+	 * @returns {Promise<void>}
+	 */
+	lock(lockFilePath?: string, lockFileOpts?: ILockFileOptions): Promise<void>;
+
+	/**
+	 * Close and unlink the lockfile.
+	 * @param {string} lockFilePath Path to lockfile that has to be created. Defaults to `<profile dir>/lockfile.lock`
+	 * @returns {void}
+	 */
+	unlock(lockFilePath?: string): void;
+
+	/**
+	 * Check if the lockfile is locked and not stale.
+	 * @param {string} lockFilePath Path to lockfile that has to be created. Defaults to `<profile dir>/lockfile.lock`
+	 * @param {ILockFileOptions} lockFileOpts Options used for creating the lockfile.
+	 * @returns {boolean} true in case file is locked, false otherwise
+	 */
+	check(lockFilePath?: string, lockFileOpts?: ILockFileOptions): boolean;
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "inquirer": "0.8.2",
     "ios-device-lib": "~0.3.0",
     "ios-sim-portable": "~3.1.0",
+    "lockfile": "1.0.3",
     "lodash": "4.13.1",
     "log4js": "0.6.9",
     "marked": "0.3.3",
@@ -75,6 +76,7 @@
   "devDependencies": {
     "@types/chai": "4.0.1",
     "@types/chai-as-promised": "0.0.31",
+    "@types/lockfile": "1.0.0",
     "@types/node": "6.0.61",
     "@types/qr-image": "3.2.0",
     "@types/request": "0.0.45",

--- a/services/lockfile.ts
+++ b/services/lockfile.ts
@@ -1,0 +1,57 @@
+import * as lockfile from "lockfile";
+import * as path from "path";
+
+export class LockFile implements ILockFile {
+
+	private get defaultLockFilePath(): string {
+		return path.join(this.$options.profileDir, "lockfile.lock");
+	}
+
+	private get defaultLockParams(): lockfile.Options {
+		// We'll retry 100 times and time between retries is 100ms, i.e. full wait in case we are unable to get lock will be 10 seconds.
+		// In case lock is older than 3 minutes, consider it stale and try to get a new lock.
+		const lockParams: lockfile.Options = {
+			retryWait: 100,
+			retries: 100,
+			stale: 180 * 1000,
+		};
+
+		return lockParams;
+	}
+
+	constructor(private $options: ICommonOptions) {
+	}
+
+	public lock(lockFilePath?: string, lockFileOpts?: lockfile.Options): Promise<void> {
+		const { filePath, fileOpts } = this.getLockFileSettings(lockFilePath, lockFileOpts);
+
+		return new Promise<void>((resolve, reject) => {
+			lockfile.lock(filePath, fileOpts, (err: Error) => {
+				err ? reject(err) : resolve();
+			});
+		});
+	}
+
+	public unlock(lockFilePath?: string): void {
+		const { filePath } = this.getLockFileSettings(lockFilePath);
+		lockfile.unlockSync(filePath);
+	}
+
+	public check(lockFilePath?: string, lockFileOpts?: lockfile.Options): boolean {
+		const { filePath, fileOpts } = this.getLockFileSettings(lockFilePath, lockFileOpts);
+
+		return lockfile.checkSync(filePath, fileOpts);
+	}
+
+	private getLockFileSettings(filePath?: string, fileOpts?: lockfile.Options): { filePath: string, fileOpts: lockfile.Options } {
+		filePath = filePath || this.defaultLockFilePath;
+		fileOpts = fileOpts || this.defaultLockParams;
+
+		return {
+			filePath,
+			fileOpts
+		};
+	}
+}
+
+$injector.register("lockfile", LockFile);

--- a/services/user-settings-service.ts
+++ b/services/user-settings-service.ts
@@ -14,12 +14,12 @@ export class UserSettingsServiceBase implements IUserSettingsService {
 	}
 
 	public async getSettingValue<T>(settingName: string): Promise<T> {
-		const action = async () => {
+		const action = async (): Promise<T> => {
 			await this.loadUserSettingsFile();
 			return this.userSettingsData ? this.userSettingsData[settingName] : null;
 		};
 
-		return this.executeActionWithLock(action);
+		return this.executeActionWithLock<T>(action);
 	}
 
 	public async saveSetting<T>(key: string, value: T): Promise<void> {
@@ -30,18 +30,18 @@ export class UserSettingsServiceBase implements IUserSettingsService {
 	}
 
 	public async removeSetting(key: string): Promise<void> {
-		const action = async () => {
+		const action = async (): Promise<void> => {
 			await this.loadUserSettingsFile();
 
 			delete this.userSettingsData[key];
 			await this.saveSettings();
 		};
 
-		return this.executeActionWithLock(action);
+		return this.executeActionWithLock<void>(action);
 
 	}
 
-	private async executeActionWithLock(action: () => Promise<any>): Promise<any> {
+	private async executeActionWithLock<T>(action: () => Promise<T>): Promise<T> {
 		try {
 			await this.$lockfile.lock(this.lockFilePath);
 			const result = await action();
@@ -52,7 +52,7 @@ export class UserSettingsServiceBase implements IUserSettingsService {
 	}
 
 	public saveSettings(data?: any): Promise<void> {
-		const action = async () => {
+		const action = async (): Promise<void> => {
 			await this.loadUserSettingsFile();
 			this.userSettingsData = this.userSettingsData || {};
 
@@ -65,7 +65,7 @@ export class UserSettingsServiceBase implements IUserSettingsService {
 			this.$fs.writeJson(this.userSettingsFilePath, this.userSettingsData);
 		};
 
-		return this.executeActionWithLock(action);
+		return this.executeActionWithLock<void>(action);
 	}
 
 	// TODO: Remove Promise, reason: writeFile - blocked as other implementation of the interface has async operation.

--- a/services/user-settings-service.ts
+++ b/services/user-settings-service.ts
@@ -3,15 +3,23 @@ import * as path from "path";
 export class UserSettingsServiceBase implements IUserSettingsService {
 	private userSettingsFilePath: string = null;
 	protected userSettingsData: any = null;
+	private get lockFilePath(): string {
+		return `${this.userSettingsFilePath}.lock`;
+	}
 
 	constructor(userSettingsFilePath: string,
-		protected $fs: IFileSystem) {
+		protected $fs: IFileSystem,
+		protected $lockfile: ILockFile) {
 		this.userSettingsFilePath = userSettingsFilePath;
 	}
 
 	public async getSettingValue<T>(settingName: string): Promise<T> {
-		await this.loadUserSettingsFile();
-		return this.userSettingsData ? this.userSettingsData[settingName] : null;
+		const action = async () => {
+			await this.loadUserSettingsFile();
+			return this.userSettingsData ? this.userSettingsData[settingName] : null;
+		};
+
+		return this.executeActionWithLock(action);
 	}
 
 	public async saveSetting<T>(key: string, value: T): Promise<void> {
@@ -22,44 +30,67 @@ export class UserSettingsServiceBase implements IUserSettingsService {
 	}
 
 	public async removeSetting(key: string): Promise<void> {
-		await this.loadUserSettingsFile();
+		const action = async () => {
+			await this.loadUserSettingsFile();
 
-		delete this.userSettingsData[key];
-		await this.saveSettings();
+			delete this.userSettingsData[key];
+			await this.saveSettings();
+		};
+
+		return this.executeActionWithLock(action);
+
 	}
 
-	public async saveSettings(data?: any): Promise<void> {
-		await this.loadUserSettingsFile();
-		this.userSettingsData = this.userSettingsData || {};
+	private async executeActionWithLock(action: () => Promise<any>): Promise<any> {
+		try {
+			await this.$lockfile.lock(this.lockFilePath);
+			const result = await action();
+			return result;
+		} finally {
+			this.$lockfile.unlock(this.lockFilePath);
+		}
+	}
 
-		_(data)
-			.keys()
-			.each(propertyName => {
-				this.userSettingsData[propertyName] = data[propertyName];
-			});
+	public saveSettings(data?: any): Promise<void> {
+		const action = async () => {
+			await this.loadUserSettingsFile();
+			this.userSettingsData = this.userSettingsData || {};
 
-		this.$fs.writeJson(this.userSettingsFilePath, this.userSettingsData);
+			_(data)
+				.keys()
+				.each(propertyName => {
+					this.userSettingsData[propertyName] = data[propertyName];
+				});
+
+			this.$fs.writeJson(this.userSettingsFilePath, this.userSettingsData);
+		};
+
+		return this.executeActionWithLock(action);
 	}
 
 	// TODO: Remove Promise, reason: writeFile - blocked as other implementation of the interface has async operation.
 	public async loadUserSettingsFile(): Promise<void> {
 		if (!this.userSettingsData) {
-			if (!this.$fs.exists(this.userSettingsFilePath)) {
-				const unexistingDirs = this.getUnexistingDirectories(this.userSettingsFilePath);
+			await this.loadUserSettingsData();
+		}
+	}
 
-				this.$fs.writeFile(this.userSettingsFilePath, null);
+	protected async loadUserSettingsData(): Promise<void> {
+		if (!this.$fs.exists(this.userSettingsFilePath)) {
+			const unexistingDirs = this.getUnexistingDirectories(this.userSettingsFilePath);
 
-				// when running under 'sudo' we create the <path to home dir>/.local/share/.nativescript-cli dir with root as owner
-				// and other Applications cannot access this directory anymore. (bower/heroku/etc)
-				if (process.env.SUDO_USER) {
-					for (const dir of unexistingDirs) {
-						await this.$fs.setCurrentUserAsOwner(dir, process.env.SUDO_USER);
-					}
+			this.$fs.writeFile(this.userSettingsFilePath, null);
+
+			// when running under 'sudo' we create the <path to home dir>/.local/share/.nativescript-cli dir with root as owner
+			// and other Applications cannot access this directory anymore. (bower/heroku/etc)
+			if (process.env.SUDO_USER) {
+				for (const dir of unexistingDirs) {
+					await this.$fs.setCurrentUserAsOwner(dir, process.env.SUDO_USER);
 				}
 			}
-
-			this.userSettingsData = this.$fs.readJson(this.userSettingsFilePath);
 		}
+
+		this.userSettingsData = this.$fs.readJson(this.userSettingsFilePath);
 	}
 
 	private getUnexistingDirectories(filePath: string): Array<string> {


### PR DESCRIPTION
Add new lockfile service (use lockfile npm package) and lock all operations for reading/writing user-settings.json.
These operations may be executed in different processes, so they must be synced between them.