### PR TITLE
Clear deviceLib instance on dispose

### DIFF
--- a/mobile/ios/device/ios-device-operations.ts
+++ b/mobile/ios/device/ios-device-operations.ts
@@ -164,6 +164,7 @@ export class IOSDeviceOperations implements IIOSDeviceOperations, IDisposable {
 		if (this.shouldDispose && this.deviceLib) {
 			this.deviceLib.removeAllListeners();
 			this.deviceLib.dispose(signal);
+			this.deviceLib = null;
 			this.$logger.trace("IOSDeviceOperations disposed.");
 		}
 	}


### PR DESCRIPTION
After disposing set `this.deviceLib` to `null` in order to prevent any future disposals.

Ping @TsvetanMilanov 