### PR TITLE
Fix iOS11 Simulator log

### DIFF
--- a/mobile/ios/simulator/ios-simulator-log-provider.ts
+++ b/mobile/ios/simulator/ios-simulator-log-provider.ts
@@ -10,7 +10,7 @@ export class IOSSimulatorLogProvider implements Mobile.IiOSSimulatorLogProvider 
 
 	public startLogProcess(deviceIdentifier: string): void {
 		if (!this.isStarted) {
-			const deviceLogChildProcess: ChildProcess = this.$iOSSimResolver.iOSSim.getDeviceLogProcess(deviceIdentifier);
+			const deviceLogChildProcess: ChildProcess = this.$iOSSimResolver.iOSSim.getDeviceLogProcess(deviceIdentifier, 'senderImagePath contains "NativeScript"');
 
 			const action = (data: NodeBuffer | string) => {
 				this.$deviceLogProvider.logData(data.toString(), this.$devicePlatformsConstants.iOS, deviceIdentifier);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "iconv-lite": "0.4.3",
     "inquirer": "0.8.2",
     "ios-device-lib": "~0.3.0",
-    "ios-sim-portable": "~3.1.0",
+    "ios-sim-portable": "3.2.0",
     "lockfile": "1.0.3",
     "lodash": "4.13.1",
     "log4js": "0.6.9",


### PR DESCRIPTION
Part of the fix for https://github.com/NativeScript/nativescript-cli/issues/3141#issuecomment-333449119.

Log format for iOS 10.3: "Oct  3 19:07:55 machinename cliapp[15339]: CONSOLE LOG file:///app/main-view-model.js:18:20: Test Console fix..."

Log format for iOS 11: "2017-10-09 13:34:38.527844+0300  localhost cliapp[22235]: (NativeScript) CONSOLE LOG file:///app/main-view-model.js:18:20: Test Console fix.."