### PR TITLE
Fix unit tests on Windows

### DIFF
--- a/test/unit-tests/mobile/android/logcat-helper.ts
+++ b/test/unit-tests/mobile/android/logcat-helper.ts
@@ -11,14 +11,17 @@ class ChildProcessStub {
 	public spawn(command: string, args?: string[], options?: any): childProcess.ChildProcess {
 		ChildProcessStub.methodCallCount++;
 		let pathToExecutable = "";
+		let shell = "";
 		if (this.isWin) {
 			pathToExecutable = "type";
+			shell = "cmd";
 		} else {
 			pathToExecutable = "cat";
 		}
 		pathToExecutable = path.join(pathToExecutable);
 		const pathToSample = path.join(__dirname, "valid-sample.txt");
-		return childProcess.spawn(pathToExecutable, [pathToSample]);
+
+		return childProcess.spawn(pathToExecutable, [pathToSample], { shell });
 	}
 }
 


### PR DESCRIPTION
Currently unit tests fail on Windows as the `type` command used in the tests is not a real executable - it is integrated in the `cmd`. So spawning `type` fails and the tests fail as well.
In order to fix this, pass `shell` option to child process, so the child process will spawn CMD and after that type command will succeed.