### PR TITLE
Fix leaking handlers for iOS device logs

### DIFF
--- a/appbuilder/device-emitter.ts
+++ b/appbuilder/device-emitter.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import { DeviceDiscoveryEventNames } from "../constants";
+import { DeviceDiscoveryEventNames, DEVICE_LOG_EVENT_NAME } from "../constants";
 
 export class DeviceEmitter extends EventEmitter {
 	constructor(private $deviceLogProvider: EventEmitter,
@@ -34,7 +34,7 @@ export class DeviceEmitter extends EventEmitter {
 		});
 
 		this.$deviceLogProvider.on("data", (identifier: string, data: any) => {
-			this.emit('deviceLogData', identifier, data.toString());
+			this.emit(DEVICE_LOG_EVENT_NAME, identifier, data.toString());
 		});
 	}
 

--- a/constants.ts
+++ b/constants.ts
@@ -39,6 +39,8 @@ export class DeviceDiscoveryEventNames {
 	static DEVICE_LOST = "deviceLost";
 }
 
+export const DEVICE_LOG_EVENT_NAME = "deviceLogData";
+
 export const TARGET_FRAMEWORK_IDENTIFIERS = {
 	Cordova: "Cordova",
 	NativeScript: "NativeScript"

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -96,6 +96,12 @@ declare module Mobile {
 		isEmulator: boolean;
 		openDeviceLogStream(): Promise<void>;
 		getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo>;
+
+		/**
+		 * Called when device is lost. Its purpose is to clean any resources used by the instance.
+		 * @returns {void}
+		 */
+		detach?(): void;
 	}
 
 	interface IiOSDevice extends IDevice {
@@ -767,14 +773,14 @@ declare module Mobile {
 	}
 }
 
-interface IIOSDeviceOperations extends IDisposable {
+interface IIOSDeviceOperations extends IDisposable, NodeJS.EventEmitter {
 	install(ipaPath: string, deviceIdentifiers: string[], errorHandler?: DeviceOperationErrorHandler): Promise<IOSDeviceResponse>;
 
 	uninstall(appIdentifier: string, deviceIdentifiers: string[], errorHandler?: DeviceOperationErrorHandler): Promise<IOSDeviceResponse>;
 
 	startLookingForDevices(deviceFoundCallback: DeviceInfoCallback, deviceLostCallback: DeviceInfoCallback, options?: Mobile.IDeviceLookingOptions): Promise<void>;
 
-	startDeviceLog(deviceIdentifier: string, printLogFunction: (response: IOSDeviceLib.IDeviceLogData) => void): void;
+	startDeviceLog(deviceIdentifier: string): void;
 
 	apps(deviceIdentifiers: string[], errorHandler?: DeviceOperationErrorHandler): Promise<IOSDeviceAppInfo>;
 

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -139,6 +139,11 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 
 	private onDeviceLost(device: Mobile.IDevice): void {
 		this.$logger.trace(`Lost device with identifier '${device.deviceInfo.identifier}'`);
+
+		if (device.detach) {
+			device.detach();
+		}
+
 		delete this._devices[device.deviceInfo.identifier];
 		this.emit(constants.DeviceDiscoveryEventNames.DEVICE_LOST, device);
 	}

--- a/test/unit-tests/appbuilder/device-emitter.ts
+++ b/test/unit-tests/appbuilder/device-emitter.ts
@@ -3,7 +3,7 @@ import { assert } from "chai";
 import { EventEmitter } from "events";
 import { ProjectConstants } from "../../../appbuilder/project-constants";
 import { DeviceEmitter } from "../../../appbuilder/device-emitter";
-import { DeviceDiscoveryEventNames } from "../../../constants";
+import { DeviceDiscoveryEventNames, DEVICE_LOG_EVENT_NAME } from "../../../constants";
 // Injector dependencies must be classes.
 // EventEmitter is function, so our annotate method will fail.
 class CustomEventEmitter extends EventEmitter {
@@ -109,11 +109,11 @@ describe("deviceEmitter", () => {
 				deviceLogProvider = testInjector.resolve("deviceLogProvider");
 			});
 
-			describe("raises deviceLogData with correct identifier and data", () => {
+			describe(`raises ${DEVICE_LOG_EVENT_NAME} with correct identifier and data`, () => {
 				const expectedDeviceLogData = "This is some log data from device.";
 
 				const attachDeviceLogDataVerificationHandler = (expectedDeviceIdentifier: string, done: mocha.Done) => {
-					deviceEmitter.on("deviceLogData", (identifier: string, data: any) => {
+					deviceEmitter.on(DEVICE_LOG_EVENT_NAME, (identifier: string, data: any) => {
 						assert.deepEqual(identifier, expectedDeviceIdentifier);
 						assert.deepEqual(data, expectedDeviceLogData);
 						// Wait for all operations to be completed and call done after that.


### PR DESCRIPTION
In case iOS Device is detached, the `IOSDevice` instance is kept alive. The reason is the handler for device logs, that `IOSDevice` passes to `iOSDeviceOperations`.
As `iOSDeviceOperations` is still alive, the `IOSDevice` instance is also alive. Reattaching the same device will cause duplicate logs. Detaching and attaching it again will lead to additional logs.

In order to fix the issue, convert `iOSDeviceOpertations` to event emitter and emit event when there's data for logging. Each `IOSDevice` will add handler for the event and will do its logic.
In case device is detached (i.e. `DeviceLost` event is fired in `DevicesService`), call a newly added method to the specific `IDevice` instance. It's purpose is to clean the used resource.
For iOS device, this method will remove the handler for `devceLogData` event of `iOSDeviceOperations`.