### PR TITLE
Use profileDir from settingsService

### DIFF
--- a/appbuilder/proton-static-config.ts
+++ b/appbuilder/proton-static-config.ts
@@ -20,5 +20,7 @@ export class ProtonStaticConfig extends StaticConfigBase {
 	public CLIENT_NAME = "Desktop Client - Universal";
 
 	public ANALYTICS_EXCEPTIONS_API_KEY: string = null;
+
+	public PROFILE_DIR_NAME: string = ".appbuilder-desktop-universal";
 }
 $injector.register("staticConfig", ProtonStaticConfig);

--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -3,7 +3,7 @@ export class PostInstallCommand implements ICommand {
 		private $staticConfig: Config.IStaticConfig,
 		private $commandsService: ICommandsService,
 		private $helpService: IHelpService,
-		private $options: ICommonOptions,
+		private $settingsService: ISettingsService,
 		private $doctorService: IDoctorService,
 		private $analyticsService: IAnalyticsService,
 		private $logger: ILogger) {
@@ -18,7 +18,7 @@ export class PostInstallCommand implements ICommand {
 			// it is no longer accessible for the user initiating the installation
 			// patch the owner here
 			if (process.env.SUDO_USER) {
-				await this.$fs.setCurrentUserAsOwner(this.$options.profileDir, process.env.SUDO_USER);
+				await this.$fs.setCurrentUserAsOwner(this.$settingsService.getProfileDir(), process.env.SUDO_USER);
 			}
 		}
 

--- a/commands/preuninstall.ts
+++ b/commands/preuninstall.ts
@@ -6,10 +6,10 @@ export class PreUninstallCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
 	constructor(private $fs: IFileSystem,
-		private $options: ICommonOptions) { }
+		private $settingsService: ISettingsService) { }
 
 	public async execute(args: string[]): Promise<void> {
-		this.$fs.deleteFile(path.join(this.$options.profileDir, "KillSwitches", "cli"));
+		this.$fs.deleteFile(path.join(this.$settingsService.getProfileDir(), "KillSwitches", "cli"));
 	}
 }
 

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -79,7 +79,13 @@ interface IConfigurationSettings {
 	 * This string will be used when constructing the UserAgent http header.
 	 * @type {string}
 	 */
-	userAgentName: string;
+	userAgentName?: string;
+
+	/**
+	 * Describes the profile directory that will be used for various CLI settings, like user-settings.json file location, extensions, etc.
+	 * @type {string}
+	 */
+	profileDir?: string;
 }
 
 /**
@@ -92,6 +98,12 @@ interface ISettingsService {
 	 * @returns {void}
 	 */
 	setSettings(settings: IConfigurationSettings): void;
+
+	/**
+	 * Returns currently used profile directory.
+	 * @returns {string}
+	 */
+	getProfileDir(): string;
 }
 
 /**

--- a/definitions/config.d.ts
+++ b/definitions/config.d.ts
@@ -28,6 +28,7 @@ declare module Config {
 		PATH_TO_BOOTSTRAP: string;
 		QR_SIZE: number;
 		INSTALLATION_SUCCESS_MESSAGE?: string;
+		PROFILE_DIR_NAME: string
 	}
 
 	interface IConfig {

--- a/services/lockfile.ts
+++ b/services/lockfile.ts
@@ -6,7 +6,7 @@ export class LockFile implements ILockFile {
 
 	@cache()
 	private get defaultLockFilePath(): string {
-		return path.join(this.$options.profileDir, "lockfile.lock");
+		return path.join(this.$settingsService.getProfileDir(), "lockfile.lock");
 	}
 
 	private get defaultLockParams(): lockfile.Options {
@@ -22,7 +22,7 @@ export class LockFile implements ILockFile {
 	}
 
 	constructor(private $fs: IFileSystem,
-		private $options: ICommonOptions) {
+		private $settingsService: ISettingsService) {
 	}
 
 	public lock(lockFilePath?: string, lockFileOpts?: lockfile.Options): Promise<void> {

--- a/services/proxy-service.ts
+++ b/services/proxy-service.ts
@@ -8,9 +8,9 @@ export class ProxyService implements IProxyService {
 
 	constructor(private $credentialsService: ICredentialsService,
 		private $fs: IFileSystem,
-		private $options: ICommonOptions,
+		private $settingsService: ISettingsService,
 		private $staticConfig: Config.IStaticConfig) {
-		this.proxyCacheFilePath = path.join(this.$options.profileDir, Proxy.CACHE_FILE_NAME);
+		this.proxyCacheFilePath = path.join(this.$settingsService.getProfileDir(), Proxy.CACHE_FILE_NAME);
 		this.credentialsKey = `${this.$staticConfig.CLIENT_NAME}_PROXY`;
 	}
 

--- a/services/settings-service.ts
+++ b/services/settings-service.ts
@@ -1,13 +1,33 @@
 import { exported } from "../decorators";
+import * as path from "path";
+import * as osenv from "osenv";
 
 export class SettingsService implements ISettingsService {
-	constructor(private $staticConfig: Config.IStaticConfig) { }
+	private _profileDir: string;
+
+	constructor(private $staticConfig: Config.IStaticConfig,
+		private $hostInfo: IHostInfo) {
+		this._profileDir = this.getDefaultProfileDir();
+	}
 
 	@exported("settingsService")
-	setSettings(settings: IConfigurationSettings): void {
-		if (settings.userAgentName) {
+	public setSettings(settings: IConfigurationSettings): void {
+		if (settings && settings.userAgentName) {
 			this.$staticConfig.USER_AGENT_NAME = settings.userAgentName;
 		}
+
+		if (settings && settings.profileDir) {
+			this._profileDir = path.resolve(settings.profileDir);
+		}
+	}
+
+	public getProfileDir(): string {
+		return this._profileDir;
+	}
+
+	private getDefaultProfileDir(): string {
+		const defaultProfileDirLocation = this.$hostInfo.isWindows ? process.env.AppData : path.join(osenv.home(), ".local", "share");
+		return path.join(defaultProfileDirLocation, this.$staticConfig.PROFILE_DIR_NAME);
 	}
 }
 

--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -19,6 +19,7 @@ export abstract class StaticConfigBase implements Config.IStaticConfig {
 	public version: string = null;
 	public pathToPackageJson: string;
 	private _userAgent: string = null;
+	public abstract PROFILE_DIR_NAME: string;
 
 	public get USER_AGENT_NAME(): string {
 		if (!this._userAgent) {

--- a/test/unit-tests/services/settings-service.ts
+++ b/test/unit-tests/services/settings-service.ts
@@ -1,0 +1,116 @@
+import { Yok } from "../../../yok";
+import { SettingsService } from "../../../services/settings-service";
+import { assert } from "chai";
+
+const osenv = require("osenv");
+const path = require("path");
+const originalOsenvHome = osenv.home;
+const originalPathResolve = path.resolve;
+const originalProcessEnvAppData = process.env.AppData;
+
+interface ITestCase {
+	expectedUserAgentName: string;
+	expectedProfileDir: string;
+	testName: string;
+	dataPassedToSetSettings: IConfigurationSettings;
+}
+
+describe("settingsService", () => {
+	const osenvHome = "homeDir";
+	const appDataEnv = "appData";
+	const profileDirName = "profileDir";
+
+	before(() => {
+		osenv.home = () => osenvHome;
+		path.resolve = (p: string) => p;
+		process.env.AppData = appDataEnv;
+	});
+
+	after(() => {
+		osenv.home = originalOsenvHome;
+		path.resolve = originalPathResolve;
+		process.env.AppData = originalProcessEnvAppData;
+	});
+
+	const createTestInjector = (opts?: { userAgentName?: string, isWindows?: boolean }): IInjector => {
+		const testInjector = new Yok();
+		testInjector.register("staticConfig", {
+			USER_AGENT_NAME: opts && opts.userAgentName || "userAgentName",
+			PROFILE_DIR_NAME: profileDirName
+		});
+
+		testInjector.register("hostInfo", {
+			isWindows: opts && _.has(opts, "isWindows") ? opts.isWindows : true
+		});
+
+		return testInjector;
+	};
+
+	const getExpectedProfileDir = (opts: { isWindows: boolean } = { isWindows: true }) => {
+		const defaultProfileDirLocation = opts.isWindows ? appDataEnv : path.join(osenvHome, ".local", "share");
+		return path.join(defaultProfileDirLocation, profileDirName);
+	};
+
+	describe("sets the profileDir to its default value", () => {
+		_.each([true, false], isWindows => {
+			it(`when os is ${isWindows ? "" : "not "}Windows`, () => {
+				const testInjector = createTestInjector();
+				const hostInfo = testInjector.resolve<IHostInfo>("hostInfo");
+				hostInfo.isWindows = isWindows;
+
+				const settingsService = testInjector.resolve<ISettingsService>(SettingsService);
+				const actualProfileDir = settingsService.getProfileDir();
+				const expectedProfileDir = getExpectedProfileDir({ isWindows });
+				assert.equal(actualProfileDir, expectedProfileDir);
+			});
+		});
+	});
+
+	describe("setSettings", () => {
+		const defaultUserAgentName = "defaultUserAgentName";
+		const customUserAgentName = "customUserAgentName";
+		const customProfileDir = "customProfileDir";
+
+		const testData: ITestCase[] = [
+			{
+				expectedUserAgentName: defaultUserAgentName,
+				expectedProfileDir: getExpectedProfileDir(),
+				testName: "does not fail when nothing is passed",
+				dataPassedToSetSettings: null
+			},
+			{
+				expectedUserAgentName: customUserAgentName,
+				expectedProfileDir: customProfileDir,
+				testName: "sets both userAgentName and profileDir when they are passed",
+				dataPassedToSetSettings: { userAgentName: customUserAgentName, profileDir: customProfileDir }
+			},
+			{
+				expectedUserAgentName: customUserAgentName,
+				expectedProfileDir: getExpectedProfileDir(),
+				testName: "sets only userAgentName when its the only passed value",
+				dataPassedToSetSettings: { userAgentName: customUserAgentName }
+			},
+			{
+				expectedUserAgentName: defaultUserAgentName,
+				expectedProfileDir: customProfileDir,
+				testName: "sets only profileDir when its the only passed value",
+				dataPassedToSetSettings: { profileDir: customProfileDir }
+			},
+		];
+
+		_.each(testData, testCase => {
+			it(testCase.testName, () => {
+				const testInjector = createTestInjector();
+				const staticConfig = testInjector.resolve<Config.IStaticConfig>("staticConfig");
+				staticConfig.USER_AGENT_NAME = defaultUserAgentName;
+
+				const settingsService = testInjector.resolve<ISettingsService>(SettingsService);
+				settingsService.setSettings(testCase.dataPassedToSetSettings);
+
+				const actualProfileDir = settingsService.getProfileDir();
+				assert.equal(actualProfileDir, testCase.expectedProfileDir);
+				assert.equal(staticConfig.USER_AGENT_NAME, testCase.expectedUserAgentName);
+			});
+		});
+	});
+});

--- a/test/unit-tests/stubs.ts
+++ b/test/unit-tests/stubs.ts
@@ -77,3 +77,13 @@ export class HooksServiceStub implements IHooksService {
 
 	hookArgsName = "hookArgs";
 }
+
+export class SettingsService implements ISettingsService {
+	public setSettings (settings: IConfigurationSettings) {
+		// Intentionally left blank
+	}
+
+	public getProfileDir() {
+		return "profileDir";
+	}
+}


### PR DESCRIPTION
Currently CLI's configuration directory is used from `$options.profileDir`. When user passes `--profileDir <path>`, the `$options.profileDir` value is populated.
In case user does not pass anything, a default value is set. All services that require configuration directory use the `$options.profileDir`. However, this causes several issues:
- `$options` is intended for use only when CLI is used as a standalone command line. In case you are using it as a library, the `$options` object will not be populated.
- Unable to test local installations of extensions when CLI is used as library - there's no way to set the custom profileDir when using CLI as a library. So the extensions are always loaded from the default location.

In order to resolve these issues, move the logic for profileDir in `settingsService` and introduce a new method to get the profileDir. In order to ensure code is backwards compatible (i.e. extensions that use `$options.profileDir` should still work), modify `$options` to set the value of `profileDir` in `settingsService`.
Whenever you want to test local extensions you can use:
```JavaScript
const tns = require("nativescript");
tns.settingsService.setSettings({ profileDir: "my custom dir" });
Promise.all(tns.extensibilityService.loadExtensions())
	.then((result) => {
		console.log("Loaded extensions:", result);
		// write your code here
	});
```

Replace all places where `$options.profileDir` is used with `$settingsService.getProfileDir()`.