### PR TITLE
Fix showing default help (from index.md)

### DIFF
--- a/services/help-service.ts
+++ b/services/help-service.ts
@@ -119,7 +119,7 @@ export class HelpService implements IHelpService {
 	}
 
 	private async convertCommandNameToFileName(commandName: string): Promise<string> {
-		const defaultCommandMatch = commandName.match(/(\w+?)\|\*/);
+		const defaultCommandMatch = commandName && commandName.match(/(\w+?)\|\*/);
 		if (defaultCommandMatch) {
 			this.$logger.trace("Default command found. Replace current command name '%s' with '%s'.", commandName, defaultCommandMatch[1]);
 			commandName = defaultCommandMatch[1];
@@ -127,11 +127,11 @@ export class HelpService implements IHelpService {
 
 		const availableCommands = this.$injector.getRegisteredCommandsNames(true).sort();
 		this.$logger.trace("List of registered commands: %s", availableCommands.join(", "));
-		if (!_.includes(availableCommands, commandName)) {
+		if (commandName && !_.includes(availableCommands, commandName)) {
 			this.$errors.failWithoutHelp("Unknown command '%s'. Try '$ %s help' for a full list of supported commands.", commandName, this.$staticConfig.CLIENT_NAME.toLowerCase());
 		}
 
-		return commandName.replace(/\|/g, "-") || "index";
+		return (commandName && commandName.replace(/\|/g, "-")) || "index";
 	}
 
 	private tryOpeningSelectedPage(htmlPage: string): boolean {

--- a/test/unit-tests/services/help-service.ts
+++ b/test/unit-tests/services/help-service.ts
@@ -419,5 +419,20 @@ and another one`
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla param1 param2 end") >= 0);
 		});
+
+		_.each(["", null, undefined], (commandName: string) => {
+			it("shows index help when command is not specified", async () => {
+				const injector = createTestInjector();
+				injector.register("fs", {
+					enumerateFilesInDirectorySync: (path: string) => ["index.md"],
+					readText: () => "index data is read"
+				});
+
+				const helpService = injector.resolve<IHelpService>("helpService");
+				await helpService.showCommandLineHelp(commandName);
+				const output = injector.resolve("logger").output;
+				assert.isTrue(output.indexOf("index data is read") >= 0);
+			});
+		});
 	});
 });


### PR DESCRIPTION
In case user executes:
- `tns help` - we should show the default index.html help with all commands
- `tns --help` - we should show the default command line help generated from index.md file with all commands

This has been broken during changing html-help-service to help-service.
Fix the default behavior and add tests for it.