### PR TITLE
Fix tns help command

### DIFF
--- a/services/help-service.ts
+++ b/services/help-service.ts
@@ -127,7 +127,7 @@ export class HelpService implements IHelpService {
 
 		const availableCommands = this.$injector.getRegisteredCommandsNames(true).sort();
 		this.$logger.trace("List of registered commands: %s", availableCommands.join(", "));
-		if (!_.includes(availableCommands, commandName)) {
+		if (commandName && !_.includes(availableCommands, commandName)) {
 			this.$errors.failWithoutHelp("Unknown command '%s'. Try '$ %s help' for a full list of supported commands.", commandName, this.$staticConfig.CLIENT_NAME.toLowerCase());
 		}
 


### PR DESCRIPTION
Fix help command without arguments(`tns --help` or `tns help`).