### PR TITLE
Fix execution of hooks outside of process

### DIFF
--- a/services/hooks-service.ts
+++ b/services/hooks-service.ts
@@ -143,16 +143,16 @@ export class HooksService implements IHooksService {
 					}
 
 					this.$logger.trace('Hook completed');
-				} else {
-					const environment = this.prepareEnvironment(hook.fullPath);
-					this.$logger.trace("Executing %s hook at location %s with environment ", hookName, hook.fullPath, environment);
+				}
+			} else {
+				const environment = this.prepareEnvironment(hook.fullPath);
+				this.$logger.trace("Executing %s hook at location %s with environment ", hookName, hook.fullPath, environment);
 
-					const output = await this.$childProcess.spawnFromEvent(command, [hook.fullPath], "close", environment, { throwError: false });
-					results.push(output);
+				const output = await this.$childProcess.spawnFromEvent(command, [hook.fullPath], "close", environment, { throwError: false });
+				results.push(output);
 
-					if (output.exitCode !== 0) {
-						throw new Error(output.stdout + output.stderr);
-					}
+				if (output.exitCode !== 0) {
+					throw new Error(output.stdout + output.stderr);
 				}
 			}
 		}


### PR DESCRIPTION
In case you need a hook to be executed outside of process, you should place correct shebang at the beginning of the file and CLI should spawn it.
However, this is not working at the moment, as when CLI detects that the hook should be spawned, it just does nothing. The code is incorrectly placed inside the `if` for in process execution. This causes another issue - in case a hook returns a function, which returns falsey value, we decide the hook should be executed outside of process and spawn a new Node.js process to execute the hook. So we execute it twice.

Fix the if-else logic, so the hooks will work correctly.