### PR TITLE
Cherry-pick commits for {N} CLI 3.3.1 release

### DIFF
--- a/appbuilder/device-emitter.ts
+++ b/appbuilder/device-emitter.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import { DeviceDiscoveryEventNames } from "../constants";
+import { DeviceDiscoveryEventNames, DEVICE_LOG_EVENT_NAME } from "../constants";
 
 export class DeviceEmitter extends EventEmitter {
 	constructor(private $deviceLogProvider: EventEmitter,
@@ -34,7 +34,7 @@ export class DeviceEmitter extends EventEmitter {
 		});
 
 		this.$deviceLogProvider.on("data", (identifier: string, data: any) => {
-			this.emit('deviceLogData', identifier, data.toString());
+			this.emit(DEVICE_LOG_EVENT_NAME, identifier, data.toString());
 		});
 	}
 

--- a/appbuilder/proton-static-config.ts
+++ b/appbuilder/proton-static-config.ts
@@ -20,5 +20,7 @@ export class ProtonStaticConfig extends StaticConfigBase {
 	public CLIENT_NAME = "Desktop Client - Universal";
 
 	public ANALYTICS_EXCEPTIONS_API_KEY: string = null;
+
+	public PROFILE_DIR_NAME: string = ".appbuilder-desktop-universal";
 }
 $injector.register("staticConfig", ProtonStaticConfig);

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -92,7 +92,7 @@ $injector.require("dynamicHelpService", "./services/dynamic-help-service");
 $injector.require("microTemplateService", "./services/micro-templating-service");
 $injector.require("mobileHelper", "./mobile/mobile-helper");
 $injector.require("devicePlatformsConstants", "./mobile/device-platforms-constants");
-$injector.require("helpService", "./services/html-help-service");
+$injector.require("helpService", "./services/help-service");
 $injector.require("messageContractGenerator", "./services/message-contract-generator");
 $injector.require("proxyService", "./services/proxy-service");
 $injector.require("credentialsService", "./services/credentials-service");

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -92,7 +92,7 @@ $injector.require("dynamicHelpService", "./services/dynamic-help-service");
 $injector.require("microTemplateService", "./services/micro-templating-service");
 $injector.require("mobileHelper", "./mobile/mobile-helper");
 $injector.require("devicePlatformsConstants", "./mobile/device-platforms-constants");
-$injector.require("htmlHelpService", "./services/html-help-service");
+$injector.require("helpService", "./services/html-help-service");
 $injector.require("messageContractGenerator", "./services/message-contract-generator");
 $injector.require("proxyService", "./services/proxy-service");
 $injector.require("credentialsService", "./services/credentials-service");

--- a/commands/help.ts
+++ b/commands/help.ts
@@ -1,10 +1,6 @@
-import { EOL } from "os";
-
 export class HelpCommand implements ICommand {
-	constructor(private $logger: ILogger,
-		private $injector: IInjector,
-		private $htmlHelpService: IHtmlHelpService,
-		private $staticConfig: Config.IStaticConfig,
+	constructor(private $injector: IInjector,
+		private $helpService: IHelpService,
 		private $options: ICommonOptions) { }
 
 	public enableHooks = false;
@@ -22,14 +18,9 @@ export class HelpCommand implements ICommand {
 		}
 
 		if (this.$options.help) {
-			const help = await this.$htmlHelpService.getCommandLineHelpForCommand(topic);
-			if (this.$staticConfig.FULL_CLIENT_NAME) {
-				this.$logger.info(this.$staticConfig.FULL_CLIENT_NAME.green.bold + EOL);
-			}
-
-			this.$logger.printMarkdown(help);
+			await this.$helpService.showCommandLineHelp(topic);
 		} else {
-			await this.$htmlHelpService.openHelpForCommandInBrowser(topic);
+			await this.$helpService.openHelpForCommandInBrowser(topic);
 		}
 	}
 }

--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -2,7 +2,7 @@ export class PostInstallCommand implements ICommand {
 	constructor(private $fs: IFileSystem,
 		private $staticConfig: Config.IStaticConfig,
 		private $commandsService: ICommandsService,
-		private $htmlHelpService: IHtmlHelpService,
+		private $helpService: IHelpService,
 		private $options: ICommonOptions,
 		private $doctorService: IDoctorService,
 		private $analyticsService: IAnalyticsService,
@@ -22,7 +22,7 @@ export class PostInstallCommand implements ICommand {
 			}
 		}
 
-		await this.$htmlHelpService.generateHtmlPages();
+		await this.$helpService.generateHtmlPages();
 
 		const doctorResult = await this.$doctorService.printWarnings({ trackResult: false });
 		// Explicitly ask for confirmation of usage-reporting:

--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -3,7 +3,7 @@ export class PostInstallCommand implements ICommand {
 		private $staticConfig: Config.IStaticConfig,
 		private $commandsService: ICommandsService,
 		private $helpService: IHelpService,
-		private $options: ICommonOptions,
+		private $settingsService: ISettingsService,
 		private $doctorService: IDoctorService,
 		private $analyticsService: IAnalyticsService,
 		private $logger: ILogger) {
@@ -18,7 +18,7 @@ export class PostInstallCommand implements ICommand {
 			// it is no longer accessible for the user initiating the installation
 			// patch the owner here
 			if (process.env.SUDO_USER) {
-				await this.$fs.setCurrentUserAsOwner(this.$options.profileDir, process.env.SUDO_USER);
+				await this.$fs.setCurrentUserAsOwner(this.$settingsService.getProfileDir(), process.env.SUDO_USER);
 			}
 		}
 

--- a/commands/preuninstall.ts
+++ b/commands/preuninstall.ts
@@ -6,10 +6,10 @@ export class PreUninstallCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
 	constructor(private $fs: IFileSystem,
-		private $options: ICommonOptions) { }
+		private $settingsService: ISettingsService) { }
 
 	public async execute(args: string[]): Promise<void> {
-		this.$fs.deleteFile(path.join(this.$options.profileDir, "KillSwitches", "cli"));
+		this.$fs.deleteFile(path.join(this.$settingsService.getProfileDir(), "KillSwitches", "cli"));
 	}
 }
 

--- a/constants.ts
+++ b/constants.ts
@@ -39,6 +39,8 @@ export class DeviceDiscoveryEventNames {
 	static DEVICE_LOST = "deviceLost";
 }
 
+export const DEVICE_LOG_EVENT_NAME = "deviceLogData";
+
 export const TARGET_FRAMEWORK_IDENTIFIERS = {
 	Cordova: "Cordova",
 	NativeScript: "NativeScript"

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -540,7 +540,7 @@ interface IErrors {
 	fail(formatStr: string, ...args: any[]): never;
 	fail(opts: { formatStr?: string; errorCode?: number; suppressCommandHelp?: boolean }, ...args: any[]): never;
 	failWithoutHelp(message: string, ...args: any[]): never;
-	beginCommand(action: () => Promise<boolean>, printCommandHelp: () => Promise<boolean>): Promise<boolean>;
+	beginCommand(action: () => Promise<boolean>, printCommandHelp: () => Promise<void>): Promise<boolean>;
 	verifyHeap(message: string): void;
 	printCallStack: boolean;
 }
@@ -955,7 +955,7 @@ interface IMicroTemplateService {
 	parseContent(data: string, options: { isHtml: boolean }): Promise<string>;
 }
 
-interface IHtmlHelpService {
+interface IHelpService {
 	generateHtmlPages(): Promise<void>;
 
 	/**
@@ -966,6 +966,13 @@ interface IHtmlHelpService {
 	getCommandLineHelpForCommand(commandName: string): Promise<string>;
 
 	openHelpForCommandInBrowser(commandName: string): Promise<void>;
+
+	/**
+	 * Shows command line help for specified command.
+	 * @param {string} commandName The name of the command for which to show the help.
+	 * @returns {Promise<void>}
+	 */
+	showCommandLineHelp(commandName: string): Promise<void>;
 }
 
 /**

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -721,6 +721,13 @@ interface IAnalyticsSettingsService {
 	 * @returns {Promise<string>}
 	 */
 	getClientId(): Promise<string>;
+
+	/**
+	 * Gets user agent string identifing the current system in the following format: `${identifier} (${systemInfo}) ${osArch}`
+	 * @param {string} identifier The product identifier.
+	 * @returns {string} The user agent string.
+	 */
+	getUserAgentString(identifier: string): string;
 }
 
 interface IHostCapabilities {

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -958,13 +958,6 @@ interface IMicroTemplateService {
 interface IHelpService {
 	generateHtmlPages(): Promise<void>;
 
-	/**
-	 * Gets the help content for a specific command that should be shown on the terminal.
-	 * @param {string} commandName Name of the command for which to read the help.
-	 * @returns {Promise<string>} Help content of the command parsed with all terminal rules applied (stripped content that should be shown only for html help).
-	 */
-	getCommandLineHelpForCommand(commandName: string): Promise<string>;
-
 	openHelpForCommandInBrowser(commandName: string): Promise<void>;
 
 	/**

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -79,7 +79,13 @@ interface IConfigurationSettings {
 	 * This string will be used when constructing the UserAgent http header.
 	 * @type {string}
 	 */
-	userAgentName: string;
+	userAgentName?: string;
+
+	/**
+	 * Describes the profile directory that will be used for various CLI settings, like user-settings.json file location, extensions, etc.
+	 * @type {string}
+	 */
+	profileDir?: string;
 }
 
 /**
@@ -92,6 +98,12 @@ interface ISettingsService {
 	 * @returns {void}
 	 */
 	setSettings(settings: IConfigurationSettings): void;
+
+	/**
+	 * Returns currently used profile directory.
+	 * @returns {string}
+	 */
+	getProfileDir(): string;
 }
 
 /**

--- a/definitions/config.d.ts
+++ b/definitions/config.d.ts
@@ -13,7 +13,6 @@ declare module Config {
 		ERROR_REPORT_SETTING_NAME: string;
 		SYS_REQUIREMENTS_LINK: string;
 		version: string;
-		helpTextPath: string;
 		getAdbFilePath(): Promise<string>;
 		disableAnalytics?: boolean;
 		disableCommandHooks?: boolean;

--- a/definitions/config.d.ts
+++ b/definitions/config.d.ts
@@ -28,6 +28,7 @@ declare module Config {
 		PATH_TO_BOOTSTRAP: string;
 		QR_SIZE: number;
 		INSTALLATION_SUCCESS_MESSAGE?: string;
+		PROFILE_DIR_NAME: string
 	}
 
 	interface IConfig {

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -96,6 +96,12 @@ declare module Mobile {
 		isEmulator: boolean;
 		openDeviceLogStream(): Promise<void>;
 		getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo>;
+
+		/**
+		 * Called when device is lost. Its purpose is to clean any resources used by the instance.
+		 * @returns {void}
+		 */
+		detach?(): void;
 	}
 
 	interface IiOSDevice extends IDevice {
@@ -767,14 +773,14 @@ declare module Mobile {
 	}
 }
 
-interface IIOSDeviceOperations extends IDisposable {
+interface IIOSDeviceOperations extends IDisposable, NodeJS.EventEmitter {
 	install(ipaPath: string, deviceIdentifiers: string[], errorHandler?: DeviceOperationErrorHandler): Promise<IOSDeviceResponse>;
 
 	uninstall(appIdentifier: string, deviceIdentifiers: string[], errorHandler?: DeviceOperationErrorHandler): Promise<IOSDeviceResponse>;
 
 	startLookingForDevices(deviceFoundCallback: DeviceInfoCallback, deviceLostCallback: DeviceInfoCallback, options?: Mobile.IDeviceLookingOptions): Promise<void>;
 
-	startDeviceLog(deviceIdentifier: string, printLogFunction: (response: IOSDeviceLib.IDeviceLogData) => void): void;
+	startDeviceLog(deviceIdentifier: string): void;
 
 	apps(deviceIdentifiers: string[], errorHandler?: DeviceOperationErrorHandler): Promise<IOSDeviceAppInfo>;
 

--- a/errors.ts
+++ b/errors.ts
@@ -151,7 +151,7 @@ export class Errors implements IErrors {
 		return this.fail({ formatStr: util.format.apply(null, args), suppressCommandHelp: true });
 	}
 
-	public async beginCommand(action: () => Promise<boolean>, printCommandHelp: () => Promise<boolean>): Promise<boolean> {
+	public async beginCommand(action: () => Promise<boolean>, printCommandHelp: () => Promise<void>): Promise<boolean> {
 		try {
 			return await action();
 		} catch (ex) {

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -139,6 +139,11 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 
 	private onDeviceLost(device: Mobile.IDevice): void {
 		this.$logger.trace(`Lost device with identifier '${device.deviceInfo.identifier}'`);
+
+		if (device.detach) {
+			device.detach();
+		}
+
 		delete this._devices[device.deviceInfo.identifier];
 		this.emit(constants.DeviceDiscoveryEventNames.DEVICE_LOST, device);
 	}

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -24,7 +24,8 @@ export class CommandsService implements ICommandsService {
 		private $logger: ILogger,
 		private $options: ICommonOptions,
 		private $resources: IResourceLoader,
-		private $staticConfig: Config.IStaticConfig) {
+		private $staticConfig: Config.IStaticConfig,
+		private $helpService: IHelpService) {
 	}
 
 	public allCommands(opts: { includeDevCommands: boolean }): string[] {
@@ -77,9 +78,8 @@ export class CommandsService implements ICommandsService {
 		return false;
 	}
 
-	private async printHelp(commandName: string): Promise<boolean> {
-		this.$options.help = true;
-		return this.executeCommandUnchecked("help", [this.beautifyCommandName(commandName)]);
+	private printHelp(commandName: string): Promise<void> {
+		return this.$helpService.showCommandLineHelp(this.beautifyCommandName(commandName));
 	}
 
 	private async executeCommandAction(commandName: string, commandArguments: string[], action: (_commandName: string, _commandArguments: string[]) => Promise<boolean>): Promise<boolean> {

--- a/services/dynamic-help-service.ts
+++ b/services/dynamic-help-service.ts
@@ -15,7 +15,7 @@ export class DynamicHelpService implements IDynamicHelpService {
 
 	public getLocalVariables(options: { isHtml: boolean }): IDictionary<any> {
 		const isHtml = options.isHtml;
-		//in html help we want to show all help. Only CONSOLE specific help(wrapped in if(isConsole) ) must be omitted
+		// in html help we want to show all help. Only CONSOLE specific help(wrapped in if(isConsole) ) must be omitted
 		const localVariables = this.$dynamicHelpProvider.getLocalVariables(options);
 		localVariables["isLinux"] = isHtml || this.isPlatform("linux");
 		localVariables["isWindows"] = isHtml || this.isPlatform("win32");

--- a/services/help-service.ts
+++ b/services/help-service.ts
@@ -119,7 +119,7 @@ export class HelpService implements IHelpService {
 	}
 
 	private async convertCommandNameToFileName(commandName: string): Promise<string> {
-		const defaultCommandMatch = commandName.match(/(\w+?)\|\*/);
+		const defaultCommandMatch = commandName && commandName.match(/(\w+?)\|\*/);
 		if (defaultCommandMatch) {
 			this.$logger.trace("Default command found. Replace current command name '%s' with '%s'.", commandName, defaultCommandMatch[1]);
 			commandName = defaultCommandMatch[1];
@@ -127,11 +127,11 @@ export class HelpService implements IHelpService {
 
 		const availableCommands = this.$injector.getRegisteredCommandsNames(true).sort();
 		this.$logger.trace("List of registered commands: %s", availableCommands.join(", "));
-		if (!_.includes(availableCommands, commandName)) {
+		if (commandName && !_.includes(availableCommands, commandName)) {
 			this.$errors.failWithoutHelp("Unknown command '%s'. Try '$ %s help' for a full list of supported commands.", commandName, this.$staticConfig.CLIENT_NAME.toLowerCase());
 		}
 
-		return commandName.replace(/\|/g, "-") || "index";
+		return (commandName && commandName.replace(/\|/g, "-")) || "index";
 	}
 
 	private tryOpeningSelectedPage(htmlPage: string): boolean {

--- a/services/help-service.ts
+++ b/services/help-service.ts
@@ -74,7 +74,12 @@ export class HelpService implements IHelpService {
 		this.$logger.printMarkdown(help);
 	}
 
-	public async getCommandLineHelpForCommand(commandName: string): Promise<string> {
+	/**
+	 * Gets the help content for a specific command that should be shown on the terminal.
+	 * @param {string} commandName Name of the command for which to read the help.
+	 * @returns {Promise<string>} Help content of the command parsed with all terminal rules applied (stripped content that should be shown only for html help).
+	 */
+	private async getCommandLineHelpForCommand(commandName: string): Promise<string> {
 		const helpText = await this.readMdFileForCommand(commandName);
 		const commandLineHelp = (await this.$microTemplateService.parseContent(helpText, { isHtml: false }))
 			.replace(/&nbsp;/g, " ")

--- a/services/hooks-service.ts
+++ b/services/hooks-service.ts
@@ -139,14 +139,15 @@ export class HooksService implements IHooksService {
 					}
 
 					this.$logger.trace('Hook completed');
-				} else {
-					const environment = this.prepareEnvironment(hook.fullPath);
-					this.$logger.trace("Executing %s hook at location %s with environment ", hookName, hook.fullPath, environment);
+				}
+			} else {
+				const environment = this.prepareEnvironment(hook.fullPath);
+				this.$logger.trace("Executing %s hook at location %s with environment ", hookName, hook.fullPath, environment);
 
-					const output = await this.$childProcess.spawnFromEvent(command, [hook.fullPath], "close", environment, { throwError: false });
-					if (output.exitCode !== 0) {
-						throw new Error(output.stdout + output.stderr);
-					}
+				const output = await this.$childProcess.spawnFromEvent(command, [hook.fullPath], "close", environment, { throwError: false });
+
+				if (output.exitCode !== 0) {
+					throw new Error(output.stdout + output.stderr);
 				}
 			}
 		}

--- a/services/html-help-service.ts
+++ b/services/html-help-service.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import { EOL } from "os";
 import marked = require("marked");
 
-export class HtmlHelpService implements IHtmlHelpService {
+export class HelpService implements IHelpService {
 	private static MARKDOWN_FILE_EXTENSION = ".md";
 	private static HTML_FILE_EXTENSION = ".html";
 	private static MAN_PAGE_NAME_REGEX = /@MAN_PAGE_NAME@/g;
@@ -38,47 +38,13 @@ export class HtmlHelpService implements IHtmlHelpService {
 		private $fs: IFileSystem,
 		private $staticConfig: Config.IStaticConfig,
 		private $microTemplateService: IMicroTemplateService,
-		private $opener: IOpener,
-		private $commandsServiceProvider: ICommandsServiceProvider) {
+		private $opener: IOpener) {
 		this.pathToHtmlPages = this.$staticConfig.HTML_PAGES_DIR;
 		this.pathToManPages = this.$staticConfig.MAN_PAGES_DIR;
 	}
 
-	public async generateHtmlPages(): Promise<void> {
-		const mdFiles = this.$fs.enumerateFilesInDirectorySync(this.pathToManPages);
-		const basicHtmlPage = this.$fs.readText(this.pathToBasicPage);
-		await Promise.all(_.map(mdFiles, markdownFile => this.createHtmlPage(basicHtmlPage, markdownFile)));
-		this.$logger.trace("Finished generating HTML files.");
-	}
-
-	// This method should return Promise in order to generate all html pages simultaneously.
-	private async createHtmlPage(basicHtmlPage: string, pathToMdFile: string): Promise<void> {
-		const mdFileName = path.basename(pathToMdFile);
-		const htmlFileName = mdFileName.replace(HtmlHelpService.MARKDOWN_FILE_EXTENSION, HtmlHelpService.HTML_FILE_EXTENSION);
-		this.$logger.trace("Generating '%s' help topic.", htmlFileName);
-
-		const helpText = this.$fs.readText(pathToMdFile);
-		const outputText = await this.$microTemplateService.parseContent(helpText, { isHtml: true });
-		const htmlText = marked(outputText);
-
-		const filePath = pathToMdFile
-			.replace(path.basename(this.pathToManPages), path.basename(this.pathToHtmlPages))
-			.replace(mdFileName, htmlFileName);
-		this.$logger.trace("HTML file path for '%s' man page is: '%s'.", mdFileName, filePath);
-
-		const outputHtml = basicHtmlPage
-			.replace(HtmlHelpService.MAN_PAGE_NAME_REGEX, mdFileName.replace(HtmlHelpService.MARKDOWN_FILE_EXTENSION, ""))
-			.replace(HtmlHelpService.HTML_COMMAND_HELP_REGEX, htmlText)
-			.replace(HtmlHelpService.RELATIVE_PATH_TO_STYLES_CSS_REGEX, path.relative(path.dirname(filePath), this.pathToStylesCss))
-			.replace(HtmlHelpService.RELATIVE_PATH_TO_IMAGES_REGEX, path.relative(path.dirname(filePath), this.pathToImages))
-			.replace(HtmlHelpService.RELATIVE_PATH_TO_INDEX_REGEX, path.relative(path.dirname(filePath), this.pathToIndexHtml));
-
-		this.$fs.writeFile(filePath, outputHtml);
-		this.$logger.trace("Finished writing file '%s'.", filePath);
-	}
-
 	public async openHelpForCommandInBrowser(commandName: string): Promise<void> {
-		const htmlPage = await this.convertCommandNameToFileName(commandName) + HtmlHelpService.HTML_FILE_EXTENSION;
+		const htmlPage = await this.convertCommandNameToFileName(commandName) + HelpService.HTML_FILE_EXTENSION;
 		this.$logger.trace("Opening help for command '%s'. FileName is '%s'.", commandName, htmlPage);
 
 		this.$fs.ensureDirectoryExists(this.pathToHtmlPages);
@@ -92,6 +58,61 @@ export class HtmlHelpService implements IHtmlHelpService {
 		}
 	}
 
+	public async generateHtmlPages(): Promise<void> {
+		const mdFiles = this.$fs.enumerateFilesInDirectorySync(this.pathToManPages);
+		const basicHtmlPage = this.$fs.readText(this.pathToBasicPage);
+		await Promise.all(_.map(mdFiles, markdownFile => this.createHtmlPage(basicHtmlPage, markdownFile)));
+		this.$logger.trace("Finished generating HTML files.");
+	}
+
+	public async showCommandLineHelp(commandName: string): Promise<void> {
+		const help = await this.getCommandLineHelpForCommand(commandName);
+		if (this.$staticConfig.FULL_CLIENT_NAME) {
+			this.$logger.info(this.$staticConfig.FULL_CLIENT_NAME.green.bold + EOL);
+		}
+
+		this.$logger.printMarkdown(help);
+	}
+
+	public async getCommandLineHelpForCommand(commandName: string): Promise<string> {
+		const helpText = await this.readMdFileForCommand(commandName);
+		const commandLineHelp = (await this.$microTemplateService.parseContent(helpText, { isHtml: false }))
+			.replace(/&nbsp;/g, " ")
+			.replace(HelpService.MARKDOWN_LINK_REGEX, "$1")
+			.replace(HelpService.SPAN_REGEX, (matchingSubstring: string, textBeforeSpan: string, textInsideSpan: string, index: number, fullString: string): string => {
+				return textBeforeSpan + textInsideSpan.replace(this.newLineRegex, "");
+			})
+			.replace(HelpService.NEW_LINE_REGEX, EOL);
+
+		return commandLineHelp;
+	}
+
+	// This method should return Promise in order to generate all html pages simultaneously.
+	private async createHtmlPage(basicHtmlPage: string, pathToMdFile: string): Promise<void> {
+		const mdFileName = path.basename(pathToMdFile);
+		const htmlFileName = mdFileName.replace(HelpService.MARKDOWN_FILE_EXTENSION, HelpService.HTML_FILE_EXTENSION);
+		this.$logger.trace("Generating '%s' help topic.", htmlFileName);
+
+		const helpText = this.$fs.readText(pathToMdFile);
+		const outputText = await this.$microTemplateService.parseContent(helpText, { isHtml: true });
+		const htmlText = marked(outputText);
+
+		const filePath = pathToMdFile
+			.replace(path.basename(this.pathToManPages), path.basename(this.pathToHtmlPages))
+			.replace(mdFileName, htmlFileName);
+		this.$logger.trace("HTML file path for '%s' man page is: '%s'.", mdFileName, filePath);
+
+		const outputHtml = basicHtmlPage
+			.replace(HelpService.MAN_PAGE_NAME_REGEX, mdFileName.replace(HelpService.MARKDOWN_FILE_EXTENSION, ""))
+			.replace(HelpService.HTML_COMMAND_HELP_REGEX, htmlText)
+			.replace(HelpService.RELATIVE_PATH_TO_STYLES_CSS_REGEX, path.relative(path.dirname(filePath), this.pathToStylesCss))
+			.replace(HelpService.RELATIVE_PATH_TO_IMAGES_REGEX, path.relative(path.dirname(filePath), this.pathToImages))
+			.replace(HelpService.RELATIVE_PATH_TO_INDEX_REGEX, path.relative(path.dirname(filePath), this.pathToIndexHtml));
+
+		this.$fs.writeFile(filePath, outputHtml);
+		this.$logger.trace("Finished writing file '%s'.", filePath);
+	}
+
 	private async convertCommandNameToFileName(commandName: string): Promise<string> {
 		const defaultCommandMatch = commandName.match(/(\w+?)\|\*/);
 		if (defaultCommandMatch) {
@@ -101,11 +122,8 @@ export class HtmlHelpService implements IHtmlHelpService {
 
 		const availableCommands = this.$injector.getRegisteredCommandsNames(true).sort();
 		this.$logger.trace("List of registered commands: %s", availableCommands.join(", "));
-		if (commandName && _.startsWith(commandName, this.$commandsServiceProvider.dynamicCommandsPrefix) && !_.includes(availableCommands, commandName)) {
-			const dynamicCommands = await this.$commandsServiceProvider.getDynamicCommands();
-			if (!_.includes(dynamicCommands, commandName)) {
-				this.$errors.failWithoutHelp("Unknown command '%s'. Try '$ %s help' for a full list of supported commands.", commandName, this.$staticConfig.CLIENT_NAME.toLowerCase());
-			}
+		if (!_.includes(availableCommands, commandName)) {
+			this.$errors.failWithoutHelp("Unknown command '%s'. Try '$ %s help' for a full list of supported commands.", commandName, this.$staticConfig.CLIENT_NAME.toLowerCase());
 		}
 
 		return commandName.replace(/\|/g, "-") || "index";
@@ -127,7 +145,7 @@ export class HtmlHelpService implements IHtmlHelpService {
 	}
 
 	private async readMdFileForCommand(commandName: string): Promise<string> {
-		const mdFileName = await this.convertCommandNameToFileName(commandName) + HtmlHelpService.MARKDOWN_FILE_EXTENSION;
+		const mdFileName = await this.convertCommandNameToFileName(commandName) + HelpService.MARKDOWN_FILE_EXTENSION;
 		this.$logger.trace("Reading help for command '%s'. FileName is '%s'.", commandName, mdFileName);
 
 		const markdownFile = _.find(this.$fs.enumerateFilesInDirectorySync(this.pathToManPages), file => path.basename(file) === mdFileName);
@@ -137,19 +155,6 @@ export class HtmlHelpService implements IHtmlHelpService {
 
 		this.$errors.failWithoutHelp("Unknown command '%s'. Try '$ %s help' for a full list of supported commands.", mdFileName.replace(".md", ""), this.$staticConfig.CLIENT_NAME.toLowerCase());
 	}
-
-	public async getCommandLineHelpForCommand(commandName: string): Promise<string> {
-		const helpText = await this.readMdFileForCommand(commandName);
-		const commandLineHelp = (await this.$microTemplateService.parseContent(helpText, { isHtml: false }))
-			.replace(/&nbsp;/g, " ")
-			.replace(HtmlHelpService.MARKDOWN_LINK_REGEX, "$1")
-			.replace(HtmlHelpService.SPAN_REGEX, (matchingSubstring: string, textBeforeSpan: string, textInsideSpan: string, index: number, fullString: string): string => {
-				return textBeforeSpan + textInsideSpan.replace(this.newLineRegex, "");
-			})
-			.replace(HtmlHelpService.NEW_LINE_REGEX, EOL);
-
-		return commandLineHelp;
-	}
 }
 
-$injector.register("htmlHelpService", HtmlHelpService);
+$injector.register("helpService", HelpService);

--- a/services/lockfile.ts
+++ b/services/lockfile.ts
@@ -6,7 +6,7 @@ export class LockFile implements ILockFile {
 
 	@cache()
 	private get defaultLockFilePath(): string {
-		return path.join(this.$options.profileDir, "lockfile.lock");
+		return path.join(this.$settingsService.getProfileDir(), "lockfile.lock");
 	}
 
 	private get defaultLockParams(): lockfile.Options {
@@ -22,7 +22,7 @@ export class LockFile implements ILockFile {
 	}
 
 	constructor(private $fs: IFileSystem,
-		private $options: ICommonOptions) {
+		private $settingsService: ISettingsService) {
 	}
 
 	public lock(lockFilePath?: string, lockFileOpts?: lockfile.Options): Promise<void> {

--- a/services/proxy-service.ts
+++ b/services/proxy-service.ts
@@ -8,9 +8,9 @@ export class ProxyService implements IProxyService {
 
 	constructor(private $credentialsService: ICredentialsService,
 		private $fs: IFileSystem,
-		private $options: ICommonOptions,
+		private $settingsService: ISettingsService,
 		private $staticConfig: Config.IStaticConfig) {
-		this.proxyCacheFilePath = path.join(this.$options.profileDir, Proxy.CACHE_FILE_NAME);
+		this.proxyCacheFilePath = path.join(this.$settingsService.getProfileDir(), Proxy.CACHE_FILE_NAME);
 		this.credentialsKey = `${this.$staticConfig.CLIENT_NAME}_PROXY`;
 	}
 

--- a/services/settings-service.ts
+++ b/services/settings-service.ts
@@ -1,13 +1,33 @@
 import { exported } from "../decorators";
+import * as path from "path";
+import * as osenv from "osenv";
 
 export class SettingsService implements ISettingsService {
-	constructor(private $staticConfig: Config.IStaticConfig) { }
+	private _profileDir: string;
+
+	constructor(private $staticConfig: Config.IStaticConfig,
+		private $hostInfo: IHostInfo) {
+		this._profileDir = this.getDefaultProfileDir();
+	}
 
 	@exported("settingsService")
-	setSettings(settings: IConfigurationSettings): void {
-		if (settings.userAgentName) {
+	public setSettings(settings: IConfigurationSettings): void {
+		if (settings && settings.userAgentName) {
 			this.$staticConfig.USER_AGENT_NAME = settings.userAgentName;
 		}
+
+		if (settings && settings.profileDir) {
+			this._profileDir = path.resolve(settings.profileDir);
+		}
+	}
+
+	public getProfileDir(): string {
+		return this._profileDir;
+	}
+
+	private getDefaultProfileDir(): string {
+		const defaultProfileDirLocation = this.$hostInfo.isWindows ? process.env.AppData : path.join(osenv.home(), ".local", "share");
+		return path.join(defaultProfileDirLocation, this.$staticConfig.PROFILE_DIR_NAME);
 	}
 }
 

--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -19,6 +19,7 @@ export abstract class StaticConfigBase implements Config.IStaticConfig {
 	public version: string = null;
 	public pathToPackageJson: string;
 	private _userAgent: string = null;
+	public abstract PROFILE_DIR_NAME: string;
 
 	public get USER_AGENT_NAME(): string {
 		if (!this._userAgent) {

--- a/static-config-base.ts
+++ b/static-config-base.ts
@@ -36,10 +36,6 @@ export abstract class StaticConfigBase implements Config.IStaticConfig {
 
 	constructor(protected $injector: IInjector) { }
 
-	public get helpTextPath(): string {
-		return null;
-	}
-
 	public async getAdbFilePath(): Promise<string> {
 		if (!this._adbFilePath) {
 			this._adbFilePath = await this.getAdbFilePathCore();

--- a/test/unit-tests/appbuilder/device-emitter.ts
+++ b/test/unit-tests/appbuilder/device-emitter.ts
@@ -3,7 +3,7 @@ import { assert } from "chai";
 import { EventEmitter } from "events";
 import { ProjectConstants } from "../../../appbuilder/project-constants";
 import { DeviceEmitter } from "../../../appbuilder/device-emitter";
-import { DeviceDiscoveryEventNames } from "../../../constants";
+import { DeviceDiscoveryEventNames, DEVICE_LOG_EVENT_NAME } from "../../../constants";
 // Injector dependencies must be classes.
 // EventEmitter is function, so our annotate method will fail.
 class CustomEventEmitter extends EventEmitter {
@@ -109,11 +109,11 @@ describe("deviceEmitter", () => {
 				deviceLogProvider = testInjector.resolve("deviceLogProvider");
 			});
 
-			describe("raises deviceLogData with correct identifier and data", () => {
+			describe(`raises ${DEVICE_LOG_EVENT_NAME} with correct identifier and data`, () => {
 				const expectedDeviceLogData = "This is some log data from device.";
 
 				const attachDeviceLogDataVerificationHandler = (expectedDeviceIdentifier: string, done: mocha.Done) => {
-					deviceEmitter.on("deviceLogData", (identifier: string, data: any) => {
+					deviceEmitter.on(DEVICE_LOG_EVENT_NAME, (identifier: string, data: any) => {
 						assert.deepEqual(identifier, expectedDeviceIdentifier);
 						assert.deepEqual(data, expectedDeviceLogData);
 						// Wait for all operations to be completed and call done after that.

--- a/test/unit-tests/mobile/android/logcat-helper.ts
+++ b/test/unit-tests/mobile/android/logcat-helper.ts
@@ -11,14 +11,17 @@ class ChildProcessStub {
 	public spawn(command: string, args?: string[], options?: any): childProcess.ChildProcess {
 		ChildProcessStub.methodCallCount++;
 		let pathToExecutable = "";
+		let shell = "";
 		if (this.isWin) {
 			pathToExecutable = "type";
+			shell = "cmd";
 		} else {
 			pathToExecutable = "cat";
 		}
 		pathToExecutable = path.join(pathToExecutable);
 		const pathToSample = path.join(__dirname, "valid-sample.txt");
-		return childProcess.spawn(pathToExecutable, [pathToSample]);
+
+		return childProcess.spawn(pathToExecutable, [pathToSample], { shell });
 	}
 }
 

--- a/test/unit-tests/services/help-service.ts
+++ b/test/unit-tests/services/help-service.ts
@@ -1,6 +1,6 @@
 import { CommonLoggerStub, ErrorsStub } from "../stubs";
 import { MicroTemplateService } from "../../../services/micro-templating-service";
-import { HelpService } from "../../../services/html-help-service";
+import { HelpService } from "../../../services/help-service";
 import { assert } from "chai";
 import { EOL } from "os";
 import { Yok } from '../../../yok';

--- a/test/unit-tests/services/help-service.ts
+++ b/test/unit-tests/services/help-service.ts
@@ -419,5 +419,20 @@ and another one`
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla param1 param2 end") >= 0);
 		});
+
+		_.each(["", null, undefined], (commandName: string) => {
+			it("shows index help when command is not specified", async () => {
+				const injector = createTestInjector();
+				injector.register("fs", {
+					enumerateFilesInDirectorySync: (path: string) => ["index.md"],
+					readText: () => "index data is read"
+				});
+
+				const helpService = injector.resolve<IHelpService>("helpService");
+				await helpService.showCommandLineHelp(commandName);
+				const output = injector.resolve("logger").output;
+				assert.isTrue(output.indexOf("index data is read") >= 0);
+			});
+		});
 	});
 });

--- a/test/unit-tests/services/help-service.ts
+++ b/test/unit-tests/services/help-service.ts
@@ -1,0 +1,423 @@
+import { CommonLoggerStub, ErrorsStub } from "../stubs";
+import { MicroTemplateService } from "../../../services/micro-templating-service";
+import { HelpService } from "../../../services/html-help-service";
+import { assert } from "chai";
+import { EOL } from "os";
+import { Yok } from '../../../yok';
+
+interface ITestData {
+	input: string;
+	expectedOutput: string;
+}
+
+const createTestInjector = (opts?: { isProjectTypeResult: boolean; isPlatformResult: boolean }): IInjector => {
+	const injector = new Yok();
+	injector.register("staticConfig", {});
+	injector.register("errors", ErrorsStub);
+	injector.register("options", { help: true });
+
+	injector.register("logger", CommonLoggerStub);
+
+	opts = opts || { isPlatformResult: true, isProjectTypeResult: true };
+
+	injector.register("dynamicHelpProvider", {
+		getLocalVariables: () => ({})
+	});
+
+	injector.register("dynamicHelpService", {
+		isProjectType: (...args: string[]): boolean => opts.isProjectTypeResult,
+		isPlatform: (...args: string[]): boolean => { return opts.isPlatformResult; },
+		getLocalVariables: (): IDictionary<any> => {
+			const localVariables: IDictionary<any> = {};
+			localVariables["myLocalVar"] = opts.isProjectTypeResult;
+			localVariables["isLinux"] = opts.isPlatformResult;
+			localVariables["isWindows"] = opts.isPlatformResult;
+			localVariables["isMacOS"] = opts.isPlatformResult;
+			return localVariables;
+		}
+	});
+	injector.register("microTemplateService", MicroTemplateService);
+	injector.register("helpService", HelpService);
+	injector.register("opener", {
+		open(target: string, appname?: string): void {/* mock */ }
+	});
+	injector.register("commandsServiceProvider", {
+		getDynamicCommands: (): Promise<string[]> => {
+			return Promise.resolve(<string[]>[]);
+		}
+	});
+
+	injector.registerCommand("foo", {});
+
+	return injector;
+};
+
+describe("helpService", () => {
+	describe("showCommandLineHelp", () => {
+		const testData: ITestData[] = [
+			{
+				input: "bla <span>test</span> bla",
+				expectedOutput: "bla test bla"
+			},
+			{
+				input: 'bla <span>span 1</span> bla <span>span 2</span> end',
+				expectedOutput: "bla span 1 bla span 2 end"
+			},
+			{
+				input: 'bla <span style="color:red">test</span> bla',
+				expectedOutput: "bla test bla"
+			},
+			{
+				input: 'bla <span style="color:red;font-size:15px">test</span> bla',
+				expectedOutput: "bla test bla"
+			},
+			{
+				input: `bla
+<span style="color:red;font-size:15px">
+test
+</span>bla`,
+				expectedOutput: "blatestbla"
+			},
+			{
+				input: `bla
+<span style="color:red;font-size:15px">
+span 1
+</span>bla
+<span style="color:red;font-size:15px">
+span 2
+</span>
+end`,
+				expectedOutput: "blaspan 1blaspan 2end"
+			},
+			{
+				input: `some text on upper line
+and another one
+bla
+<span style="color:red;font-size:15px">
+span 1
+</span>bla
+<span style="color:red;font-size:15px">
+span 2
+</span>
+end`,
+				expectedOutput: `some text on upper line
+and another one
+blaspan 1blaspan 2end`
+			},
+			{
+				input: `some text on upper line
+and another one
+bla
+<span style="color:red;font-size:15px">
+span 1
+</span>bla
+<span style="color:red;font-size:15px">
+span 2
+</span>
+end
+some text on next line
+and another one`,
+				expectedOutput: `some text on upper line
+and another one
+blaspan 1blaspan 2end
+some text on next line
+and another one`
+			}
+		];
+
+		describe("does not print <span> tags in terminal", () => {
+			for (const testIndex in testData) {
+				it(`test case ${testIndex}`, async () => {
+					const testCase = testData[testIndex];
+					const injector = createTestInjector();
+					injector.register("module", {
+						command: () => "woot"
+					});
+
+					injector.register("fs", {
+						enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+						readText: () => testCase.input
+					});
+
+					const helpService = injector.resolve<IHelpService>("helpService");
+					await helpService.showCommandLineHelp("foo");
+					const actualOutput = injector.resolve("logger").output.trim();
+					assert.equal(actualOutput, testCase.expectedOutput);
+				});
+			}
+		});
+
+		it("does not print <br> tags in terminal", async () => {
+			const injector = createTestInjector();
+			injector.register("module", {
+				command: () => "woot"
+			});
+
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => `some text<br>more text</br></ br>and more<br/>and again<br />and final line`
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+			const actualOutput = injector.resolve("logger").output.trim();
+			const expectedOutput = `some text${EOL}more text${EOL}${EOL}and more${EOL}and again${EOL}and final line`;
+			assert.equal(actualOutput, expectedOutput);
+		});
+
+		it("processes substitution points", async () => {
+			const injector = createTestInjector();
+			injector.register("module", {
+				command: () => "woot"
+			});
+
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "bla <%= #{module.command} %> bla"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+			assert.isTrue(injector.resolve("logger").output.indexOf("bla woot bla") >= 0);
+		});
+
+		it("process correctly if construction with dynamicCall returning false", async () => {
+			const injector = createTestInjector();
+			injector.register("module", {
+				command: () => false
+			});
+
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "bla <% if (#{module.command}) { %> secondBla <% } %>"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla") >= 0);
+			assert.isTrue(output.indexOf("secondBla") < 0);
+		});
+
+		it("process correctly if construction with dynamicCall returning true", async () => {
+			const injector = createTestInjector();
+			injector.register("module", {
+				command: () => true
+			});
+
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "bla <% if (#{module.command}) { %>secondBla<% } %>"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla") >= 0);
+			assert.isTrue(output.indexOf("secondBla") > 0);
+			assert.isTrue(output.indexOf("bla secondBla") >= 0);
+		});
+
+		it("process correctly if construction returning false", async () => {
+			const injector = createTestInjector();
+
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "bla <% if (false) { %> secondBla <% } %>"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla") >= 0);
+			assert.isTrue(output.indexOf("secondBla") < 0);
+			assert.isTrue(output.indexOf("bla secondBla") < 0);
+		});
+
+		it("process correctly if construction returning true", async () => {
+			const injector = createTestInjector();
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "bla <% if (true) { %>secondBla<% } %>"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla") >= 0);
+			assert.isTrue(output.indexOf("secondBla") > 0);
+			assert.isTrue(output.indexOf("bla secondBla") >= 0);
+		});
+
+		it("process correctly is* platform variables when they are true", async () => {
+			const injector = createTestInjector();
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "bla <% if (isLinux) { %>isLinux<% } %> <% if(isWindows) { %>isWindows<%}%> <%if(isMacOS) {%>isMacOS<%}%>"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla isLinux isWindows isMacOS") >= 0);
+		});
+
+		it("process correctly is* platform variables when they are false", async () => {
+			const injector = createTestInjector({ isProjectTypeResult: false, isPlatformResult: false });
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "bla <% if (isLinux) { %>isLinux<% } %> <% if(isWindows) { %>isWindows<%}%> <%if(isMacOS) {%>isMacOS<%}%>"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla isLinux isWindows isMacOS") < 0);
+			assert.isTrue(output.indexOf("isLinux") < 0);
+			assert.isTrue(output.indexOf("isWindows") < 0);
+			assert.isTrue(output.indexOf("isMacOS") < 0);
+			assert.isTrue(output.indexOf("bla") >= 0);
+		});
+
+		it("process correctly multiple if statements with local variables (all are true)", async () => {
+			const injector = createTestInjector();
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				// all variables must be true
+				readText: () => "bla <% if (isLinux) { %><% if(myLocalVar) {%>isLinux and myLocalVar <% } %><% } %>end"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla isLinux and myLocalVar end") >= 0);
+		});
+
+		it("process correctly multiple if statements with local variables (all are false)", async () => {
+			const injector = createTestInjector({ isProjectTypeResult: false, isPlatformResult: false });
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				// all variables must be false
+				readText: () => "bla <% if (isLinux) { %><% if(myLocalVar) {%>isLinux and myLocalVar <% } %><% } %>end"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla isLinux and myLocalVar end") < 0);
+			assert.isTrue(output.indexOf("isLinux") < 0);
+			assert.isTrue(output.indexOf("myLocalVar") < 0);
+			assert.isTrue(output.indexOf("bla end") >= 0);
+		});
+
+		it("process correctly multiple if statements with local variables (isProjectType is false, isPlatform is true)", async () => {
+			const injector = createTestInjector({ isProjectTypeResult: false, isPlatformResult: true });
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "bla <% if (isLinux) { %>isLinux <% if(myLocalVar) {%>myLocalVar <% } %><% } %>end"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla isLinux end") >= 0);
+		});
+
+		it("process correctly multiple if statements with dynamicCalls (all are true)", async () => {
+			const injector = createTestInjector();
+			injector.register("module", {
+				command1: () => true,
+				command2: () => true
+			});
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "bla <% if (#{module.command1}) { %>command1<% if(#{module.command2}) {%> and command2 <% } %><% } %>end"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla command1 and command2 end") >= 0);
+		});
+
+		it("process correctly multiple if statements with dynamicCalls (all are false)", async () => {
+			const injector = createTestInjector();
+			injector.register("module", {
+				command1: () => false,
+				command2: () => false
+			});
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "bla <% if (#{module.command1}) { %>command1<% if(#{module.command2}) {%> and command2 <% } %><% } %>end"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla command1 and command2 end") < 0);
+			assert.isTrue(output.indexOf("command1") < 0);
+			assert.isTrue(output.indexOf("command2") < 0);
+			assert.isTrue(output.indexOf("bla end") >= 0);
+		});
+
+		it("process correctly multiple if statements with dynamicCalls (different result)", async () => {
+			const injector = createTestInjector();
+			injector.register("module", {
+				command1: () => true,
+				command2: () => false,
+				command3: () => false
+			});
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "bla <% if (#{module.command1}) { %>command1 <% if(#{module.command2}) {%> and command2 <% if(#{module.command3}) { %>and command3 <% } %> <% } %><% } %>end"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla command1 end") >= 0);
+			assert.isTrue(output.indexOf("command2") < 0);
+			assert.isTrue(output.indexOf("command3") < 0);
+		});
+
+		it("process correctly multiple dynamicCalls", async () => {
+			const injector = createTestInjector();
+			injector.register("module", {
+				command1: () => "command1",
+				command2: () => "command2",
+				command3: () => "command3"
+			});
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "bla <%= #{module.command1}%> <%= #{module.command2} %> <%= #{module.command3} %> end"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla command1 command2 command3 end") >= 0);
+		});
+
+		it("process correctly dynamicCalls with parameters", async () => {
+			const injector = createTestInjector();
+			injector.register("module", {
+				command1: (...args: string[]) => args.join(" ")
+			});
+			injector.register("fs", {
+				enumerateFilesInDirectorySync: (path: string) => ["foo.md"],
+				readText: () => "--[foo]-- bla <%= #{module.command1(param1, param2)}%> end--[/]--"
+			});
+
+			const helpService = injector.resolve<IHelpService>("helpService");
+			await helpService.showCommandLineHelp("foo");
+			const output = injector.resolve("logger").output;
+			assert.isTrue(output.indexOf("bla param1 param2 end") >= 0);
+		});
+	});
+});

--- a/test/unit-tests/services/settings-service.ts
+++ b/test/unit-tests/services/settings-service.ts
@@ -1,0 +1,116 @@
+import { Yok } from "../../../yok";
+import { SettingsService } from "../../../services/settings-service";
+import { assert } from "chai";
+
+const osenv = require("osenv");
+const path = require("path");
+const originalOsenvHome = osenv.home;
+const originalPathResolve = path.resolve;
+const originalProcessEnvAppData = process.env.AppData;
+
+interface ITestCase {
+	expectedUserAgentName: string;
+	expectedProfileDir: string;
+	testName: string;
+	dataPassedToSetSettings: IConfigurationSettings;
+}
+
+describe("settingsService", () => {
+	const osenvHome = "homeDir";
+	const appDataEnv = "appData";
+	const profileDirName = "profileDir";
+
+	before(() => {
+		osenv.home = () => osenvHome;
+		path.resolve = (p: string) => p;
+		process.env.AppData = appDataEnv;
+	});
+
+	after(() => {
+		osenv.home = originalOsenvHome;
+		path.resolve = originalPathResolve;
+		process.env.AppData = originalProcessEnvAppData;
+	});
+
+	const createTestInjector = (opts?: { userAgentName?: string, isWindows?: boolean }): IInjector => {
+		const testInjector = new Yok();
+		testInjector.register("staticConfig", {
+			USER_AGENT_NAME: opts && opts.userAgentName || "userAgentName",
+			PROFILE_DIR_NAME: profileDirName
+		});
+
+		testInjector.register("hostInfo", {
+			isWindows: opts && _.has(opts, "isWindows") ? opts.isWindows : true
+		});
+
+		return testInjector;
+	};
+
+	const getExpectedProfileDir = (opts: { isWindows: boolean } = { isWindows: true }) => {
+		const defaultProfileDirLocation = opts.isWindows ? appDataEnv : path.join(osenvHome, ".local", "share");
+		return path.join(defaultProfileDirLocation, profileDirName);
+	};
+
+	describe("sets the profileDir to its default value", () => {
+		_.each([true, false], isWindows => {
+			it(`when os is ${isWindows ? "" : "not "}Windows`, () => {
+				const testInjector = createTestInjector();
+				const hostInfo = testInjector.resolve<IHostInfo>("hostInfo");
+				hostInfo.isWindows = isWindows;
+
+				const settingsService = testInjector.resolve<ISettingsService>(SettingsService);
+				const actualProfileDir = settingsService.getProfileDir();
+				const expectedProfileDir = getExpectedProfileDir({ isWindows });
+				assert.equal(actualProfileDir, expectedProfileDir);
+			});
+		});
+	});
+
+	describe("setSettings", () => {
+		const defaultUserAgentName = "defaultUserAgentName";
+		const customUserAgentName = "customUserAgentName";
+		const customProfileDir = "customProfileDir";
+
+		const testData: ITestCase[] = [
+			{
+				expectedUserAgentName: defaultUserAgentName,
+				expectedProfileDir: getExpectedProfileDir(),
+				testName: "does not fail when nothing is passed",
+				dataPassedToSetSettings: null
+			},
+			{
+				expectedUserAgentName: customUserAgentName,
+				expectedProfileDir: customProfileDir,
+				testName: "sets both userAgentName and profileDir when they are passed",
+				dataPassedToSetSettings: { userAgentName: customUserAgentName, profileDir: customProfileDir }
+			},
+			{
+				expectedUserAgentName: customUserAgentName,
+				expectedProfileDir: getExpectedProfileDir(),
+				testName: "sets only userAgentName when its the only passed value",
+				dataPassedToSetSettings: { userAgentName: customUserAgentName }
+			},
+			{
+				expectedUserAgentName: defaultUserAgentName,
+				expectedProfileDir: customProfileDir,
+				testName: "sets only profileDir when its the only passed value",
+				dataPassedToSetSettings: { profileDir: customProfileDir }
+			},
+		];
+
+		_.each(testData, testCase => {
+			it(testCase.testName, () => {
+				const testInjector = createTestInjector();
+				const staticConfig = testInjector.resolve<Config.IStaticConfig>("staticConfig");
+				staticConfig.USER_AGENT_NAME = defaultUserAgentName;
+
+				const settingsService = testInjector.resolve<ISettingsService>(SettingsService);
+				settingsService.setSettings(testCase.dataPassedToSetSettings);
+
+				const actualProfileDir = settingsService.getProfileDir();
+				assert.equal(actualProfileDir, testCase.expectedProfileDir);
+				assert.equal(staticConfig.USER_AGENT_NAME, testCase.expectedUserAgentName);
+			});
+		});
+	});
+});

--- a/test/unit-tests/stubs.ts
+++ b/test/unit-tests/stubs.ts
@@ -37,7 +37,9 @@ export class CommonLoggerStub implements ILogger {
 		return null;
 	}
 
-	printMarkdown(message: string): void { }
+	printMarkdown(message: string): void {
+		this.output += message;
+	}
 }
 
 export class ErrorsStub implements IErrors {
@@ -54,7 +56,7 @@ export class ErrorsStub implements IErrors {
 		throw new Error(message);
 	}
 
-	async beginCommand(action: () => Promise<boolean>, printHelpCommand: () => Promise<boolean>): Promise<boolean> {
+	async beginCommand(action: () => Promise<boolean>, printHelpCommand: () => Promise<void>): Promise<boolean> {
 		return action();
 	}
 

--- a/test/unit-tests/stubs.ts
+++ b/test/unit-tests/stubs.ts
@@ -77,3 +77,13 @@ export class HooksServiceStub implements IHooksService {
 
 	hookArgsName = "hookArgs";
 }
+
+export class SettingsService implements ISettingsService {
+	public setSettings (settings: IConfigurationSettings) {
+		// Intentionally left blank
+	}
+
+	public getProfileDir() {
+		return "profileDir";
+	}
+}


### PR DESCRIPTION
Cherry-picked in release:
- Fix unit tests on Windows (#1019) 80fe24c09c58acab00c7e200c05e2751774f8ef0
- Expose getUserAgent in the analyticsSettingsService (#1020) eac6e6bec934f92edae1bbb8b12e845ba8aa4bb0
- Fix leaking handlers for iOS device logs (#1022) c6853d39fb9aaaaf68e13af766c77f638eec527a
- Do not track help command when other command fails (#1021) c93c34b20c8dfb2ccbff579c3d3be85c80778e7d
- Rename html-help-service.ts to html-service.ts (#1021) b5fe5ff7e2db9cc3870c347655f38b21d1e24506
- Use profileDir from settingsService (#1023) 25c9f0fcc582be04516a23a06260255c0210413b
- Fix showing default help (from index.md) (#1024) b034b304395e616b83d3007aeaa98298ceef2944
- Fix execution of hooks outside of process (#1026) 6918147a223080bee4b7f05a65d12256c17e17fc