### PR TITLE
Expose API for getting installed applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,6 +752,22 @@ Sample result will be:
 ]
 ```
 
+* `getInstalledApplications(deviceIdentifier: string): Promise<string[]>` - returns information about applications installed on specified device. The method will reject the resulting Promise in case the passed `deviceIdentifier` is not found (i.e. there's no currently attached device with this identifier).
+
+Sample usage:
+```JavaScript
+require("mobile-cli-lib").devicesService.getInstalledApplications("4df18f307d8a8f1b")
+	.then(function(appIdentifiers) {
+		console.log("Installed applications are: ", appIdentifiers);
+	}, function(err) {
+		console.log(err);
+	});
+```
+Sample result of the method call is:
+```JSON
+["com.telerik.app1", "org.nativescript.app1"]
+```
+
 ### Module liveSyncService
 > Stability: 1 - Could be changed due to some new requirments.
 

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -418,6 +418,13 @@ declare module Mobile {
 		isCompanionAppInstalledOnDevices(deviceIdentifiers: string[], framework: string): Promise<IAppInstalledInfo>[];
 		getDebuggableApps(deviceIdentifiers: string[]): Promise<Mobile.IDeviceApplicationInformation[]>[];
 		getDebuggableViews(deviceIdentifier: string, appIdentifier: string): Promise<Mobile.IDebugWebViewInfo[]>;
+
+		/**
+		 * Returns all applications installed on the specified device.
+		 * @param {string} deviceIdentifer The identifier of the device for which to get installed applications.
+		 * @returns {Promise<string[]>} Array of all application identifiers of the apps installed on device.
+		 */
+		getInstalledApplications(deviceIdentifier: string): Promise<string[]>;
 	}
 
 	/**

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -116,6 +116,12 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	}
 
 	@exported("devicesService")
+	public async getInstalledApplications(deviceIdentifier: string): Promise<string[]> {
+		const device = await this.getDevice(deviceIdentifier);
+		return device.applicationManager.getInstalledApplications();
+	}
+
+	@exported("devicesService")
 	public addDeviceDiscovery(deviceDiscovery: Mobile.IDeviceDiscovery): void {
 		this._otherDeviceDiscoveries.push(deviceDiscovery);
 		this._allDeviceDiscoveries.push(deviceDiscovery);

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -1571,4 +1571,23 @@ describe("devicesService", () => {
 			assert.deepEqual(actualDebuggableViews, undefined);
 		});
 	});
+
+	describe("getInstalledApplications", () => {
+		beforeEach(() => {
+			androidDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, androidDevice);
+			iOSDeviceDiscovery.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, iOSDevice);
+		});
+
+		_.each([null, undefined, "", "invalid device id"], deviceId => {
+			it(`fails when invalid identfier is passed: '${deviceId === '' ? "empty string" : deviceId}'`, async () => {
+				const expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIdentifierErrorMessageWithIdentifier", deviceId);
+				await assert.isRejected(devicesService.getInstalledApplications(deviceId), expectedErrorMessage);
+			});
+		});
+
+		it("returns installed applications", async () => {
+			const actualResult = await devicesService.getInstalledApplications(androidDevice.deviceInfo.identifier);
+			assert.deepEqual(actualResult, ["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"]);
+		});
+	});
 });


### PR DESCRIPTION
Expose API for getting installed applications for a specific device when CLI is required as library. Add the new method to `devicesService`.