### PR TITLE
Recursively look for projectDir when executing hooks

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -452,6 +452,25 @@ export function getPidFromiOSSimulatorLogs(applicationIdentifier: string, logLin
 	return null;
 }
 
+export function getValueFromNestedObject(obj: any, key: string): any {
+	function _getValueRecursive(_obj: any, _key: string): any[] {
+		if (_.has(_obj, _key)) {
+			return [_obj];
+		}
+
+		const res: any[] = [];
+		_.forEach(_obj, (v, k) => {
+			if (typeof v === "object" && typeof k === "string" && !_.startsWith(k, '$') && !_.endsWith(k.toLowerCase(), "service") && (v = _getValueRecursive(v, _key)).length) {
+				res.push.apply(res, v);
+			}
+		});
+
+		return res;
+	}
+
+	return _.head(_getValueRecursive(obj, key));
+}
+
 //--- begin part copied from AngularJS
 
 //The MIT License

--- a/services/hooks-service.ts
+++ b/services/hooks-service.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as util from "util";
-import { annotate } from "../helpers";
+import { annotate, getValueFromNestedObject } from "../helpers";
 
 class Hook implements IHook {
 	constructor(public name: string,
@@ -69,7 +69,12 @@ export class HooksService implements IHooksService {
 		}
 
 		const hookArgs: any = hookArguments && hookArguments[this.hookArgsName];
-		const projectDir = hookArgs && (hookArgs.projectDir || (hookArgs.projectData && hookArgs.projectData.projectDir));
+		let projectDir = hookArgs && hookArgs.projectDir;
+		if (!projectDir && hookArgs) {
+			const candidate = getValueFromNestedObject(hookArgs, "projectDir");
+			projectDir = candidate && candidate.projectDir;
+		}
+
 		this.$logger.trace(`Project dir from hooksArgs is: ${projectDir}.`);
 
 		this.initialize(projectDir);

--- a/test/unit-tests/helpers.ts
+++ b/test/unit-tests/helpers.ts
@@ -457,4 +457,88 @@ describe("helpers", () => {
 			_.each(getPidFromiOSSimulatorLogsTestData, testData => assertPidTestData(testData));
 		});
 	});
+
+	describe("getValueFromNestedObject", () => {
+		interface IValueFromNestedObjectTestData extends ITestData {
+			key: string;
+		}
+
+		const key = "key";
+		const dollarKey = "$key";
+		const dollarTestObj = { [dollarKey]: "value" };
+		const serviceKey = "keyEndingWithService";
+		const serviceTestObj = { [serviceKey]: "value" };
+		const testObj = { key };
+		const getValueFromNestedObjectTestData: IValueFromNestedObjectTestData[] = [
+			{
+				key,
+				input: {},
+				expectedResult: undefined
+			},
+			{
+				key,
+				input: testObj,
+				expectedResult: testObj
+			},
+			{
+				key,
+				input: { nestedKey: testObj },
+				expectedResult: testObj
+			},
+			{
+				key,
+				input: { nestedKey: { anotherNestedKey: testObj } },
+				expectedResult: testObj
+			},
+			{
+				key,
+				input: { otherKey: "otherValue" },
+				expectedResult: undefined
+			},
+			{
+				key,
+				input: { otherKey: "otherValue" },
+				expectedResult: undefined
+			},
+			{
+				key: dollarKey,
+				input: dollarTestObj,
+				expectedResult: dollarTestObj
+			},
+			{
+				key: dollarKey,
+				input: { nestedKey: dollarTestObj },
+				expectedResult: dollarTestObj
+			},
+			{
+				key: dollarKey,
+				input: { "$nestedKey": dollarTestObj },
+				expectedResult: undefined
+			},
+			{
+				key: serviceKey,
+				input: serviceTestObj,
+				expectedResult: serviceTestObj
+			},
+			{
+				key: serviceKey,
+				input: { nestedKey: serviceTestObj },
+				expectedResult: serviceTestObj
+			},
+			{
+				key: serviceKey,
+				input: { nestedKeyService: serviceTestObj },
+				expectedResult: undefined
+			}
+		];
+
+		const assertValueFromNestedObjectTestData = (testData: IValueFromNestedObjectTestData) => {
+			const actualResult = helpers.getValueFromNestedObject(testData.input, testData.key);
+			assert.deepEqual(actualResult, testData.expectedResult, `For input ${JSON.stringify(testData.input)}, the expected result is: ${JSON.stringify(testData.expectedResult || "undefined")}, but actual result is: ${JSON.stringify(actualResult || "undefined")}.`);
+		};
+
+		it("returns expected result", () => {
+			_.each(getValueFromNestedObjectTestData, testData => assertValueFromNestedObjectTestData(testData));
+		});
+	});
 });


### PR DESCRIPTION
Whenever executing a hook we try and pass the `projectDir` to the hook, however we expect the original method, marked with `@hook` to either have the actual property `projectDir` as an argument or at least have an argument, named `projectData` from which we can get the `projectDir`.
This is incorrect, as the `projectDir` property may be nested in some argument further down.
Recursively traverse all arguments and try and locate the `projectDir` property.

Skip, however, especially large objects like those starting with `$` (dependency-injected classes) or those ending with `service` (more dependency-injected classes) in order to prevent a maximum callstack exception.

Ping @rosen-vladimirov @PanayotCankov @sis0k0 