### PR TITLE
Replace rename with write+delete

### DIFF
--- a/services/project-files-manager.ts
+++ b/services/project-files-manager.ts
@@ -75,7 +75,9 @@ export class ProjectFilesManager implements IProjectFilesManager {
 						this.$fs.writeFile(filePath, fileContent);
 					}
 					// Rename the file
-					this.$fs.rename(filePath, onDeviceFilePath);
+					// this.$fs.rename is not called as it is error prone on some systems with slower hard drives and rigorous antivirus software
+					this.$fs.writeFile(onDeviceFilePath, this.$fs.readText(filePath));
+					this.$fs.deleteFile(filePath);
 				}
 			}
 		});


### PR DESCRIPTION
On some systems with slower hard drives and rigorous antivirus software, on numerous occasions the newly created files in `platforms` directory are locked and cannot be renamed. The rename fails with `EPERM`.
Switching to write+delete in favor of rename eliminates said issue.

ping @rosen-vladimirov @KristianDD 