### PR TITLE
Fix EMFILE error when running on Android

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -91,3 +91,5 @@ export const enum AnalyticsClients {
 	NonInteractive = "Non-interactive",
 	Unknown = "Unknown"
 }
+
+export const DEFAULT_CHUNK_SIZE = 100;

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -671,9 +671,9 @@ declare module Mobile {
 		 */
 		getShasumsFromDevice(): Promise<IStringDictionary>;
 		/**
-		 * Computes the shasums of localToDevicePaths and changes the content of hash file on device
+		 * Uploads updated shasums to hash file on device
 		 */
-		uploadHashFileToDevice(data: IStringDictionary | Mobile.ILocalToDevicePathData[]): Promise<void>;
+		uploadHashFileToDevice(data: IStringDictionary): Promise<void>;
 		/**
 		 * Computes the shasums of localToDevicePaths and updates hash file on device
 		 */
@@ -688,6 +688,14 @@ declare module Mobile {
 		 * @return {Promise<boolean>} boolean True if file exists and false otherwise.
 		 */
 		doesShasumFileExistsOnDevice(): Promise<boolean>;
+
+		/**
+		 * Generates hashes of specified localToDevicePaths by chunks and persists them in the passed @shasums argument.
+		 * @param {Mobile.ILocalToDevicePathData[]} localToDevicePaths The localToDevicePaths objects for which the hashes should be generated.
+		 * @param {IStringDicitionary} shasums Object in which the shasums will be persisted.
+		 * @returns {Promise<string>[]} DevicePaths of all elements from the input localToDevicePaths.
+		 */
+		generateHashesFromLocalToDevicePaths(localToDevicePaths: Mobile.ILocalToDevicePathData[], shasums: IStringDictionary): Promise<string[]>;
 	}
 
 	/**

--- a/helpers.ts
+++ b/helpers.ts
@@ -8,6 +8,24 @@ import * as crypto from "crypto";
 
 const Table = require("cli-table");
 
+export async function executeActionByChunks<T>(initialData: T[] | IDictionary<T>, chunkSize: number, elementAction: (element: T, key?: string | number) => Promise<any>): Promise<void> {
+	let arrayToChunk: (T | string)[];
+	let action: (key: string | T) => Promise<any>;
+
+	if (_.isArray(initialData)) {
+		arrayToChunk = initialData;
+		action = (element: T) => elementAction(element, initialData.indexOf(element));
+	} else {
+		arrayToChunk = _.keys(initialData);
+		action = (key: string) => elementAction(initialData[key], key);
+	}
+
+	const chunks = _.chunk(arrayToChunk, chunkSize);
+	for (const chunk of chunks) {
+		await Promise.all(_.map(chunk, element => action(element)));
+	}
+}
+
 export function deferPromise<T>(): IDeferPromise<T> {
 	let resolve: (value?: T | PromiseLike<T>) => void;
 	let reject: (reason?: any) => void;


### PR DESCRIPTION
During running on Android, CLI tries to take smart decision which files to upload. This is done by checking the shasum of all project files and comparing it with the latest one uploaded to device. However, in huge projects, this leads to error with code EMFILE as the OS have limits for opened file handles.
This happens as CLI executes the operation simultaneously for all files. In order to fix this behavior, execute the actions by chunks (currently set to 100).
Introduce new method in helpers to execute this action and add tests for it.

Fixes https://github.com/NativeScript/nativescript-angular/issues/1079 and https://github.com/NativeScript/nativescript-cli/issues/3268