### PR TITLE
Fix detection of Javac version

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1123,8 +1123,6 @@ interface ISysInfoData extends IPlatform {
 	nodeGypVer: string;
 
 	// dependencies
-	/** version of java, as returned by `java -version` */
-	javaVer: string;
 	/** Xcode version string as returned by `xcodebuild -version`. Valid only on Mac */
 	xcodeVer: string;
 	/** Version string of adb, as returned by `adb version` */
@@ -1155,9 +1153,6 @@ interface ISysInfo {
 	 * @return {Promise<ISysInfoData>} Object containing information for current system.
 	 */
 	getSysInfo(pathToPackageJson: string, androidToolsInfo?: { pathToAdb: string }): Promise<ISysInfoData>;
-
-	/** Returns Java version. **/
-	getJavaVersion(): Promise<string>;
 
 	/** Returns Java compiler version. **/
 	getJavaCompilerVersion(): Promise<string>;

--- a/helpers.ts
+++ b/helpers.ts
@@ -290,10 +290,18 @@ export async function getFuturesResults<T>(promises: Promise<T | T[]>[], predica
 		.value();
 }
 
+/**
+ * Appends zeroes to a version string until it reaches a specified length.
+ * @param {string} version The version on which to append zeroes.
+ * @param requiredVersionLength The required length of the version string.
+ * @returns {string} Appended version string. In case input is null, undefined or empty string, it is returned immediately without appending anything.
+ */
 export function appendZeroesToVersion(version: string, requiredVersionLength: number): string {
-	const zeroesToAppend = requiredVersionLength - version.split(".").length;
-	for (let index = 0; index < zeroesToAppend; index++) {
-		version += ".0";
+	if (version) {
+		const zeroesToAppend = requiredVersionLength - version.split(".").length;
+		for (let index = 0; index < zeroesToAppend; index++) {
+			version += ".0";
+		}
 	}
 
 	return version;

--- a/test/unit-tests/helpers.ts
+++ b/test/unit-tests/helpers.ts
@@ -15,6 +15,61 @@ describe("helpers", () => {
 		assert.deepEqual(actualResult, testData.expectedResult, `For input ${testData.input}, the expected result is: ${testData.expectedResult}, but actual result is: ${actualResult}.`);
 	};
 
+	describe("appendZeroesToVersion", () => {
+		interface IAppendZeroesToVersionTestData extends ITestData {
+			requiredVersionLength: number;
+		}
+
+		const testData: IAppendZeroesToVersionTestData[] = [
+			{
+				input: "3.0.0",
+				requiredVersionLength: 3,
+				expectedResult: "3.0.0"
+			},
+			{
+				input: "3.0",
+				requiredVersionLength: 3,
+				expectedResult: "3.0.0"
+			},
+			{
+				input: "3",
+				requiredVersionLength: 3,
+				expectedResult: "3.0.0"
+			},
+			{
+				input: "1.8.0_152",
+				requiredVersionLength: 3,
+				expectedResult: "1.8.0_152"
+			},
+			{
+				input: "",
+				requiredVersionLength: 3,
+				expectedResult: ""
+			},
+			{
+				input: null,
+				requiredVersionLength: 3,
+				expectedResult: null
+			},
+			{
+				input: undefined,
+				requiredVersionLength: 3,
+				expectedResult: undefined
+			},
+			{
+				input: "1",
+				requiredVersionLength: 5,
+				expectedResult: "1.0.0.0.0"
+			},
+		];
+
+		it("appends correct number of zeroes", () => {
+			_.each(testData, testCase => {
+				assert.deepEqual(helpers.appendZeroesToVersion(testCase.input, testCase.requiredVersionLength), testCase.expectedResult);
+			});
+		});
+	});
+
 	describe("executeActionByChunks", () => {
 		const chunkSize = 2;
 


### PR DESCRIPTION
The command `javac -version` prints result to stderr when JAVA 8 is used and to stdout when JAVA 9 is used. Current check in CLI uses the stderr output, so when JAVA 9 is installed it fails to detect the correct version.
In order to support both JAVA 8 and JAVA 9, capture both stdout and stderr and get the version from there.
Also remove unneeded check for Java version - we care about JAVA Compiler, which is included in JDK.