### PR TITLE
Return correct error when response is not JSON

### DIFF
--- a/http-client.ts
+++ b/http-client.ts
@@ -262,7 +262,8 @@ export class HttpClient implements Server.IHttpClient {
 					return err.Message;
 				}
 			} catch (parsingFailed) {
-				return `The server returned unexpected response: ${parsingFailed.toString()}`;
+				this.$logger.trace("Failed to get error from http request: ", parsingFailed);
+				return `The server returned unexpected response: ${body}`;
 			}
 
 			return body;


### PR DESCRIPTION
In some cases, when any of the requests fail, the response is not JSON (the servers do not respect the Accept header of the request) and return html.
In this case the JSON.parse operation that we execute in order to find the real error, is failing and we return error that we are unable to parse the result.
This leads to confusion in many cases, so return the real response of the server instead. So when html is returned, it will be included in the error.
This will help the users when they have some firewall issues and they are unable to connect to our servers. In this case they almost always receive html in which it is stated that this page is forbidded and they should contact their admins.