### PR TITLE
Add getSpinner method to $progressIndicator

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1564,6 +1564,38 @@ interface IProgressIndicator {
 	 * @return {Promise<T>}
 	 */
 	showProgressIndicator<T>(promise: Promise<T>, timeout: number, options?: { surpressTrailingNewLine?: boolean }): Promise<T>;
+
+	/**
+	 * Returns a spinner instance that will print a specified message when spinner is started and will repeat it until spinner is stopped.
+	 * In case the terminal is not interactive, a mocked instance is returned, so the spinner will print the required message a single time - when it is started.
+	 * @param {string} message The message to be printed.
+	 * @returns {ISpinner} Instance of clui.Spinner in case terminal is interactive, mocked instance otherwise.
+	 */
+	getSpinner(message: string): ISpinner;
+}
+
+/**
+ * Describes the clui spinner.
+ */
+interface ISpinner {
+	/**
+	 * Sets the message that will be printed by spinner.
+	 * @param {string} msg The new message.
+	 * @returns {void}
+	 */
+	message(msg: string): void;
+
+	/**
+	 * Starts the spinner.
+	 * @returns {void}
+	 */
+	start(): void;
+
+	/**
+	 * Stops the spinner.
+	 * @returns {void}
+	 */
+	stop(): void;
 }
 
 /**

--- a/http-client.ts
+++ b/http-client.ts
@@ -3,8 +3,6 @@ import { EOL } from "os";
 import * as helpers from "./helpers";
 import * as zlib from "zlib";
 import * as util from "util";
-import progress = require("progress-stream");
-import filesize = require("filesize");
 import { HttpStatusCodes } from "./constants";
 import * as request from "request";
 
@@ -133,8 +131,6 @@ export class HttpClient implements Server.IHttpClient {
 							this.setResponseResult(promiseActions, timerId, { response });
 						});
 
-						pipeTo = this.trackDownloadProgress(pipeTo);
-
 						responseStream.pipe(pipeTo);
 					} else {
 						const data: string[] = [];
@@ -202,39 +198,6 @@ export class HttpClient implements Server.IHttpClient {
 
 			result.resolve(finalResult);
 		}
-	}
-
-	private trackDownloadProgress(pipeTo: NodeJS.WritableStream): NodeJS.ReadableStream {
-		// \r for carriage return doesn't work on windows in node for some reason so we have to use it's hex representation \x1B[0G
-		let lastMessageSize = 0;
-		const carriageReturn = "\x1B[0G";
-		let timeElapsed = 0;
-
-		const progressStream = progress({ time: 1000 }, (progress: any) => {
-			timeElapsed = progress.runtime;
-
-			if (timeElapsed >= 1) {
-				this.$logger.write("%s%s", carriageReturn, Array(lastMessageSize + 1).join(" "));
-
-				const message = util.format("%sDownload progress ... %s | %s | %s/s",
-					carriageReturn,
-					Math.floor(progress.percentage) + "%",
-					filesize(progress.transferred),
-					filesize(progress.speed));
-
-				this.$logger.write(message);
-				lastMessageSize = message.length;
-			}
-		});
-
-		progressStream.on("finish", () => {
-			if (timeElapsed >= 1) {
-				this.$logger.out("%s%s%s%s", carriageReturn, Array(lastMessageSize + 1).join(" "), carriageReturn, "Download completed.");
-			}
-		});
-
-		progressStream.pipe(pipeTo);
-		return progressStream;
 	}
 
 	private getErrorMessage(statusCode: number, body: string): string {


### PR DESCRIPTION
Add `getSpinner` method to `$progressIndicator` - it will return a new instance of clui.Spinner in case terminal is interactive. In case it is not - a mocked instance will be returned.
This way in CI builds the spinner will not print tons of repeated messages.