### PR TITLE
Introduce connectToPort method to iOSEmulatorServices

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -580,8 +580,34 @@ declare module Mobile {
 		iOSSimPath: string;
 	}
 
+	/**
+	 * Describes the information when trying to connect to port.
+	 */
+	interface IConnectToPortData {
+		/**
+		 * The port to connect.
+		 * @type {number}
+		 */
+		port: number;
+
+		/**
+		 * Timeout in milliseconds.
+		 * @type {number}
+		 */
+		timeout?: number;
+	}
+
 	interface IiOSSimulatorService extends IEmulatorPlatformServices {
 		postDarwinNotification(notification: string): Promise<void>;
+
+		/**
+		 * Tries to connect to specified port for speciefied amount of time.
+		 * In case it succeeds, a socket is returned.
+		 * In case it fails, undefined is returned.
+		 * @param {IConnectToPortData} connectToPortData Data describing port and timeout to try to connect.
+		 * @returns {net.Socket} Returns instance of net.Socket when connection is successful, otherwise undefined is returned.
+		 */
+		connectToPort(connectToPortData: IConnectToPortData): Promise<any>;
 	}
 
 	interface IEmulatorSettingsService {

--- a/mobile/ios/simulator/ios-emulator-services.ts
+++ b/mobile/ios/simulator/ios-emulator-services.ts
@@ -1,4 +1,9 @@
+import * as net from "net";
+import { connectEventuallyUntilTimeout } from "../../../helpers";
+
 class IosEmulatorServices implements Mobile.IiOSSimulatorService {
+	private static DEFAULT_TIMEOUT = 10000;
+
 	constructor(private $logger: ILogger,
 		private $emulatorSettingsService: Mobile.IEmulatorSettingsService,
 		private $errors: IErrors,
@@ -56,6 +61,15 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 		}
 
 		await this.$childProcess.spawnFromEvent(nodeCommandName, iosSimArgs, "close", { stdio: "inherit" });
+	}
+
+	public async connectToPort(data: Mobile.IConnectToPortData): Promise<net.Socket> {
+		try {
+			const socket = await connectEventuallyUntilTimeout(() => net.connect(data.port), data.timeout || IosEmulatorServices.DEFAULT_TIMEOUT);
+			return socket;
+		} catch (e) {
+			this.$logger.debug(e);
+		}
 	}
 
 	private async runApplicationOnEmulatorCore(app: string, emulatorOptions?: Mobile.IEmulatorOptions): Promise<any> {


### PR DESCRIPTION
Introduce new method - connectToPort to iOSEmulatorServices. This method will try to connect to specified port on users machine (typically this port will be used by NativeScript applications runnin on iOS Simulator) for a specified amount of time. In case it succeeds, the socket of the connection is returned. In case it fails, undefined is returned.