### PR TITLE
feat(livesync): execute all hooks

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -365,13 +365,10 @@ export function decorateMethod(before: (method1: any, self1: any, args1: any[]) 
 			if (newMethods && newMethods.length) {
 				const replacementMethods = _.filter(newMethods, f => _.isFunction(f));
 				if (replacementMethods.length > 0) {
-					if (replacementMethods.length > 1) {
-						const $logger = $injector.resolve<ILogger>("logger");
-						$logger.warn(`Multiple methods detected which try to replace ${sink.name}. Will execute only the first of them.`);
-					}
 
 					hasBeenReplaced = true;
-					result = _.head(replacementMethods)(args, sink.bind(this));
+					const chainedReplacementMethod = _.reduce(replacementMethods, (prev, next) => next.bind(next, args, prev), sink.bind(this));
+					result = chainedReplacementMethod();
 				}
 			}
 


### PR DESCRIPTION
Instead of executing the first hook which tries to replace one of CLI's methods, execute them all in succession.
Pass the a reference to the original CLI method to the first hook, then a reference to the first hook's function to the second and so on.
This approach is inspired by objective-C's method swizzling and serves as a similar mechanism. Hooks should decide wether to call the original method or not.

Ping @rosen-vladimirov @KristianDD 