### PR TITLE
feat(extensions): Allow generation of help content for extension commands

### DIFF
--- a/definitions/extensibility.d.ts
+++ b/definitions/extensibility.d.ts
@@ -1,0 +1,79 @@
+/**
+ * Describes each extension.
+ */
+interface IExtensionData {
+	/**
+	 * The name of the extension.
+	 */
+	extensionName: string;
+
+	/**
+	 * Extension version.
+	 */
+	version: string;
+
+	/**
+	 * Describes the location of the .md files containing the help of the commands included in the extension.
+	 * The property will contain the full path to the extension docs, constructed by getting the value of the docs key in nativescript key of the extensions package.json
+	 * and joining it with the full extension path. As some extensions may not have docs, the property may not be set.
+	 */
+	docs?: string;
+
+	/**
+	 * Full path to the directory of the installed extension.
+	 */
+	pathToExtension: string;
+}
+
+/**
+ * Defines methods for working with CLI's extensions.
+ */
+interface IExtensibilityService {
+	/**
+	 * Installs a specified extension.
+	 * @param {string} extensionName Name of the extension to be installed. It may contain version as well, i.e. myPackage, myPackage@1.0.0,
+	 * myPackage.tgz, https://github.com/myOrganization/myPackage/tarball/master, https://github.com/myOrganization/myPackage, etc.
+	 * @returns {Promise<IExtensionData>} Information about installed extensions.
+	 */
+	installExtension(extensionName: string): Promise<IExtensionData>;
+
+	/**
+	 * Uninstalls extension from the installation.
+	 * @param {string} extensionName Name of the extension to be uninstalled.
+	 * @returns {Promise<void>}
+	 */
+	uninstallExtension(extensionName: string): Promise<void>;
+
+	/**
+	 * Loads all extensions, so their methods and commands can be used from CLI.
+	 * For each of the extensions, a new Promise is returned. It will be rejected in case the extension cannot be loaded. However other promises will not be reflected by this failure.
+	 * In case a promise is rejected, the error will have additional property (extensionName) that shows which is the extension that cannot be loaded in the process.
+	 * @returns {Promise<IExtensionData>[]} Array of promises, each is resolved with information about loaded extension.
+	 */
+	loadExtensions(): Promise<IExtensionData>[];
+
+	/**
+	 * Loads a single extension, so its methods and commands can be used from CLI.
+	 * @param {string} extensionName Name of the extension to be installed. It may contain version as well, i.e. myPackage, myPackage@1.0.0
+	 * A Promise is returned. It will be rejected in case the extension cannot be loaded.
+	 * @returns {Promise<IExtensionData>} Promise, resolved with IExtensionData.
+	 */
+	loadExtension(extensionName: string): Promise<IExtensionData>;
+
+	/**
+	 * Gets information about installed dependencies - names and versions.
+	 * @returns {IStringDictionary}
+	 */
+	getInstalledExtensions(): IStringDictionary;
+
+	/**
+	 * Gives full information for each extension.
+	 * @returns {IExtensionData[]} Data for each of the installed extensions, like name, version, path to extension, etc.
+	 */
+	getInstalledExtensionsData(): IExtensionData[];
+}
+
+/**
+ * Describes the error that will be raised when a problem with extension is detected.
+ */
+interface IExtensionLoadingError extends Error, IExtensionData { }

--- a/docs/helpers/basic-extensions-page.html
+++ b/docs/helpers/basic-extensions-page.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+  <title>@MAN_PAGE_NAME@</title>
+  <link rel="shortcut icon" type="image/ico" href="@RELATIVE_PATH_TO_IMAGES@/favicon.ico"/>
+  <meta http-equiv="content-type" value="text/html;utf-8">
+  <link rel="stylesheet" type="text/css" href="@RELATIVE_PATH_TO_STYLES_CSS@"/>
+</head>
+  <body>
+  <a href="@RELATIVE_PATH_TO_INDEX@"><img class="logo" src="@RELATIVE_PATH_TO_IMAGES@/logo.png"></a>
+  <h1 style="text-align: center">@EXTENSION_NAME@ extension</h1>
+   @HTML_COMMAND_HELP@
+  </body>
+</html>
+

--- a/test/unit-tests/services/help-service.ts
+++ b/test/unit-tests/services/help-service.ts
@@ -48,6 +48,10 @@ const createTestInjector = (opts?: { isProjectTypeResult: boolean; isPlatformRes
 		}
 	});
 
+	injector.register("fs", {
+		exists: (filePath: string) => false
+	});
+
 	injector.register("extensibilityService", {
 		getInstalledExtensionsData: (): IExtensionData[] => []
 	});
@@ -58,6 +62,8 @@ const createTestInjector = (opts?: { isProjectTypeResult: boolean; isPlatformRes
 };
 
 describe("helpService", () => {
+	const blaEnd = "bla end";
+
 	describe("showCommandLineHelp", () => {
 		const testData: ITestData[] = [
 			{
@@ -318,7 +324,7 @@ and another one`
 			assert.isTrue(output.indexOf("bla isLinux and myLocalVar end") < 0);
 			assert.isTrue(output.indexOf("isLinux") < 0);
 			assert.isTrue(output.indexOf("myLocalVar") < 0);
-			assert.isTrue(output.indexOf("bla end") >= 0);
+			assert.isTrue(output.indexOf(blaEnd) >= 0);
 		});
 
 		it("process correctly multiple if statements with local variables (isProjectType is false, isPlatform is true)", async () => {
@@ -368,7 +374,7 @@ and another one`
 			assert.isTrue(output.indexOf("bla command1 and command2 end") < 0);
 			assert.isTrue(output.indexOf("command1") < 0);
 			assert.isTrue(output.indexOf("command2") < 0);
-			assert.isTrue(output.indexOf("bla end") >= 0);
+			assert.isTrue(output.indexOf(blaEnd) >= 0);
 		});
 
 		it("process correctly multiple if statements with dynamicCalls (different result)", async () => {
@@ -459,8 +465,9 @@ and another one`
 						return [];
 					},
 					readText: (pathToRead: string) => {
-						return pathToRead === join(extensionDocsDir, "foo.md") ? "bla end" : "";
-					}
+						return pathToRead === join(extensionDocsDir, "foo.md") ? blaEnd : "";
+					},
+					exists: (filePath: string) => true
 				});
 
 				const $extensibilityService = injector.resolve<IExtensibilityService>("extensibilityService");
@@ -477,16 +484,17 @@ and another one`
 				const helpService = injector.resolve<IHelpService>("helpService");
 				await helpService.showCommandLineHelp("foo");
 				const output = injector.resolve("logger").output;
-				assert.isTrue(output.indexOf("bla end") >= 0);
+				assert.isTrue(output.indexOf(blaEnd) >= 0);
 
-				assert.equal(enumerateFilesInDirectorySyncCalledCounter, expectedEnumerateFilesInDirectorySyncCalledCounter, "The enumerateFilesInDirectorySync method must be called exactly three times - one for CLI help, one for extension2 and one for extension3");
+				assert.equal(enumerateFilesInDirectorySyncCalledCounter, expectedEnumerateFilesInDirectorySyncCalledCounter,
+					`The enumerateFilesInDirectorySync method must be called exactly ${enumerateFilesInDirectorySyncCalledCounter} times.`);
 			};
 
 			it("help from a single installed extension is successfully loaded", async () => {
 				await assertData(2);
 			});
 
-			it("when multiple extensions are installed, the full ", async () => {
+			it("when multiple extensions are installed, the correct help content is shown", async () => {
 				const extensionsData = [
 					{
 						extensionName: "extension1",


### PR DESCRIPTION
Each CLI extension may add new commands to CLI. Allow showing command help for these commands in case:
1. Commmand execution fails.
2. Users need more information for command - `tns <command> --help`
3. Users need full html help for command - `tns help <command>`.

Each extension that wants to use this functionality will have to add `nativescript` key in its `package.json` and add `docs` key in it. The `docs` key must point to the directory where the help content (.md files) is located, relative to the root directory of the extension.
When CLI needs to show command line help for extension's command, it will search the docs directories of all extensions.
When CLI needs to show HTML help for the extension's commands, it will generate `html` directory right next to the docs dir in the extension.

Move extensibility.d.ts from {N} to mobile-cli-lib just to ensure correct transpilation.

### Add different basic page for extensions html pages
When generating html pages for extensions commands, use a different html
page that has the extension name as header at the top.
Add a placeholder and replace it when generating the html page.