### PR TITLE
fix: allow force dispose

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -169,7 +169,7 @@ declare module Server {
 }
 
 interface IDisposable {
-	dispose(): void;
+	dispose(disposeOptions?: IForceOption): void;
 }
 
 /**
@@ -1250,7 +1250,11 @@ interface IProfileDir {
 	profileDir: string;
 }
 
-interface ICommonOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvailableDevices, IProfileDir {
+interface IForceOption {
+	force: boolean;
+}
+
+interface ICommonOptions extends IForceOption, IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvailableDevices, IProfileDir {
 	argv: IYargArgv;
 	validateOptions(commandSpecificDashedOptions?: IDictionary<IDashedOption>): void;
 	options: IDictionary<any>;
@@ -1278,7 +1282,6 @@ interface ICommonOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd,
 	skipRefresh: boolean;
 	file: string;
 	analyticsClient: string;
-	force: boolean;
 	companion: boolean;
 	emulator: boolean;
 	sdk: string;

--- a/mobile/ios/device/ios-device-operations.ts
+++ b/mobile/ios/device/ios-device-operations.ts
@@ -163,7 +163,7 @@ export class IOSDeviceOperations extends EventEmitter implements IIOSDeviceOpera
 	public dispose(disposeOptions?: IForceOption): void {
 		// We need to check if we should dispose the device lib.
 		// For example we do not want to dispose it when we start printing the device logs.
-		if ((disposeOptions && disposeOptions.force) || (this.shouldDispose && this.deviceLib)) {
+		if (this.deviceLib && (disposeOptions && disposeOptions.force || this.shouldDispose)) {
 			this.deviceLib.removeAllListeners();
 			this.deviceLib.dispose();
 			this.deviceLib = null;

--- a/mobile/ios/device/ios-device-operations.ts
+++ b/mobile/ios/device/ios-device-operations.ts
@@ -160,12 +160,12 @@ export class IOSDeviceOperations extends EventEmitter implements IIOSDeviceOpera
 		return this.getMultipleResults<IOSDeviceLib.IDeviceResponse>(() => this.deviceLib.stop(stopArray), errorHandler);
 	}
 
-	public dispose(signal?: string): void {
+	public dispose(disposeOptions?: IForceOption): void {
 		// We need to check if we should dispose the device lib.
 		// For example we do not want to dispose it when we start printing the device logs.
-		if (this.shouldDispose && this.deviceLib) {
+		if ((disposeOptions && disposeOptions.force) || (this.shouldDispose && this.deviceLib)) {
 			this.deviceLib.removeAllListeners();
-			this.deviceLib.dispose(signal);
+			this.deviceLib.dispose();
 			this.deviceLib = null;
 			this.$logger.trace("IOSDeviceOperations disposed.");
 		}

--- a/yok.ts
+++ b/yok.ts
@@ -432,11 +432,11 @@ export class Yok implements IInjector {
 		return `${this.COMMANDS_NAMESPACE}.${name}`;
 	}
 
-	public dispose(): void {
+	public dispose(disposeOptions?: IForceOption): void {
 		Object.keys(this.modules).forEach((moduleName) => {
 			const instance = this.modules[moduleName].instance;
 			if (instance && instance.dispose && instance !== this) {
-				instance.dispose();
+				instance.dispose(disposeOptions);
 			}
 		});
 	}


### PR DESCRIPTION
Allow passing `force` to `dispose` operation. Some services which implement `IDisposable` need to have a way to forcefully shut down.

Ping @rosen-vladimirov 
