### PR TITLE
feat(extensibility): Add hint how to get access to a command from extension

### DIFF
--- a/commands/help.ts
+++ b/commands/help.ts
@@ -11,16 +11,23 @@ export class HelpCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
-		let topic = (args[0] || "").toLowerCase();
-		const hierarchicalCommand = this.$injector.buildHierarchicalCommand(args[0], _.tail(args));
+		let commandName = (args[0] || "").toLowerCase();
+		let commandArguments = _.tail(args);
+		const hierarchicalCommand = this.$injector.buildHierarchicalCommand(args[0], commandArguments);
 		if (hierarchicalCommand) {
-			topic = hierarchicalCommand.commandName;
+			commandName = hierarchicalCommand.commandName;
+			commandArguments = hierarchicalCommand.remainingArguments;
 		}
 
+		const commandData: ICommandData = {
+			commandName,
+			commandArguments
+		};
+
 		if (this.$options.help) {
-			await this.$helpService.showCommandLineHelp(topic);
+			await this.$helpService.showCommandLineHelp(commandData);
 		} else {
-			await this.$helpService.openHelpForCommandInBrowser(topic);
+			await this.$helpService.openHelpForCommandInBrowser(commandData);
 		}
 	}
 }

--- a/constants.ts
+++ b/constants.ts
@@ -93,3 +93,9 @@ export const enum AnalyticsClients {
 }
 
 export const DEFAULT_CHUNK_SIZE = 100;
+
+export const enum CommandsDelimiters {
+	HierarchicalCommand = "|",
+	DefaultHierarchicalCommand = "|*",
+	HooksCommand = "-"
+}

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -965,14 +965,19 @@ interface IMicroTemplateService {
 interface IHelpService {
 	generateHtmlPages(): Promise<void>;
 
-	openHelpForCommandInBrowser(commandName: string): Promise<void>;
+	/**
+	 * Finds the html help for specified command and opens it in the browser.
+	 * @param {IComandData} commandData Data describing searched command - name and arguments.
+	 * @returns {Promise<void>}
+	 */
+	openHelpForCommandInBrowser(commandData: ICommandData): Promise<void>;
 
 	/**
 	 * Shows command line help for specified command.
 	 * @param {string} commandName The name of the command for which to show the help.
 	 * @returns {Promise<void>}
 	 */
-	showCommandLineHelp(commandName: string): Promise<void>;
+	showCommandLineHelp(commandData: ICommandData): Promise<void>;
 }
 
 /**

--- a/definitions/commands-service.d.ts
+++ b/definitions/commands-service.d.ts
@@ -11,3 +11,18 @@ interface ICommandsServiceProvider {
 	generateDynamicCommands(): Promise<void>;
 	registerDynamicSubCommands(): void;
 }
+
+/**
+ * Describes the command data.
+ */
+interface ICommandData {
+	/**
+	 * Name of the command, usually the one registered in bootstrap.
+	 */
+	commandName: string;
+
+	/**
+	 * Additional arguments passed to the command.
+	 */
+	commandArguments: string[];
+}

--- a/definitions/extensibility.d.ts
+++ b/definitions/extensibility.d.ts
@@ -1,12 +1,17 @@
 /**
- * Describes each extension.
+ * Describes extension name data.
  */
-interface IExtensionData {
+interface IExtensionName {
 	/**
 	 * The name of the extension.
 	 */
 	extensionName: string;
+}
 
+/**
+ * Describes each extension.
+ */
+interface IExtensionData extends IExtensionName {
 	/**
 	 * Extension version.
 	 */
@@ -23,6 +28,41 @@ interface IExtensionData {
 	 * Full path to the directory of the installed extension.
 	 */
 	pathToExtension: string;
+}
+
+/**
+ * Describes the object passed to getExtensionNameWhereCommandIsRegistered
+ */
+interface IGetExtensionCommandInfoParams {
+	/**
+	 * All input strings specified by user.
+	 */
+	inputStrings: string[];
+
+	/**
+	 * The separator that is used between each strings when command is registered.
+	 */
+	commandDelimiter: string;
+
+	/**
+	 * The default separator that is used between each strings when command is registered.
+	 */
+	defaultCommandDelimiter: string;
+}
+
+/**
+ * Describes information in which extension a command is registered.
+ */
+interface IExtensionCommandInfo extends IExtensionName {
+	/**
+	 * The name of the command registered in the extension.
+	 */
+	registeredCommandName: string;
+
+	/**
+	 * Information how to install the extension.
+	 */
+	installationMessage: string;
 }
 
 /**
@@ -71,6 +111,19 @@ interface IExtensibilityService {
 	 * @returns {IExtensionData[]} Data for each of the installed extensions, like name, version, path to extension, etc.
 	 */
 	getInstalledExtensionsData(): IExtensionData[];
+
+	/**
+	 * Gives the name of the extension that contains a required command.
+	 * The method finds all extensions from npm and checks the command property defined in the nativescript key of the package.json.
+	 * Based on specified input array, the method tries to find a suitable command that is defined in the extension.
+	 * @example In case the input is `tns execute this command now`, the array will be ["execute", "this", "command", "now"].
+	 * There may be an extension that defines execute|this as a command. The method will check each extension for the following commands:
+	 * execute|this|command|now, execute|this|command, execute|this, execute
+	 * In case it finds any of this commands, the method will return the extension name and the command name.
+	 * @param {string[]} inputStrings All strings written on the terminal.
+	 * @returns {IExtensionCommandInfo} Information about the extension and the registered command.
+	 */
+	getExtensionNameWhereCommandIsRegistered(inputOpts: IGetExtensionCommandInfoParams): Promise<IExtensionCommandInfo>;
 }
 
 /**

--- a/helpers.ts
+++ b/helpers.ts
@@ -11,6 +11,31 @@ import * as util from "util";
 
 const Table = require("cli-table");
 
+/**
+ * Creates regular expression from input string.
+ * The method replaces all occurences of RegExp special symbols in the input string with \<symbol>.
+ * @param {string} input The string from which a regular expression should be created.
+ * @param {string} opts RegExp options, for example "gm" - global and multiline.
+ * @returns {RegExp} The regular expression created from the input string.
+ */
+export function createRegExp(input: string, opts?: string): RegExp {
+	if (!input || !_.isString(input)) {
+		throw new Error("Input must be a string.");
+	}
+
+	const escapedSource = regExpEscape(input);
+	return new RegExp(escapedSource, opts);
+}
+
+/**
+ * Escapes all special symbols used in regex.
+ * @param {string} input The string in which to replace the special regexp symbols.
+ * @returns {string} A string in which all regex symbols are escaped.
+ */
+export function regExpEscape(input: string): string {
+	return input.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&");
+}
+
 export function trackDownloadProgress(destinationStream: NodeJS.WritableStream, url: string): NodeJS.ReadableStream {
 	// \r for carriage return doesn't work on windows in node for some reason so we have to use it's hex representation \x1B[0G
 	let lastMessageSize = 0;

--- a/test/unit-tests/services/help-service.ts
+++ b/test/unit-tests/services/help-service.ts
@@ -151,7 +151,7 @@ and another one`
 					});
 
 					const helpService = injector.resolve<IHelpService>("helpService");
-					await helpService.showCommandLineHelp("foo");
+					await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 					const actualOutput = injector.resolve("logger").output.trim();
 					assert.equal(actualOutput, testCase.expectedOutput);
 				});
@@ -170,7 +170,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 			const actualOutput = injector.resolve("logger").output.trim();
 			const expectedOutput = `some text${EOL}more text${EOL}${EOL}and more${EOL}and again${EOL}and final line`;
 			assert.equal(actualOutput, expectedOutput);
@@ -188,7 +188,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 			assert.isTrue(injector.resolve("logger").output.indexOf("bla woot bla") >= 0);
 		});
 
@@ -204,7 +204,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla") >= 0);
 			assert.isTrue(output.indexOf("secondBla") < 0);
@@ -222,7 +222,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla") >= 0);
@@ -239,7 +239,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla") >= 0);
@@ -255,7 +255,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla") >= 0);
@@ -271,7 +271,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla isLinux isWindows isMacOS") >= 0);
 		});
@@ -284,7 +284,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla isLinux isWindows isMacOS") < 0);
@@ -303,7 +303,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla isLinux and myLocalVar end") >= 0);
@@ -318,7 +318,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla isLinux and myLocalVar end") < 0);
@@ -335,7 +335,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla isLinux end") >= 0);
 		});
@@ -352,7 +352,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla command1 and command2 end") >= 0);
 		});
@@ -369,7 +369,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla command1 and command2 end") < 0);
 			assert.isTrue(output.indexOf("command1") < 0);
@@ -390,7 +390,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla command1 end") >= 0);
 			assert.isTrue(output.indexOf("command2") < 0);
@@ -410,7 +410,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla command1 command2 command3 end") >= 0);
 		});
@@ -426,7 +426,7 @@ and another one`
 			});
 
 			const helpService = injector.resolve<IHelpService>("helpService");
-			await helpService.showCommandLineHelp("foo");
+			await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 			const output = injector.resolve("logger").output;
 			assert.isTrue(output.indexOf("bla param1 param2 end") >= 0);
 		});
@@ -440,7 +440,7 @@ and another one`
 				});
 
 				const helpService = injector.resolve<IHelpService>("helpService");
-				await helpService.showCommandLineHelp(commandName);
+				await helpService.showCommandLineHelp({ commandName, commandArguments: [] });
 				const output = injector.resolve("logger").output;
 				assert.isTrue(output.indexOf("index data is read") >= 0);
 			});
@@ -482,7 +482,7 @@ and another one`
 				$extensibilityService.getInstalledExtensionsData = (): IExtensionData[] => extensionsData;
 
 				const helpService = injector.resolve<IHelpService>("helpService");
-				await helpService.showCommandLineHelp("foo");
+				await helpService.showCommandLineHelp({ commandName: "foo", commandArguments: [] });
 				const output = injector.resolve("logger").output;
 				assert.isTrue(output.indexOf(blaEnd) >= 0);
 


### PR DESCRIPTION
In case user executes any command that is registered in extension, but this extension is not installed, they'll receive error:
`Unknown command ...`. Instead of showing this, it is better to tell them how to get access to this command.
In order to achieve this, implement a new logic in `extensibilityService` to find commands registered in all extensions. CLI searches npm (via npms API) for packages that have the keyword `nativescript:extension`.
After that, CLI gets the package.json of the latest version of each dependency (via registry.npmjs.org) and searches for nativescript key in it. In case it has nativescript key, CLI reads the commands value inside it. The value should be string array containg all commands registered in extension's bootstrap.
When user writes down a command that is not registered in CLI, we check if there's such command and in case it is found, CLI will instruc the user how to install the respective extension.
Same will happen in case user tries to access the help content of a command that is registered in extension.