### PR TITLE
feat(Analytics): Respect playground key from package.json file

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -751,6 +751,37 @@ interface IAnalyticsSettingsService {
 	 * @returns {string} The user agent string.
 	 */
 	getUserAgentString(identifier: string): string;
+
+	/**
+	 * Gets information for projects that are exported from playground
+	 * @param projectDir Project directory path
+	 */
+ 	getPlaygroundInfo(projectDir?: string): Promise<IPlaygroundInfo>;
+}
+
+/** 
+ * Designed for getting information for projects that are exported from playground.
+ */
+interface IPlaygroundService {
+	/** 
+	 * Gets information for projects that are exported from playground
+	 * @return {Promise<IPlaygroundInfo>} collected info
+	 * @param projectDir Project directory path
+	 */
+	getPlaygroundInfo(projectDir?: string): Promise<IPlaygroundInfo>;
+}
+/**
+ * Describes information about project that is exported from playground.
+ */
+interface IPlaygroundInfo {
+	/** 
+	 * The unique client identifier
+	 */
+	id: string;
+	/**
+	 * Whether the user comes from tutorial page. Can be true or false
+	 */
+	usedTutorial: boolean;
 }
 
 interface IHostCapabilities {

--- a/services/analytics/google-analytics-custom-dimensions.d.ts
+++ b/services/analytics/google-analytics-custom-dimensions.d.ts
@@ -1,0 +1,10 @@
+declare const enum GoogleAnalyticsCustomDimensions {
+	cliVersion = "cd1",
+	projectType = "cd2",
+	clientID = "cd3",
+	sessionID = "cd4",
+	client = "cd5",
+	nodeVersion = "cd6",
+	playgroundId = "cd7",
+	usedTutorial = "cd8"
+}

--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -16,7 +16,8 @@ export class CommandsService implements ICommandsService {
 	private static HOOKS_COMMANDS_DELIMITER = "-";
 	private areDynamicSubcommandsRegistered = false;
 
-	constructor(private $commandsServiceProvider: ICommandsServiceProvider,
+	constructor(private $analyticsSettingsService: IAnalyticsSettingsService,
+		private $commandsServiceProvider: ICommandsServiceProvider,
 		private $errors: IErrors,
 		private $fs: IFileSystem,
 		private $hooksService: IHooksService,
@@ -48,6 +49,14 @@ export class CommandsService implements ICommandsService {
 					path: beautifiedCommandName,
 					title: beautifiedCommandName
 				};
+
+				const playgrounInfo = await this.$analyticsSettingsService.getPlaygroundInfo(null);
+				if (playgrounInfo && playgrounInfo.id) {
+					googleAnalyticsPageData.customDimensions = {
+						[GoogleAnalyticsCustomDimensions.playgroundId]: playgrounInfo.id,
+						[GoogleAnalyticsCustomDimensions.usedTutorial]: playgrounInfo.usedTutorial.toString()
+					};
+				}
 
 				await analyticsService.trackInGoogleAnalytics(googleAnalyticsPageData);
 			}


### PR DESCRIPTION
We need to track users that export their projects from playground and opens them in CLI or Sidekick. To support that we introduce playground key in nativescript key in package.json file. For example:
```
{
	"nativescript": {
		"playground": {
			"id": "some user quid",
			"usedTutorial": false // is not obligatory. In case it is present, can be true or false
		}
	}
}
```

In  case when package.json file contains playground key, {N} CLI reads playground data and saves it in userSettings file. If usedTutorial=true is already saved in userSettings file, {N} CLI does not overwrite it. After that {N} CLI deletes playground key from package.json file.

In case when package.json file does not contain playground key, {N} CLI checks if playground key is already saved in userSettings file. If this is the case, {N} CLI reads playground data from userSettings file.