### PR TITLE
refactor: change transferfiles return type

### DIFF
--- a/appbuilder/providers/appbuilder-livesync-provider-base.ts
+++ b/appbuilder/providers/appbuilder-livesync-provider-base.ts
@@ -16,15 +16,15 @@ export abstract class AppBuilderLiveSyncProviderBase implements ILiveSyncProvide
 	public abstract buildForDevice(device: Mobile.IDevice): Promise<string>;
 
 	public preparePlatformForSync(platform: string): Promise<void> {
-		return ;
+		return;
 	}
 
 	public canExecuteFastSync(filePath: string): boolean {
 		return false;
 	}
 
-	public transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, isFullSync: boolean): Promise<void> {
-		return deviceAppData.device.fileSystem.transferFiles(deviceAppData, localToDevicePaths);
+	public async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, isFullSync: boolean): Promise<void> {
+		await deviceAppData.device.fileSystem.transferFiles(deviceAppData, localToDevicePaths);
 	}
 
 }

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -297,7 +297,7 @@ declare module Mobile {
 		getFile(deviceFilePath: string, appIdentifier: string, outputFilePath?: string): Promise<void>;
 		putFile(localFilePath: string, deviceFilePath: string, appIdentifier: string): Promise<void>;
 		deleteFile?(deviceFilePath: string, appIdentifier: string): Promise<void>;
-		transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void>;
+		transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<Mobile.ILocalToDevicePathData[]>;
 		transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<Mobile.ILocalToDevicePathData[]>;
 		transferFile?(localFilePath: string, deviceFilePath: string): Promise<void>;
 		createFileOnDevice?(deviceFilePath: string, fileContent: string): Promise<void>;

--- a/mobile/ios/device/ios-device-file-system.ts
+++ b/mobile/ios/device/ios-device-file-system.ts
@@ -48,17 +48,17 @@ export class IOSDeviceFileSystem implements Mobile.IDeviceFileSystem {
 		});
 	}
 
-	public async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void> {
-		const files: IOSDeviceLib.IFileData[] = _(localToDevicePaths)
-			.filter(l => this.$fs.getFsStats(l.getLocalPath()).isFile())
-			.map(l => ({ source: l.getLocalPath(), destination: l.getDevicePath() }))
-			.value();
+	public async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<Mobile.ILocalToDevicePathData[]> {
+		const filesToUpload: Mobile.ILocalToDevicePathData[] = _.filter(localToDevicePaths, l => this.$fs.getFsStats(l.getLocalPath()).isFile());
+		const files: IOSDeviceLib.IFileData[] = filesToUpload.map(l => ({ source: l.getLocalPath(), destination: l.getDevicePath() }));
 
 		await this.uploadFilesCore([{
 			deviceId: this.device.deviceInfo.identifier,
 			appId: deviceAppData.appIdentifier,
 			files: files
 		}]);
+
+		return filesToUpload;
 	}
 
 	public async transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<Mobile.ILocalToDevicePathData[]> {

--- a/mobile/ios/simulator/ios-simulator-file-system.ts
+++ b/mobile/ios/simulator/ios-simulator-file-system.ts
@@ -24,10 +24,11 @@ export class IOSSimulatorFileSystem implements Mobile.IDeviceFileSystem {
 		shelljs.rm("-rf", deviceFilePath);
 	}
 
-	public async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void> {
+	public async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<Mobile.ILocalToDevicePathData[]> {
 		await Promise.all(
 			_.map(localToDevicePaths, localToDevicePathData => this.transferFile(localToDevicePathData.getLocalPath(), localToDevicePathData.getDevicePath())
 			));
+		return localToDevicePaths;
 	}
 
 	public async transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<Mobile.ILocalToDevicePathData[]> {


### PR DESCRIPTION
Return the actual files transferred to the device instead of `void`.

Ping @rosen-vladimirov 