### PR TITLE
refactor: Set logFilter's project name when starting iOS application 

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,19 +431,19 @@ devices.forEach(function(device) {
 });
 ```
 
-* `deployOnDevices(deviceIdentifiers: string[], packageFile: string, packageName: string, framework: string)` - Deploys the specified package to the specified devices.
+* `deployOnDevices(deviceIdentifiers: string[], packageFile: string, appId: string, projectName: string)` - Deploys the specified package to the specified devices.
 Returns array of Promises. Each of them will be rejected in case the file cannot be deployed on the device or in case there's no device with such identifier.
 The function accepts three arguments:
 	* `deviceIdentifiers` - array of the unique identifiers of the devices where the application will be deployed.
 	* `packageFile` - path to the specified package (`.apk` or `.ipa`);
-	* `packageName` - the identifier of the package. This corresponds to appId from `.abproject`.
-	* `framework` - the framework of the project. Valid values are `Cordova` and `NativeScript`.
+	* `appId` - the identifier of the package. This corresponds to id from `package.json`.
+	* `projectName` - the project name, this is usually the dir name of the project
 
 Sample usage:
 ```JavaScript
 Promise.all(require("mobile-cli-lib")
 				.devicesService
-				.deployOnDevices(["129604ab96a4d0053023b4bf5b288cf34a9ed5fa", "153544fa45f4a5646543b5bf1b221fe31a8fa6bc"], "./app.ipa", "com.telerik.testApp", "Cordova"))
+				.deployOnDevices(["129604ab96a4d0053023b4bf5b288cf34a9ed5fa", "153544fa45f4a5646543b5bf1b221fe31a8fa6bc"], "./app.ipa", "com.telerik.testApp", "Test App"))
 			.then(function(data) {
 				console.log(data);
 			}, function(err) {

--- a/appbuilder/device-log-provider.ts
+++ b/appbuilder/device-log-provider.ts
@@ -2,15 +2,16 @@ import { DeviceLogProviderBase } from "../mobile/device-log-provider-base";
 
 export class DeviceLogProvider extends DeviceLogProviderBase {
 	constructor(protected $logFilter: Mobile.ILogFilter,
-		$logger: ILogger) {
+		$logger: ILogger,
+		private $loggingLevels: Mobile.ILoggingLevels) {
 		super($logFilter, $logger);
 	}
 
 	public logData(line: string, platform: string, deviceIdentifier: string): void {
-		const logLevel = this.setDefaultLogLevelForDevice(deviceIdentifier);
+		this.setDefaultLogLevelForDevice(deviceIdentifier);
 
-		const applicationPid = this.getApplicationPidForDevice(deviceIdentifier),
-			data = this.$logFilter.filterData(platform, line, applicationPid, logLevel);
+		const loggingOptions = this.getDeviceLogOptionsForDevice(deviceIdentifier) || { logLevel: this.$loggingLevels.info };
+		const data = this.$logFilter.filterData(platform, line, loggingOptions);
 
 		if (data) {
 			this.emit('data', deviceIdentifier, data);

--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -51,7 +51,7 @@ export class IOSLiveSyncService implements IDeviceLiveSyncService {
 			this.$logger.trace(`Transferring from ${sourcePath} to ${destinationPath}`);
 			shell.cp("-Rf", path.join(sourcePath, "*"), destinationPath);
 
-			await this.device.applicationManager.restartApplication(deviceAppData.appIdentifier);
+			await this.device.applicationManager.restartApplication(deviceAppData.appIdentifier, "");
 		} else {
 			await this.device.fileSystem.deleteFile("/Documents/AppBuilder/ServerInfo.plist", deviceAppData.appIdentifier);
 			const notification = this.$project.projectData.Framework === constants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript ? "com.telerik.app.refreshApp" : "com.telerik.app.refreshWebView";

--- a/appbuilder/services/livesync/ios-livesync-service.ts
+++ b/appbuilder/services/livesync/ios-livesync-service.ts
@@ -51,7 +51,7 @@ export class IOSLiveSyncService implements IDeviceLiveSyncService {
 			this.$logger.trace(`Transferring from ${sourcePath} to ${destinationPath}`);
 			shell.cp("-Rf", path.join(sourcePath, "*"), destinationPath);
 
-			await this.device.applicationManager.restartApplication(deviceAppData.appIdentifier, "");
+			await this.device.applicationManager.restartApplication({ appId: deviceAppData.appIdentifier, projectName: "" });
 		} else {
 			await this.device.fileSystem.deleteFile("/Documents/AppBuilder/ServerInfo.plist", deviceAppData.appIdentifier);
 			const notification = this.$project.projectData.Framework === constants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript ? "com.telerik.app.refreshApp" : "com.telerik.app.refreshWebView";

--- a/commands/device/run-application.ts
+++ b/commands/device/run-application.ts
@@ -6,7 +6,7 @@ export class RunApplicationOnDeviceCommand implements ICommand {
 		private $staticConfig: Config.IStaticConfig,
 		private $options: ICommonOptions) { }
 
-	public allowedParameters: ICommandParameter[] = [this.$stringParameter];
+	public allowedParameters: ICommandParameter[] = [this.$stringParameter, this.$stringParameter];
 
 	public async execute(args: string[]): Promise<void> {
 		await this.$devicesService.initialize({ deviceId: this.$options.device, skipInferPlatform: true });
@@ -15,7 +15,7 @@ export class RunApplicationOnDeviceCommand implements ICommand {
 			this.$errors.failWithoutHelp("More than one device found. Specify device explicitly with --device option. To discover device ID, use $%s device command.", this.$staticConfig.CLIENT_NAME.toLowerCase());
 		}
 
-		await this.$devicesService.execute(async (device: Mobile.IDevice) => await device.applicationManager.startApplication(args[0], args[1]));
+		await this.$devicesService.execute(async (device: Mobile.IDevice) => await device.applicationManager.startApplication({ appId: args[0], projectName: args[1] }));
 	}
 }
 

--- a/commands/device/run-application.ts
+++ b/commands/device/run-application.ts
@@ -15,7 +15,7 @@ export class RunApplicationOnDeviceCommand implements ICommand {
 			this.$errors.failWithoutHelp("More than one device found. Specify device explicitly with --device option. To discover device ID, use $%s device command.", this.$staticConfig.CLIENT_NAME.toLowerCase());
 		}
 
-		await this.$devicesService.execute(async (device: Mobile.IDevice) => await device.applicationManager.startApplication(args[0]));
+		await this.$devicesService.execute(async (device: Mobile.IDevice) => await device.applicationManager.startApplication(args[0], args[1]));
 	}
 }
 

--- a/commands/device/stop-application.ts
+++ b/commands/device/stop-application.ts
@@ -4,12 +4,12 @@ export class StopApplicationOnDeviceCommand implements ICommand {
 		private $stringParameter: ICommandParameter,
 		private $options: ICommonOptions) { }
 
-	allowedParameters: ICommandParameter[] = [this.$stringParameter, this.$stringParameter];
+	allowedParameters: ICommandParameter[] = [this.$stringParameter, this.$stringParameter, this.$stringParameter];
 
 	public async execute(args: string[]): Promise<void> {
 		await this.$devicesService.initialize({ deviceId: this.$options.device, skipInferPlatform: true, platform: args[1] });
 
-		const action = (device: Mobile.IDevice) => device.applicationManager.stopApplication({ appId: args[0], projectName: args[1] });
+		const action = (device: Mobile.IDevice) => device.applicationManager.stopApplication({ appId: args[0], projectName: args[2] });
 		await this.$devicesService.execute(action);
 	}
 }

--- a/commands/device/stop-application.ts
+++ b/commands/device/stop-application.ts
@@ -9,7 +9,7 @@ export class StopApplicationOnDeviceCommand implements ICommand {
 	public async execute(args: string[]): Promise<void> {
 		await this.$devicesService.initialize({ deviceId: this.$options.device, skipInferPlatform: true, platform: args[1] });
 
-		const action = (device: Mobile.IDevice) => device.applicationManager.stopApplication(args[0]);
+		const action = (device: Mobile.IDevice) => device.applicationManager.stopApplication({ appId: args[0], projectName: args[1] });
 		await this.$devicesService.execute(action);
 	}
 }

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -173,6 +173,13 @@ declare module Mobile {
 		 * @param {string} pid The Process ID of the currently running application for which we need the logs.
 		 */
 		setApplicationPidForDevice(deviceIdentifier: string, pid: string): void;
+		
+		/**
+		 * Sets the project name of the application on the specified device.
+		 * @param {string} deviceIdentifier The unique identifier of the device.
+		 * @param {string} projectName The project name of the currently running application for which we need the logs.
+		 */
+		setProjectNameForDevice(deviceIdentifier: string, projectName: string): void;
 	}
 
 	/**
@@ -182,12 +189,17 @@ declare module Mobile {
 		/**
 		 * Process id of the application on the device.
 		 */
-		applicationPid: string;
+		applicationPid?: string;
 
 		/**
 		 * Selected log level for the current device. It can be INFO or FULL.
 		 */
 		logLevel: string;
+
+		/**
+		 * The project name.
+		 */
+		projectName?: string;
 	}
 
 	/**
@@ -215,11 +227,10 @@ declare module Mobile {
 		 * Filters data for specified platform.
 		 * @param {string} platform The platform for which is the device log.
 		 * @param {string} data The input data for filtering.
-		 * @param {string} pid @optional The application PID for this device.
-		 * @param {string} logLevel @optional The logging level based on which input data will be filtered.
+		 * @param {Mobile.IDeviceLogOptions} deviceLogOptions The logging options based on which the filtering for this device logs will be executed.
 		 * @return {string} The filtered result based on the input or null when the input data shouldn't be shown.
 		 */
-		filterData(platform: string, data: string, pid?: string, logLevel?: string): string;
+		filterData(platform: string, data: string, deviceLogOptions: Mobile.IDeviceLogOptions): string;
 	}
 
 	/**
@@ -233,7 +244,7 @@ declare module Mobile {
 		 * @param {string} pid The Process ID of the currently running application for which we need the logs.
 		 * @return {string} The filtered result based on the input or null when the input data shouldn't be shown.
 		 */
-		filterData(data: string, logLevel: string, pid: string): string;
+		filterData(data: string, deviceLogOptions: Mobile.IDeviceLogOptions): string;
 	}
 
 	interface ILoggingLevels {
@@ -247,14 +258,14 @@ declare module Mobile {
 		installApplication(packageFilePath: string, appIdentifier?: string): Promise<void>;
 		uninstallApplication(appIdentifier: string): Promise<void>;
 		reinstallApplication(appIdentifier: string, packageFilePath: string): Promise<void>;
-		startApplication(appIdentifier: string): Promise<void>;
+		startApplication(appIdentifier: string, appName: string): Promise<void>;
 		stopApplication(appIdentifier: string, appName?: string): Promise<void>;
-		restartApplication(appIdentifier: string, appName?: string): Promise<void>;
+		restartApplication(appIdentifier: string, appName: string): Promise<void>;
 		canStartApplication(): boolean;
 		checkForApplicationUpdates(): Promise<void>;
 		isLiveSyncSupported(appIdentifier: string): Promise<boolean>;
 		getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo>;
-		tryStartApplication(appIdentifier: string): Promise<void>;
+		tryStartApplication(appIdentifier: string, appName: string): Promise<void>;
 		getDebuggableApps(): Promise<Mobile.IDeviceApplicationInformation[]>;
 		getDebuggableAppViews(appIdentifiers: string[]): Promise<IDictionary<Mobile.IDebugWebViewInfo[]>>;
 	}

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -173,7 +173,7 @@ declare module Mobile {
 		 * @param {string} pid The Process ID of the currently running application for which we need the logs.
 		 */
 		setApplicationPidForDevice(deviceIdentifier: string, pid: string): void;
-		
+
 		/**
 		 * Sets the project name of the application on the specified device.
 		 * @param {string} deviceIdentifier The unique identifier of the device.
@@ -252,20 +252,24 @@ declare module Mobile {
 		full: string;
 	}
 
+	interface IApplicationData {
+		appId: string;
+		projectName: string;
+	}
 	interface IDeviceApplicationManager extends NodeJS.EventEmitter {
 		getInstalledApplications(): Promise<string[]>;
 		isApplicationInstalled(appIdentifier: string): Promise<boolean>;
 		installApplication(packageFilePath: string, appIdentifier?: string): Promise<void>;
 		uninstallApplication(appIdentifier: string): Promise<void>;
 		reinstallApplication(appIdentifier: string, packageFilePath: string): Promise<void>;
-		startApplication(appIdentifier: string, appName: string): Promise<void>;
-		stopApplication(appIdentifier: string, appName?: string): Promise<void>;
-		restartApplication(appIdentifier: string, appName: string): Promise<void>;
+		startApplication(appData: IApplicationData): Promise<void>;
+		stopApplication(appData: IApplicationData): Promise<void>;
+		restartApplication(appData: IApplicationData): Promise<void>;
 		canStartApplication(): boolean;
 		checkForApplicationUpdates(): Promise<void>;
 		isLiveSyncSupported(appIdentifier: string): Promise<boolean>;
 		getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo>;
-		tryStartApplication(appIdentifier: string, appName: string): Promise<void>;
+		tryStartApplication(appData: IApplicationData): Promise<void>;
 		getDebuggableApps(): Promise<Mobile.IDeviceApplicationInformation[]>;
 		getDebuggableAppViews(appIdentifiers: string[]): Promise<IDictionary<Mobile.IDebugWebViewInfo[]>>;
 	}

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -256,6 +256,11 @@ declare module Mobile {
 		appId: string;
 		projectName: string;
 	}
+
+	interface IInstallAppData extends IApplicationData {
+		packagePath: string;
+	}
+
 	interface IDeviceApplicationManager extends NodeJS.EventEmitter {
 		getInstalledApplications(): Promise<string[]>;
 		isApplicationInstalled(appIdentifier: string): Promise<boolean>;

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -44,8 +44,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		return this.adb.executeShellCommand(["pm", "uninstall", `${appIdentifier}`], { treatErrorsAsWarnings: true });
 	}
 
-	public async startApplication(appIdentifier: string): Promise<void> {
-
+	public async startApplication(appData: Mobile.IApplicationData): Promise<void> {
 		/*
 		Example "pm dump <app_identifier> | grep -A 1 MAIN" output"
 			android.intent.action.MAIN:
@@ -59,6 +58,7 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 			Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=org.nativescript.cliapp/com.tns.NativeScriptActivity }
 			frontOfTask=true task=TaskRecord{fe592ac #449 A=org.nativescript.cliapp U=0 StackId=1 sz=1}
 		*/
+		const appIdentifier = appData.appId;
 		const pmDumpOutput = await this.adb.executeShellCommand(["pm", "dump", appIdentifier, "|", "grep", "-A", "1", "MAIN"]);
 		const activityMatch = this.getFullyQualifiedActivityRegex();
 		const match = activityMatch.exec(pmDumpOutput);
@@ -82,9 +82,9 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		}
 	}
 
-	public stopApplication(appIdentifier: string): Promise<void> {
+	public stopApplication(appData: Mobile.IApplicationData): Promise<void> {
 		this.$logcatHelper.stop(this.identifier);
-		return this.adb.executeShellCommand(["am", "force-stop", `${appIdentifier}`]);
+		return this.adb.executeShellCommand(["am", "force-stop", `${appData.appId}`]);
 	}
 
 	public getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo> {

--- a/mobile/android/android-log-filter.ts
+++ b/mobile/android/android-log-filter.ts
@@ -12,11 +12,9 @@ export class AndroidLogFilter implements Mobile.IPlatformLogFilter {
 	constructor(private $loggingLevels: Mobile.ILoggingLevels) { }
 
 	public filterData(data: string, loggingOptions: Mobile.IDeviceLogOptions = <any>{}): string {
-		const pid = loggingOptions.applicationPid;
-
 		const specifiedLogLevel = (loggingOptions.logLevel || '').toUpperCase();
 		if (specifiedLogLevel === this.$loggingLevels.info) {
-			const log = this.getConsoleLogFromLine(data, pid);
+			const log = this.getConsoleLogFromLine(data, loggingOptions.applicationPid);
 			if (log) {
 				if (log.tag) {
 					return `${log.tag}: ${log.message}` + os.EOL;

--- a/mobile/android/android-log-filter.ts
+++ b/mobile/android/android-log-filter.ts
@@ -11,8 +11,10 @@ export class AndroidLogFilter implements Mobile.IPlatformLogFilter {
 
 	constructor(private $loggingLevels: Mobile.ILoggingLevels) { }
 
-	public filterData(data: string, logLevel: string, pid: string): string {
-		const specifiedLogLevel = (logLevel || '').toUpperCase();
+	public filterData(data: string, loggingOptions: Mobile.IDeviceLogOptions = <any>{}): string {
+		const pid = loggingOptions.applicationPid;
+
+		const specifiedLogLevel = (loggingOptions.logLevel || '').toUpperCase();
 		if (specifiedLogLevel === this.$loggingLevels.info) {
 			const log = this.getConsoleLogFromLine(data, pid);
 			if (log) {

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -21,9 +21,9 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 		await this.installApplication(packageFilePath, appIdentifier);
 	}
 
-	public async restartApplication(appIdentifier: string, appName?: string): Promise<void> {
+	public async restartApplication(appIdentifier: string, appName: string): Promise<void> {
 		await this.stopApplication(appIdentifier, appName);
-		await this.startApplication(appIdentifier);
+		await this.startApplication(appIdentifier, appName);
 	}
 
 	public async isApplicationInstalled(appIdentifier: string): Promise<boolean> {
@@ -68,10 +68,10 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 		return this.checkForApplicationUpdatesPromise;
 	}
 
-	public async tryStartApplication(appIdentifier: string): Promise<void> {
+	public async tryStartApplication(appIdentifier: string, appName: string): Promise<void> {
 		try {
 			if (this.canStartApplication()) {
-				await this.startApplication(appIdentifier);
+				await this.startApplication(appIdentifier, appName);
 			}
 		} catch (err) {
 			this.$logger.trace(`Unable to start application ${appIdentifier}. Error is: ${err.message}`);
@@ -82,7 +82,7 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 
 	public abstract async installApplication(packageFilePath: string, appIdentifier?: string): Promise<void>;
 	public abstract async uninstallApplication(appIdentifier: string): Promise<void>;
-	public abstract async startApplication(appIdentifier: string): Promise<void>;
+	public abstract async startApplication(appIdentifier: string, appName: string): Promise<void>;
 	public abstract async stopApplication(appIdentifier: string, appName?: string): Promise<void>;
 	public abstract async getInstalledApplications(): Promise<string[]>;
 	public abstract async getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo>;

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -21,9 +21,9 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 		await this.installApplication(packageFilePath, appIdentifier);
 	}
 
-	public async restartApplication(appIdentifier: string, appName: string): Promise<void> {
-		await this.stopApplication(appIdentifier, appName);
-		await this.startApplication(appIdentifier, appName);
+	public async restartApplication(appData: Mobile.IApplicationData): Promise<void> {
+		await this.stopApplication(appData);
+		await this.startApplication(appData);
 	}
 
 	public async isApplicationInstalled(appIdentifier: string): Promise<boolean> {
@@ -68,13 +68,13 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 		return this.checkForApplicationUpdatesPromise;
 	}
 
-	public async tryStartApplication(appIdentifier: string, appName: string): Promise<void> {
+	public async tryStartApplication(appData: Mobile.IApplicationData): Promise<void> {
 		try {
 			if (this.canStartApplication()) {
-				await this.startApplication(appIdentifier, appName);
+				await this.startApplication(appData);
 			}
 		} catch (err) {
-			this.$logger.trace(`Unable to start application ${appIdentifier}. Error is: ${err.message}`);
+			this.$logger.trace(`Unable to start application ${appData.appId}. Error is: ${err.message}`);
 		}
 	}
 
@@ -82,8 +82,8 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 
 	public abstract async installApplication(packageFilePath: string, appIdentifier?: string): Promise<void>;
 	public abstract async uninstallApplication(appIdentifier: string): Promise<void>;
-	public abstract async startApplication(appIdentifier: string, appName: string): Promise<void>;
-	public abstract async stopApplication(appIdentifier: string, appName?: string): Promise<void>;
+	public abstract async startApplication(appData: Mobile.IApplicationData): Promise<void>;
+	public abstract async stopApplication(appData: Mobile.IApplicationData): Promise<void>;
 	public abstract async getInstalledApplications(): Promise<string[]>;
 	public abstract async getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo>;
 	public abstract canStartApplication(): boolean;

--- a/mobile/device-log-provider-base.ts
+++ b/mobile/device-log-provider-base.ts
@@ -17,6 +17,10 @@ export abstract class DeviceLogProviderBase extends EventEmitter implements Mobi
 		this.setDeviceLogOptionsProperty(deviceIdentifier, (deviceLogOptions: Mobile.IDeviceLogOptions) => deviceLogOptions.applicationPid, pid);
 	}
 
+	public setProjectNameForDevice(deviceIdentifier: string, projectName: string): void {
+		this.setDeviceLogOptionsProperty(deviceIdentifier, (deviceLogOptions: Mobile.IDeviceLogOptions) => deviceLogOptions.projectName, projectName);
+	}
+
 	protected setDefaultLogLevelForDevice(deviceIdentifier: string): string {
 		const logLevel = (this.devicesLogOptions[deviceIdentifier] && this.devicesLogOptions[deviceIdentifier].logLevel) || this.$logFilter.loggingLevel;
 		this.setLogLevel(logLevel, deviceIdentifier);
@@ -26,6 +30,15 @@ export abstract class DeviceLogProviderBase extends EventEmitter implements Mobi
 
 	protected getApplicationPidForDevice(deviceIdentifier: string): string {
 		return this.devicesLogOptions[deviceIdentifier] && this.devicesLogOptions[deviceIdentifier].applicationPid;
+	}
+
+	protected getDeviceLogOptionsForDevice(deviceIdentifier: string): Mobile.IDeviceLogOptions {
+		const loggingOptions = this.devicesLogOptions[deviceIdentifier];
+		if (!loggingOptions) {
+			this.setDefaultLogLevelForDevice(deviceIdentifier);
+		}
+
+		return this.devicesLogOptions[deviceIdentifier];
 	}
 
 	protected setDeviceLogOptionsProperty(deviceIdentifier: string, propNameFunction: Function, propertyValue: string): void {

--- a/mobile/device-log-provider.ts
+++ b/mobile/device-log-provider.ts
@@ -7,8 +7,8 @@ export class DeviceLogProvider extends DeviceLogProviderBase {
 	}
 
 	public logData(lineText: string, platform: string, deviceIdentifier: string): void {
-		const applicationPid = this.getApplicationPidForDevice(deviceIdentifier);
-		const data = this.$logFilter.filterData(platform, lineText, applicationPid);
+		const loggingOptions = this.getDeviceLogOptionsForDevice(deviceIdentifier);
+		const data = this.$logFilter.filterData(platform, lineText, loggingOptions);
 		if (data) {
 			this.$logger.write(data);
 		}

--- a/mobile/ios/device/ios-application-manager.ts
+++ b/mobile/ios/device/ios-application-manager.ts
@@ -14,7 +14,8 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 		private $hostInfo: IHostInfo,
 		private $staticConfig: Config.IStaticConfig,
 		private $iosDeviceOperations: IIOSDeviceOperations,
-		private $options: ICommonOptions) {
+		private $options: ICommonOptions,
+		private $deviceLogProvider: Mobile.IDeviceLogProvider) {
 		super($logger, $hooksService);
 	}
 
@@ -75,11 +76,12 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 		this.$logger.trace("Application %s has been uninstalled successfully.", appIdentifier);
 	}
 
-	public async startApplication(appIdentifier: string): Promise<void> {
+	public async startApplication(appIdentifier: string, projectName: string): Promise<void> {
 		if (!await this.isApplicationInstalled(appIdentifier)) {
 			this.$errors.failWithoutHelp("Invalid application id: %s. All available application ids are: %s%s ", appIdentifier, EOL, this.applicationsLiveSyncInfos.join(EOL));
 		}
 
+		this.$deviceLogProvider.setProjectNameForDevice(this.device.deviceInfo.identifier, projectName);
 		await this.runApplicationCore(appIdentifier);
 
 		this.$logger.info(`Successfully run application ${appIdentifier} on device with ID ${this.device.deviceInfo.identifier}.`);

--- a/mobile/ios/ios-log-filter.ts
+++ b/mobile/ios/ios-log-filter.ts
@@ -3,8 +3,9 @@ export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 
 	constructor(private $loggingLevels: Mobile.ILoggingLevels) { }
 
-	public filterData(data: string, logLevel: string, pid?: string): string {
-		const specifiedLogLevel = (logLevel || '').toUpperCase();
+	public filterData(data: string, loggingOptions: Mobile.IDeviceLogOptions = <any>{}): string {
+		const specifiedLogLevel = (loggingOptions.logLevel || '').toUpperCase();
+		const pid = loggingOptions && loggingOptions.applicationPid;
 
 		if (specifiedLogLevel === this.$loggingLevels.info && data) {
 			if (pid) {

--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -39,10 +39,11 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		return this.iosSim.uninstallApplication(this.identifier, appIdentifier);
 	}
 
-	public async startApplication(appIdentifier: string): Promise<void> {
+	public async startApplication(appIdentifier: string, projectName: string): Promise<void> {
 		const launchResult = this.iosSim.startApplication(this.identifier, appIdentifier);
 		const pid = launchResult.split(":")[1].trim();
 		this.$deviceLogProvider.setApplicationPidForDevice(this.identifier, pid);
+		this.$deviceLogProvider.setProjectNameForDevice(this.identifier, projectName);
 
 		if (!this.$options.justlaunch) {
 			this.$iOSSimulatorLogProvider.startLogProcess(this.identifier);

--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -39,19 +39,19 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		return this.iosSim.uninstallApplication(this.identifier, appIdentifier);
 	}
 
-	public async startApplication(appIdentifier: string, projectName: string): Promise<void> {
-		const launchResult = this.iosSim.startApplication(this.identifier, appIdentifier);
+	public async startApplication(appData: Mobile.IApplicationData): Promise<void> {
+		const launchResult = this.iosSim.startApplication(this.identifier, appData.appId);
 		const pid = launchResult.split(":")[1].trim();
 		this.$deviceLogProvider.setApplicationPidForDevice(this.identifier, pid);
-		this.$deviceLogProvider.setProjectNameForDevice(this.identifier, projectName);
+		this.$deviceLogProvider.setProjectNameForDevice(this.identifier, appData.projectName);
 
 		if (!this.$options.justlaunch) {
 			this.$iOSSimulatorLogProvider.startLogProcess(this.identifier);
 		}
 	}
 
-	public async stopApplication(appIdentifier: string, appName: string): Promise<void> {
-		return this.iosSim.stopApplication(this.identifier, appIdentifier, appName);
+	public async stopApplication(appData: Mobile.IApplicationData): Promise<void> {
+		return this.iosSim.stopApplication(this.identifier, appData.appId, appData.projectName);
 	}
 
 	public canStartApplication(): boolean {

--- a/mobile/log-filter.ts
+++ b/mobile/log-filter.ts
@@ -15,10 +15,12 @@ export class LogFilter implements Mobile.ILogFilter {
 		}
 	}
 
-	public filterData(platform: string, data: string, pid?: string, logLevel?: string): string {
+	public filterData(platform: string, data: string, loggingOptions: Mobile.IDeviceLogOptions = <any>{}): string {
+		loggingOptions = loggingOptions || <any>{};
 		const deviceLogFilter = this.getDeviceLogFilterInstance(platform);
+		loggingOptions.logLevel = loggingOptions.logLevel || this.loggingLevel;
 		if (deviceLogFilter) {
-			return deviceLogFilter.filterData(data, logLevel || this.loggingLevel, pid);
+			return deviceLogFilter.filterData(data, loggingOptions);
 		}
 
 		// In case the platform is not valid, just return the data without filtering.

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -79,10 +79,11 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	}
 	/* tslint:enable:no-unused-variable */
 
+	// Breaking change
 	@exported("devicesService")
-	public isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string): Promise<IAppInstalledInfo>[] {
+	public isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string, appName: string): Promise<IAppInstalledInfo>[] {
 		this.$logger.trace(`Called isInstalledOnDevices for identifiers ${deviceIdentifiers}. AppIdentifier is ${appIdentifier}.`);
-		return _.map(deviceIdentifiers, deviceIdentifier => this.isApplicationInstalledOnDevice(deviceIdentifier, appIdentifier));
+		return _.map(deviceIdentifiers, deviceIdentifier => this.isApplicationInstalledOnDevice(deviceIdentifier, appIdentifier, appName));
 	}
 
 	@exported("devicesService")
@@ -578,7 +579,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 		const device = this.getDeviceByIdentifier(deviceIdentifier);
 		await device.applicationManager.reinstallApplication(packageName, packageFile);
 		this.$logger.info(`Successfully deployed on device with identifier '${device.deviceInfo.identifier}'.`);
-		await device.applicationManager.tryStartApplication(packageName);
+		await device.applicationManager.tryStartApplication(packageName, packageName);
 	}
 
 	/**
@@ -651,14 +652,14 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 		return this.executeOnAllConnectedDevices(action, canExecute);
 	}
 
-	private async isApplicationInstalledOnDevice(deviceIdentifier: string, appIdentifier: string): Promise<IAppInstalledInfo> {
+	private async isApplicationInstalledOnDevice(deviceIdentifier: string, appIdentifier: string, packageName: string): Promise<IAppInstalledInfo> {
 		let isInstalled = false;
 		let isLiveSyncSupported = false;
 		const device = this.getDeviceByIdentifier(deviceIdentifier);
 
 		try {
 			isInstalled = await device.applicationManager.isApplicationInstalled(appIdentifier);
-			await device.applicationManager.tryStartApplication(appIdentifier);
+			await device.applicationManager.tryStartApplication(appIdentifier, packageName);
 			isLiveSyncSupported = await isInstalled && !!device.applicationManager.isLiveSyncSupported(appIdentifier);
 		} catch (err) {
 			this.$logger.trace("Error while checking is application installed. Error is: ", err);

--- a/services/livesync-service-base.ts
+++ b/services/livesync-service-base.ts
@@ -184,7 +184,7 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 					}
 
 					if (device.applicationManager.canStartApplication() && !shouldRefreshApplication) {
-						await device.applicationManager.startApplication(appIdentifier, "");
+						await device.applicationManager.startApplication({ appId: appIdentifier, projectName: "" });
 					}
 					wasInstalled = false;
 				}

--- a/services/livesync-service-base.ts
+++ b/services/livesync-service-base.ts
@@ -184,7 +184,7 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 					}
 
 					if (device.applicationManager.canStartApplication() && !shouldRefreshApplication) {
-						await device.applicationManager.startApplication(appIdentifier);
+						await device.applicationManager.startApplication(appIdentifier, "");
 					}
 					wasInstalled = false;
 				}

--- a/test/unit-tests/android-application-manager.ts
+++ b/test/unit-tests/android-application-manager.ts
@@ -114,13 +114,13 @@ describe("android-application-manager", () => {
 			for (let i = 0; i < androidDebugBridge.getInputLength(); i++) {
 				androidDebugBridge.validIdentifierPassed = false;
 
-				await androidApplicationManager.startApplication("valid.identifier");
+				await androidApplicationManager.startApplication({ appId: "valid.identifier", projectName: "" });
 				assert.isTrue(androidDebugBridge.validIdentifierPassed);
 				assert.isTrue(androidDebugBridge.startedWithActivityManager);
 			}
 		});
 		it("if regex fails monkey is called to start application", async () => {
-			await androidApplicationManager.startApplication(invalidIdentifier);
+			await androidApplicationManager.startApplication({ appId: invalidIdentifier, projectName: "" });
 			assert.isFalse(androidDebugBridge.startedWithActivityManager);
 		});
 	});

--- a/test/unit-tests/android-log-filter.ts
+++ b/test/unit-tests/android-log-filter.ts
@@ -210,8 +210,8 @@ describe("androidLogFilter", () => {
 	const assertFiltering = (inputData: string, expectedOutput: string, logLevel?: string, pid?: string) => {
 		const testInjector = new Yok();
 		testInjector.register("loggingLevels", LoggingLevels);
-		const androidLogFilter = testInjector.resolve(AndroidLogFilter);
-		const filteredData = androidLogFilter.filterData(inputData, logLevel, pid);
+		const androidLogFilter = <Mobile.IPlatformLogFilter>testInjector.resolve(AndroidLogFilter);
+		const filteredData = androidLogFilter.filterData(inputData, { logLevel, applicationPid: pid });
 		assert.deepEqual(filteredData, expectedOutput, `The actual result '${filteredData}' did NOT match expected output '${expectedOutput}'.`);
 	};
 

--- a/test/unit-tests/appbuilder/device-log-provider.ts
+++ b/test/unit-tests/appbuilder/device-log-provider.ts
@@ -2,18 +2,19 @@ import { Yok } from "../../../yok";
 import * as assert from "assert";
 import { DeviceLogProvider } from "../../../appbuilder/device-log-provider";
 import { CommonLoggerStub } from "../stubs";
+import { LoggingLevels } from "../../../mobile/logging-levels";
 
 function createTestInjector(loggingLevel: string, emptyFilteredData?: boolean) {
 	const testInjector = new Yok();
 	testInjector.register("logFilter", {
 		loggingLevel: loggingLevel,
-		filterData: (platform: string, data: string, pid?: string, logLevel?: string) => {
-			return emptyFilteredData ? null : `${logLevel} ${data}`;
+		filterData: (platform: string, data: string, loggingOptions: Mobile.IDeviceLogOptions) => {
+			return emptyFilteredData ? null : `${loggingOptions.logLevel} ${data}`;
 		}
 	});
 
 	testInjector.register("logger", CommonLoggerStub);
-
+	testInjector.register("loggingLevels", LoggingLevels);
 	return testInjector;
 }
 

--- a/test/unit-tests/ios-log-filter.ts
+++ b/test/unit-tests/ios-log-filter.ts
@@ -112,8 +112,8 @@ describe("iOSLogFilter", () => {
 	const assertFiltering = (inputData: string, expectedOutput: string, logLevel?: string, pid?: string) => {
 		const testInjector = new Yok();
 		testInjector.register("loggingLevels", LoggingLevels);
-		const iOSLogFilter = testInjector.resolve(IOSLogFilter);
-		const filteredData = iOSLogFilter.filterData(inputData, logLevel, pid);
+		const iOSLogFilter = <Mobile.IPlatformLogFilter>testInjector.resolve(IOSLogFilter);
+		const filteredData = iOSLogFilter.filterData(inputData, { logLevel, applicationPid: pid });
 		assert.deepEqual(filteredData, expectedOutput, `The actual result '${filteredData}' did NOT match expected output '${expectedOutput}'.`);
 	};
 

--- a/test/unit-tests/log-filter.ts
+++ b/test/unit-tests/log-filter.ts
@@ -11,14 +11,14 @@ function createTestInjector(): IInjector {
 	testInjector.register("loggingLevels", LoggingLevels);
 	testInjector.register("logFilter", LogFilter);
 	testInjector.register("iOSLogFilter", {
-		filterData: (data: string, logLevel: string, pid?: string) => {
-			return `ios: ${data} ${logLevel}`;
+		filterData: (data: string, deviceLogOptions: Mobile.IDeviceLogOptions) => {
+			return `ios: ${data} ${deviceLogOptions.logLevel}`;
 		}
 	});
 
 	testInjector.register("androidLogFilter", {
-		filterData: (data: string, logLevel: string, pid?: string) => {
-			return `android: ${data} ${logLevel}`;
+		filterData: (data: string, deviceLogOptions: Mobile.IDeviceLogOptions) => {
+			return `android: ${data} ${deviceLogOptions.logLevel}`;
 		}
 	});
 
@@ -67,22 +67,22 @@ describe("logFilter", () => {
 	describe("filterData", () => {
 		describe("when logLevel is not specified and default log level is not changed", () => {
 			it("returns same data when platform is not correct", () => {
-				const actualData = logFilter.filterData("invalidPlatform", testData, "");
+				const actualData = logFilter.filterData("invalidPlatform", testData, { logLevel });
 				assert.deepEqual(actualData, testData);
 			});
 
 			it("returns same data when platform is not passed", () => {
-				const actualData = logFilter.filterData(null, testData, "");
+				const actualData = logFilter.filterData(null, testData, { logLevel });
 				assert.deepEqual(actualData, testData);
 			});
 
 			it("returns correct data when platform is android", () => {
-				const actualData = logFilter.filterData("android", testData, "");
+				const actualData = logFilter.filterData("android", testData, { logLevel });
 				assert.deepEqual(actualData, androidInfoTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				const actualData = logFilter.filterData("ios", testData, "");
+				const actualData = logFilter.filterData("ios", testData, { logLevel });
 				assert.deepEqual(actualData, iosInfoTestData);
 			});
 		});
@@ -91,17 +91,17 @@ describe("logFilter", () => {
 			beforeEach(() => logFilter.loggingLevel = fullLogLevel);
 
 			it("returns same data when platform is not correct", () => {
-				const actualData = logFilter.filterData("invalidPlatform", testData, "");
+				const actualData = logFilter.filterData("invalidPlatform", testData, null);
 				assert.deepEqual(actualData, testData);
 			});
 
 			it("returns correct data when platform is android", () => {
-				const actualData = logFilter.filterData("android", testData, "");
+				const actualData = logFilter.filterData("android", testData, null);
 				assert.deepEqual(actualData, androidFullTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				const actualData = logFilter.filterData("ios", testData, "");
+				const actualData = logFilter.filterData("ios", testData, null);
 				assert.deepEqual(actualData, iosFullTestData);
 			});
 		});
@@ -110,17 +110,17 @@ describe("logFilter", () => {
 			beforeEach(() => logLevel = infoLogLevel);
 
 			it("returns same data when platform is not correct", () => {
-				const actualData = logFilter.filterData("invalidPlatform", testData, null, logLevel);
+				const actualData = logFilter.filterData("invalidPlatform", testData, { logLevel });
 				assert.deepEqual(actualData, testData, logLevel);
 			});
 
 			it("returns correct data when platform is android", () => {
-				const actualData = logFilter.filterData("android", testData, null, logLevel);
+				const actualData = logFilter.filterData("android", testData, { logLevel });
 				assert.deepEqual(actualData, androidInfoTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				const actualData = logFilter.filterData("ios", testData, null, logLevel);
+				const actualData = logFilter.filterData("ios", testData, { logLevel });
 				assert.deepEqual(actualData, iosInfoTestData);
 			});
 		});
@@ -129,17 +129,17 @@ describe("logFilter", () => {
 			beforeEach(() => logLevel = fullLogLevel);
 
 			it("returns same data when platform is not correct", () => {
-				const actualData = logFilter.filterData("invalidPlatform", testData, null, logLevel);
+				const actualData = logFilter.filterData("invalidPlatform", testData, { logLevel });
 				assert.deepEqual(actualData, testData, logLevel);
 			});
 
 			it("returns correct data when platform is android", () => {
-				const actualData = logFilter.filterData("android", testData,  null, logLevel);
+				const actualData = logFilter.filterData("android", testData, { logLevel });
 				assert.deepEqual(actualData, androidFullTestData);
 			});
 
 			it("returns correct data when platform is ios", () => {
-				const actualData = logFilter.filterData("ios", testData, null, logLevel);
+				const actualData = logFilter.filterData("ios", testData, { logLevel });
 				assert.deepEqual(actualData, iosFullTestData);
 			});
 		});

--- a/test/unit-tests/mobile/application-manager-base.ts
+++ b/test/unit-tests/mobile/application-manager-base.ts
@@ -24,7 +24,7 @@ class ApplicationManager extends ApplicationManagerBase {
 		return;
 	}
 
-	public async startApplication(appIdentifier: string): Promise<void> {
+	public async startApplication(appIdentifier: string, appName: string): Promise<void> {
 		return;
 	}
 
@@ -599,22 +599,22 @@ describe("ApplicationManagerBase", () => {
 				return Promise.resolve();
 			};
 
-			await applicationManager.restartApplication("appId");
+			await applicationManager.restartApplication("appId", "appName");
 			assert.deepEqual(stopApplicationParam, "appId", "When bundleIdentifier is not passed to restartApplication, stopApplication must be called with application identifier.");
 		});
 
 		it("calls startApplication with correct arguments", async () => {
 			let startApplicationAppIdParam: string;
-			applicationManager.startApplication = (appId: string) => {
+			let startApplicationAppNameParam: string;
+			applicationManager.startApplication = (appId: string, appName: string) => {
 				startApplicationAppIdParam = appId;
+				startApplicationAppNameParam = appName;
 				return Promise.resolve();
 			};
 
-			await applicationManager.restartApplication("appId");
+			await applicationManager.restartApplication("appId", "appName");
 			assert.deepEqual(startApplicationAppIdParam, "appId", "startApplication must be called with application identifier.");
-
-			await applicationManager.restartApplication("appId");
-			assert.deepEqual(startApplicationAppIdParam, "appId", "startApplication must be called with application identifier.");
+			assert.deepEqual(startApplicationAppNameParam, "appName", "startApplication must be called with application name.");
 		});
 
 		it("calls stopApplication and startApplication in correct order", async () => {
@@ -626,13 +626,13 @@ describe("ApplicationManagerBase", () => {
 				return Promise.resolve();
 			};
 
-			applicationManager.startApplication = (appId: string) => {
+			applicationManager.startApplication = (appId: string, appName: string) => {
 				assert.isTrue(isStopApplicationCalled, "When startApplication is called, stopApplication must have been resolved.");
 				isStartApplicationCalled = true;
 				return Promise.resolve();
 			};
 
-			await applicationManager.restartApplication("appId");
+			await applicationManager.restartApplication("appId", "appName");
 			assert.isTrue(isStopApplicationCalled, "stopApplication must be called.");
 			assert.isTrue(isStartApplicationCalled, "startApplication must be called.");
 		});
@@ -641,18 +641,22 @@ describe("ApplicationManagerBase", () => {
 	describe("tryStartApplication", () => {
 		it("calls startApplication, when canStartApplication returns true", async () => {
 			let startApplicationAppIdParam: string;
+			let startApplicationAppNameParam: string;
 
 			applicationManager.canStartApplication = () => true;
-			applicationManager.startApplication = (appId: string) => {
+			applicationManager.startApplication = (appId: string, appName: string) => {
 				startApplicationAppIdParam = appId;
+				startApplicationAppNameParam = appName;
 				return Promise.resolve();
 			};
 
-			await applicationManager.tryStartApplication("appId");
+			await applicationManager.tryStartApplication("appId", "appName");
 			assert.deepEqual(startApplicationAppIdParam, "appId");
+			assert.deepEqual(startApplicationAppNameParam, "appName");
 
-			await applicationManager.tryStartApplication("appId2");
+			await applicationManager.tryStartApplication("appId2", "appName2");
 			assert.deepEqual(startApplicationAppIdParam, "appId2");
+			assert.deepEqual(startApplicationAppNameParam, "appName2");
 		});
 
 		it("does not call startApplication, when canStartApplication returns false", async () => {
@@ -663,7 +667,7 @@ describe("ApplicationManagerBase", () => {
 				return Promise.resolve();
 			};
 
-			await applicationManager.tryStartApplication("appId");
+			await applicationManager.tryStartApplication("appId", "appName");
 			assert.isFalse(isStartApplicationCalled, "startApplication must not be called when canStartApplication returns false.");
 		});
 
@@ -687,7 +691,7 @@ describe("ApplicationManagerBase", () => {
 					isStartApplicationCalled = true;
 				};
 
-				await applicationManager.tryStartApplication("appId");
+				await applicationManager.tryStartApplication("appId", "appName");
 				assert.isFalse(isStartApplicationCalled, "startApplication must not be called when there's an error.");
 				assert.isTrue(logger.traceOutput.indexOf("Throw!") !== -1, "Error message must be shown in trace output.");
 				assert.isTrue(logger.traceOutput.indexOf("Unable to start application") !== -1, "'Unable to start application' must be shown in trace output.");

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -219,8 +219,8 @@ describe("devicesService", () => {
 		applicationManager: {
 			getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2"]),
 			canStartApplication: () => true,
-			startApplication: (packageName: string, framework: string) => Promise.resolve(),
-			tryStartApplication: (packageName: string, framework: string) => Promise.resolve(),
+			startApplication: (appId: Mobile.IApplicationData) => Promise.resolve(),
+			tryStartApplication: (appId: Mobile.IApplicationData) => Promise.resolve(),
 			reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
 			isApplicationInstalled: (packageName: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2"], packageName)),
 			isLiveSyncSupported: (appIdentifier: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2"], appIdentifier)),
@@ -239,8 +239,8 @@ describe("devicesService", () => {
 		applicationManager: {
 			getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"]),
 			canStartApplication: () => true,
-			startApplication: (packageName: string, framework: string) => Promise.resolve(),
-			tryStartApplication: (packageName: string, framework: string) => Promise.resolve(),
+			startApplication: (appId: Mobile.IApplicationData) => Promise.resolve(),
+			tryStartApplication: (appId: Mobile.IApplicationData) => Promise.resolve(),
 			reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
 			isApplicationInstalled: (packageName: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"], packageName)),
 			isLiveSyncSupported: (appIdentifier: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"], appIdentifier)),

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -219,8 +219,8 @@ describe("devicesService", () => {
 		applicationManager: {
 			getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2"]),
 			canStartApplication: () => true,
-			startApplication: (appId: Mobile.IApplicationData) => Promise.resolve(),
-			tryStartApplication: (appId: Mobile.IApplicationData) => Promise.resolve(),
+			startApplication: (appData: Mobile.IApplicationData) => Promise.resolve(),
+			tryStartApplication: (appData: Mobile.IApplicationData) => Promise.resolve(),
 			reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
 			isApplicationInstalled: (packageName: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2"], packageName)),
 			isLiveSyncSupported: (appIdentifier: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2"], appIdentifier)),
@@ -239,8 +239,8 @@ describe("devicesService", () => {
 		applicationManager: {
 			getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"]),
 			canStartApplication: () => true,
-			startApplication: (appId: Mobile.IApplicationData) => Promise.resolve(),
-			tryStartApplication: (appId: Mobile.IApplicationData) => Promise.resolve(),
+			startApplication: (appData: Mobile.IApplicationData) => Promise.resolve(),
+			tryStartApplication: (appData: Mobile.IApplicationData) => Promise.resolve(),
 			reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
 			isApplicationInstalled: (packageName: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"], packageName)),
 			isLiveSyncSupported: (appIdentifier: string) => Promise.resolve(_.includes(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"], appIdentifier)),


### PR DESCRIPTION
### refactor: Set logFilter's project name when starting iOS application  …
When strating iOS Application, set the projectName to the log filter, so
we can filter the logs by it. Same logic is used for Android, where we
are using the PID of the started application. So introduce
IDeviceLogOptions, where logLevel, pid and projectName can be set. Pass
the projectName wherever is required in order to get it in
startApplication.

### refactor: Use single object as arg for some of application manager methods

In order to make future refactorings easier, introduce a single object as an argument to some of the methods in devices' ApplicationManagers.