### PR TITLE
refactor: allow multipart default commands

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -96,6 +96,7 @@ export const DEFAULT_CHUNK_SIZE = 100;
 
 export const enum CommandsDelimiters {
 	HierarchicalCommand = "|",
+	DefaultCommandSymbol = "*",
 	DefaultHierarchicalCommand = "|*",
 	HooksCommand = "-"
 }

--- a/test/unit-tests/yok.ts
+++ b/test/unit-tests/yok.ts
@@ -523,93 +523,94 @@ $injector.register("a", A);
 
 		describe("returns true", () => {
 			describe("when command consists of two parts", () => {
-				it("and is valid", async () => {
+				it("and is valid", () => {
 					injector.requireCommand("sample|command", "sampleFileName");
-					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["command"]));
+					return assert.eventually.isTrue(injector.isValidHierarchicalCommand("sample", ["command"]));
 				});
 
-				it("and has default value and no arguments passed", async () => {
+				it("and has default value and no arguments passed", () => {
 					injector.requireCommand("sample|*default", "sampleFileName");
-					assert.isTrue(await injector.isValidHierarchicalCommand("sample", []));
+					return assert.eventually.isTrue(injector.isValidHierarchicalCommand("sample", []));
 				});
 
-				it("and has default value and canExecute returns true", async () => {
+				it("and has default value and canExecute returns true", () => {
 					const command = {
-						canExecute: () => true
+						canExecute: async () => true
 					};
 					injector.registerCommand("sample|*default", command);
 					injector.requireCommand("sample|*default", "sampleFileName");
-					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["arg"]));
+					return assert.eventually.isTrue(injector.isValidHierarchicalCommand("sample", ["arg"]));
 				});
 
-				it("and has default value and allowedParameters' length is greater than 0", async () => {
+				it("and has default value and allowedParameters' length is greater than 0", () => {
+					const allowedParameters: ICommandParameter[] = [{ mandatory: false, validate: async () => true }];
 					const command = {
-						allowedParameters: ["param1", "param2"]
+						allowedParameters
 					};
 					injector.registerCommand("sample|*default", command);
 					injector.requireCommand("sample|*default", "sampleFileName");
-					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["arg"]));
+					return assert.eventually.isTrue(injector.isValidHierarchicalCommand("sample", ["arg"]));
 				});
 
-				it("and has default value and argument default passed", async () => {
+				it("and has default value and argument default passed", () => {
 					injector.requireCommand("sample|*default", "sampleFileName");
-					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["default"]));
+					return assert.eventually.isTrue(injector.isValidHierarchicalCommand("sample", ["default"]));
 				});
 			});
 
 			describe("when command consists of multiple parts", () => {
-				it("and is valid", async () => {
+				it("and is valid", () => {
 					injector.requireCommand("sample|command|subcommand", "sampleFileName");
-					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["command", "subcommand"]));
+					return assert.eventually.isTrue(injector.isValidHierarchicalCommand("sample", ["command", "subcommand"]));
 				});
 
-				it("and has default value and no arguments passed", async () => {
+				it("and has default value and no arguments passed", () => {
 					injector.requireCommand("sample|command|*default", "sampleFileName");
-					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["command"]));
+					return assert.eventually.isTrue(injector.isValidHierarchicalCommand("sample", ["command"]));
 				});
 
-				it("has default value and default argument passed", async () => {
+				it("has default value and default argument passed", () => {
 					injector.requireCommand("sample|command|*default", "sampleFileName");
-					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["command", "default"]));
+					return assert.eventually.isTrue(injector.isValidHierarchicalCommand("sample", ["command", "default"]));
 				});
 			});
 		});
 
 		describe("returns false", () => {
-			it("when command is invalid", async () => {
+			it("when command is invalid", () => {
 				injector.requireCommand("sample|command", "sampleFileName");
-				assert.isFalse(await injector.isValidHierarchicalCommand("wrong", ["command"]));
+				return assert.eventually.isFalse(injector.isValidHierarchicalCommand("wrong", ["command"]));
 			});
 
-			it("when has default value and canExecute returns false", async () => {
+			it("when has default value and canExecute returns false", () => {
 				const command = {
-					canExecute: () => false
+					canExecute: async () => false
 				};
 				injector.registerCommand("sample|*default", command);
 				injector.requireCommand("sample|*default", "sampleFileName");
-				assert.isFalse(await injector.isValidHierarchicalCommand("sample", ["arg"]));
+				return assert.eventually.isFalse(injector.isValidHierarchicalCommand("sample", ["arg"]));
 			});
 		});
 
 		describe("throws", () => {
-			it("when has default value and some arguments passed", async () => {
+			it("when has default value and some arguments passed", () => {
 				injector.requireCommand("sample|*default", "sampleFileName");
-				assert.isRejected(injector.isValidHierarchicalCommand("sample", ["argument"]));
+				return assert.isRejected(injector.isValidHierarchicalCommand("sample", ["argument"]));
 			});
 
-			it("when arguments are invalid", async () => {
+			it("when arguments are invalid", () => {
 				injector.requireCommand("sample|command", "sampleFileName");
-				assert.isRejected(injector.isValidHierarchicalCommand("sample", ["commandarg"]));
+				return assert.isRejected(injector.isValidHierarchicalCommand("sample", ["commandarg"]));
 			});
 
-			it("when has default value and allowedParameters' length is 0", async () => {
-				const allowedParameters: string[] = [];
+			it("when has default value and allowedParameters' length is 0", () => {
+				const allowedParameters: ICommandParameter[] = [];
 				const command = {
 					allowedParameters
 				};
 				injector.registerCommand("sample|*default", command);
 				injector.requireCommand("sample|*default", "sampleFileName");
-				assert.isRejected(injector.isValidHierarchicalCommand("sample", ["arg"]));
+				return assert.isRejected(injector.isValidHierarchicalCommand("sample", ["arg"]));
 			});
 		});
 	});

--- a/test/unit-tests/yok.ts
+++ b/test/unit-tests/yok.ts
@@ -515,6 +515,105 @@ $injector.register("a", A);
 		});
 	});
 
+	describe("isValidHierarchicalCommand", () => {
+		let injector: IInjector;
+		beforeEach(() => {
+			injector = new Yok();
+		});
+
+		describe("returns true", () => {
+			describe("when command consists of two parts", () => {
+				it("and is valid", async () => {
+					injector.requireCommand("sample|command", "sampleFileName");
+					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["command"]));
+				});
+
+				it("and has default value and no arguments passed", async () => {
+					injector.requireCommand("sample|*default", "sampleFileName");
+					assert.isTrue(await injector.isValidHierarchicalCommand("sample", []));
+				});
+
+				it("and has default value and canExecute returns true", async () => {
+					const command = {
+						canExecute: () => true
+					};
+					injector.registerCommand("sample|*default", command);
+					injector.requireCommand("sample|*default", "sampleFileName");
+					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["arg"]));
+				});
+
+				it("and has default value and allowedParameters' length is greater than 0", async () => {
+					const command = {
+						allowedParameters: ["param1", "param2"]
+					};
+					injector.registerCommand("sample|*default", command);
+					injector.requireCommand("sample|*default", "sampleFileName");
+					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["arg"]));
+				});
+
+				it("and has default value and argument default passed", async () => {
+					injector.requireCommand("sample|*default", "sampleFileName");
+					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["default"]));
+				});
+			});
+
+			describe("when command consists of multiple parts", () => {
+				it("and is valid", async () => {
+					injector.requireCommand("sample|command|subcommand", "sampleFileName");
+					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["command", "subcommand"]));
+				});
+
+				it("and has default value and no arguments passed", async () => {
+					injector.requireCommand("sample|command|*default", "sampleFileName");
+					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["command"]));
+				});
+
+				it("has default value and default argument passed", async () => {
+					injector.requireCommand("sample|command|*default", "sampleFileName");
+					assert.isTrue(await injector.isValidHierarchicalCommand("sample", ["command", "default"]));
+				});
+			});
+		});
+
+		describe("returns false", () => {
+			it("when command is invalid", async () => {
+				injector.requireCommand("sample|command", "sampleFileName");
+				assert.isFalse(await injector.isValidHierarchicalCommand("wrong", ["command"]));
+			});
+
+			it("when has default value and canExecute returns false", async () => {
+				const command = {
+					canExecute: () => false
+				};
+				injector.registerCommand("sample|*default", command);
+				injector.requireCommand("sample|*default", "sampleFileName");
+				assert.isFalse(await injector.isValidHierarchicalCommand("sample", ["arg"]));
+			});
+		});
+
+		describe("throws", () => {
+			it("when has default value and some arguments passed", async () => {
+				injector.requireCommand("sample|*default", "sampleFileName");
+				assert.isRejected(injector.isValidHierarchicalCommand("sample", ["argument"]));
+			});
+
+			it("when arguments are invalid", async () => {
+				injector.requireCommand("sample|command", "sampleFileName");
+				assert.isRejected(injector.isValidHierarchicalCommand("sample", ["commandarg"]));
+			});
+
+			it("when has default value and allowedParameters' length is 0", async () => {
+				const allowedParameters: string[] = [];
+				const command = {
+					allowedParameters
+				};
+				injector.registerCommand("sample|*default", command);
+				injector.requireCommand("sample|*default", "sampleFileName");
+				assert.isRejected(injector.isValidHierarchicalCommand("sample", ["arg"]));
+			});
+		});
+	});
+
 	describe("buildHierarchicalCommand", () => {
 		let injector: IInjector;
 		beforeEach(() => {

--- a/yok.ts
+++ b/yok.ts
@@ -1,8 +1,7 @@
 import * as path from "path";
 import { annotate, isPromise } from "./helpers";
 import { ERROR_NO_VALID_SUBCOMMAND_FORMAT } from "./constants";
-const CommandSeparator = "|";
-const DefaultCommandSymbol = "*";
+import { CommandsDelimiters } from "./constants";
 
 let indent = "";
 function trace(formatStr: string, ...args: any[]) {
@@ -62,7 +61,7 @@ export class Yok implements IInjector {
 
 	public requireCommand(names: any, file: string): void {
 		forEachName(names, (commandName) => {
-			const commands = commandName.split(CommandSeparator);
+			const commands = commandName.split(CommandsDelimiters.HierarchicalCommand);
 
 			if (commands.length > 1) {
 				if (_.startsWith(commands[1], '*') && this.modules[this.createCommandName(commands[0])]) {
@@ -75,7 +74,7 @@ export class Yok implements IInjector {
 					this.hierarchicalCommands[parentCommandName] = [];
 				}
 
-				this.hierarchicalCommands[parentCommandName].push(_.tail(commands).join(CommandSeparator));
+				this.hierarchicalCommands[parentCommandName].push(_.tail(commands).join(CommandsDelimiters.HierarchicalCommand));
 			}
 
 			if (commands.length > 1 && !this.modules[this.createCommandName(commands[0])]) {
@@ -153,7 +152,7 @@ export class Yok implements IInjector {
 
 	public registerCommand(names: any, resolver: any): void {
 		forEachName(names, (name) => {
-			const commands = name.split(CommandSeparator);
+			const commands = name.split(CommandsDelimiters.HierarchicalCommand);
 			this.register(this.createCommandName(name), resolver);
 
 			if (commands.length > 1) {
@@ -164,20 +163,15 @@ export class Yok implements IInjector {
 
 	private getDefaultCommand(name: string, commandArguments: string[]) {
 		const subCommands = this.hierarchicalCommands[name];
-		const defaultCommand = _.find(subCommands, command => _.some(command.split(CommandSeparator), c => _.startsWith(c, DefaultCommandSymbol)));
+		const defaultCommand = _.find(subCommands, command => _.some(command.split(CommandsDelimiters.HierarchicalCommand), c => _.startsWith(c, CommandsDelimiters.DefaultCommandSymbol)));
 
 		if (defaultCommand) {
 			// In case the defaultCommand consists of more than one part (e.g. someCommand|someSubcommand|*default)
 			// we need to remove all parts from the arguments list - they are not actually arguments
 			defaultCommand
-				.split(CommandSeparator)
-				.map(c => _.startsWith(c, DefaultCommandSymbol) ? c.substr(1) : c)
-				.forEach(a => {
-					const argIndex = commandArguments.indexOf(a);
-					if (argIndex > -1) {
-						commandArguments.splice(argIndex, 1);
-					}
-				});
+				.split(CommandsDelimiters.HierarchicalCommand)
+				.map(command => _.startsWith(command, CommandsDelimiters.DefaultCommandSymbol) ? command.substr(1) : command)
+				.forEach(command => _.remove(commandArguments, arg => arg === command));
 		}
 
 		return defaultCommand;
@@ -193,7 +187,7 @@ export class Yok implements IInjector {
 			arg = arg.toLowerCase();
 			currentSubCommandName = currentSubCommandName ? this.getHierarchicalCommandName(currentSubCommandName, arg) : arg;
 			remainingArguments = _.tail(remainingArguments);
-			if (matchingSubCommandName = _.find(subCommands, (sc) => sc === currentSubCommandName || sc === DefaultCommandSymbol + currentSubCommandName)) {
+			if (matchingSubCommandName = _.find(subCommands, sc => sc === currentSubCommandName || sc === `${CommandsDelimiters.DefaultCommandSymbol}${currentSubCommandName}`)) {
 				finalSubCommandName = matchingSubCommandName;
 				finalRemainingArguments = remainingArguments;
 				foundSubCommand = true;
@@ -227,7 +221,7 @@ export class Yok implements IInjector {
 							commandName = defaultCommand ? this.getHierarchicalCommandName(name, defaultCommand) : "help";
 							// If we'll execute the default command, but it's full name had been written by the user
 							// for example "appbuilder cloud list", we have to remove the "list" option from the arguments that we'll pass to the command.
-							if (_.includes(this.hierarchicalCommands[name], DefaultCommandSymbol + args[0])) {
+							if (_.includes(this.hierarchicalCommands[name], CommandsDelimiters.DefaultCommandSymbol + args[0])) {
 								commandArguments = _.tail(args);
 							} else {
 								commandArguments = args;
@@ -255,7 +249,7 @@ export class Yok implements IInjector {
 	}
 
 	private getHierarchicalCommandName(parentCommandName: string, subCommandName: string) {
-		return [parentCommandName, subCommandName].join(CommandSeparator);
+		return [parentCommandName, subCommandName].join(CommandsDelimiters.HierarchicalCommand);
 	}
 
 	public async isValidHierarchicalCommand(commandName: string, commandArguments: string[]): Promise<boolean> {
@@ -296,7 +290,7 @@ export class Yok implements IInjector {
 	}
 
 	public isDefaultCommand(commandName: string): boolean {
-		return commandName.indexOf(DefaultCommandSymbol) > 0 && commandName.indexOf(CommandSeparator) > 0;
+		return commandName.indexOf(CommandsDelimiters.DefaultCommandSymbol) > 0 && commandName.indexOf(CommandsDelimiters.HierarchicalCommand) > 0;
 	}
 
 	public register(name: string, resolver: any, shared?: boolean): void {


### PR DESCRIPTION
In case a command like `sample|command|*default` is registered CLI should be able to correctly execute 
`tns sample command`

Added tests to ensure functionality

Ping @rosen-vladimirov @Fatme 