### PR TITLE
Add spinner when checking for NativeScript components versions

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1660,6 +1660,14 @@ interface IVersionInformation {
 	 * The latest available version of the component.
 	 */
 	latestVersion: string;
+	/**
+	 * The message that will be displayed.
+	 */
+	message?: string;
+	/**
+	 * The type of the component. Can be UpToDate, UpdateAvailable, NotInstalled.
+	 */
+	type?: "UpToDate" | "UpdateAvailable" | "NotInstalled";
 }
 
 interface IVersionData {


### PR DESCRIPTION
Currently when doctor command is executed, NativeScript components versions information is displayed as table. With this PR NativeScript components versions will be displayed with terminal spinners.

In case when component is up to date with latest available version, success spinner will be displayed.
In case when for component update is available, warn spinner will be displayed.
In case when component is not installed, fail spinner will be displayed.

This PR changes also the behaviour of `tns info` command. When `tns info` command is executed,  NativeScript components versions information also will be displayed with terminal spinners.