### PR TITLE
 fix(deviceLogs): iOS device logs are not shown when deployOnDevices is used

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -270,7 +270,6 @@ declare module Mobile {
 		startApplication(appData: IApplicationData): Promise<void>;
 		stopApplication(appData: IApplicationData): Promise<void>;
 		restartApplication(appData: IApplicationData): Promise<void>;
-		canStartApplication(): boolean;
 		checkForApplicationUpdates(): Promise<void>;
 		isLiveSyncSupported(appIdentifier: string): Promise<boolean>;
 		getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo>;

--- a/mobile/android/android-application-manager.ts
+++ b/mobile/android/android-application-manager.ts
@@ -92,10 +92,6 @@ export class AndroidApplicationManager extends ApplicationManagerBase {
 		return Promise.resolve(null);
 	}
 
-	public canStartApplication(): boolean {
-		return true;
-	}
-
 	public async isLiveSyncSupported(appIdentifier: string): Promise<boolean> {
 		const liveSyncVersion = await this.adb.sendBroadcastToDevice(LiveSyncConstants.CHECK_LIVESYNC_INTENT_NAME, { "app-id": appIdentifier });
 		return liveSyncVersion === LiveSyncConstants.VERSION_2 || liveSyncVersion === LiveSyncConstants.VERSION_3;

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -70,11 +70,9 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 
 	public async tryStartApplication(appData: Mobile.IApplicationData): Promise<void> {
 		try {
-			if (this.canStartApplication()) {
-				await this.startApplication(appData);
-			}
+			await this.startApplication(appData);
 		} catch (err) {
-			this.$logger.trace(`Unable to start application ${appData.appId}. Error is: ${err.message}`);
+			this.$logger.trace(`Unable to start application ${appData.appId} with name ${appData.projectName}. Error is: ${err.message}`);
 		}
 	}
 

--- a/mobile/application-manager-base.ts
+++ b/mobile/application-manager-base.ts
@@ -84,7 +84,6 @@ export abstract class ApplicationManagerBase extends EventEmitter implements Mob
 	public abstract async stopApplication(appData: Mobile.IApplicationData): Promise<void>;
 	public abstract async getInstalledApplications(): Promise<string[]>;
 	public abstract async getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo>;
-	public abstract canStartApplication(): boolean;
 	public abstract async getDebuggableApps(): Promise<Mobile.IDeviceApplicationInformation[]>;
 	public abstract async getDebuggableAppViews(appIdentifiers: string[]): Promise<IDictionary<Mobile.IDebugWebViewInfo[]>>;
 

--- a/mobile/ios/device/ios-application-manager.ts
+++ b/mobile/ios/device/ios-application-manager.ts
@@ -11,8 +11,6 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 		private device: Mobile.IDevice,
 		private $errors: IErrors,
 		private $iOSNotificationService: IiOSNotificationService,
-		private $hostInfo: IHostInfo,
-		private $staticConfig: Config.IStaticConfig,
 		private $iosDeviceOperations: IIOSDeviceOperations,
 		private $options: ICommonOptions,
 		private $deviceLogProvider: Mobile.IDeviceLogProvider) {
@@ -122,10 +120,6 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 	@cache()
 	private async startDeviceLog(): Promise<void> {
 		await this.device.openDeviceLogStream();
-	}
-
-	public canStartApplication(): boolean {
-		return this.$hostInfo.isDarwin || (this.$hostInfo.isWindows && this.$staticConfig.enableDeviceRunCommandOnWindows);
 	}
 
 	public getDebuggableApps(): Promise<Mobile.IDeviceApplicationInformation[]> {

--- a/mobile/ios/device/ios-application-manager.ts
+++ b/mobile/ios/device/ios-application-manager.ts
@@ -102,6 +102,7 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 
 	public async restartApplication(appData: Mobile.IApplicationData): Promise<void> {
 		try {
+			this.$deviceLogProvider.setProjectNameForDevice(this.device.deviceInfo.identifier, appData.projectName);
 			await this.stopApplication(appData);
 			await this.runApplicationCore(appData);
 		} catch (err) {

--- a/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -54,10 +54,6 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		return this.iosSim.stopApplication(this.identifier, appData.appId, appData.projectName);
 	}
 
-	public canStartApplication(): boolean {
-		return true;
-	}
-
 	public async getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo> {
 		let result: Mobile.IApplicationInfo = null;
 		const plistContent = await this.getParsedPlistContent(applicationIdentifier);

--- a/services/livesync-service-base.ts
+++ b/services/livesync-service-base.ts
@@ -183,7 +183,7 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 						shouldRefreshApplication = false;
 					}
 
-					if (device.applicationManager.canStartApplication() && !shouldRefreshApplication) {
+					if (!shouldRefreshApplication) {
 						await device.applicationManager.startApplication({ appId: appIdentifier, projectName: "" });
 					}
 					wasInstalled = false;

--- a/test/unit-tests/mobile/application-manager-base.ts
+++ b/test/unit-tests/mobile/application-manager-base.ts
@@ -40,10 +40,6 @@ class ApplicationManager extends ApplicationManagerBase {
 		return null;
 	}
 
-	public canStartApplication(): boolean {
-		return true;
-	}
-
 	public async getDebuggableApps(): Promise<Mobile.IDeviceApplicationInformation[]> {
 		return currentlyAvailableAppsForDebugging;
 	}

--- a/test/unit-tests/mobile/application-manager-base.ts
+++ b/test/unit-tests/mobile/application-manager-base.ts
@@ -640,10 +640,9 @@ describe("ApplicationManagerBase", () => {
 	});
 
 	describe("tryStartApplication", () => {
-		it("calls startApplication, when canStartApplication returns true", async () => {
+		it("calls startApplication", async () => {
 			let passedApplicationData: Mobile.IApplicationData = null;
 
-			applicationManager.canStartApplication = () => true;
 			applicationManager.startApplication = (appData: Mobile.IApplicationData) => {
 				passedApplicationData = appData;
 				return Promise.resolve();
@@ -656,18 +655,6 @@ describe("ApplicationManagerBase", () => {
 			await applicationManager.tryStartApplication(secondApplicationData);
 			assert.deepEqual(passedApplicationData, secondApplicationData);
 
-		});
-
-		it("does not call startApplication, when canStartApplication returns false", async () => {
-			let isStartApplicationCalled = false;
-			applicationManager.canStartApplication = () => false;
-			applicationManager.startApplication = (appData: Mobile.IApplicationData) => {
-				isStartApplicationCalled = true;
-				return Promise.resolve();
-			};
-
-			await applicationManager.tryStartApplication(applicationData);
-			assert.isFalse(isStartApplicationCalled, "startApplication must not be called when canStartApplication returns false.");
 		});
 
 		describe("does not throw Error", () => {
@@ -696,16 +683,7 @@ describe("ApplicationManagerBase", () => {
 				assert.isTrue(logger.traceOutput.indexOf("Unable to start application") !== -1, "'Unable to start application' must be shown in trace output.");
 			};
 
-			it("when canStartApplication throws error", async () => {
-				applicationManager.canStartApplication = (): boolean => {
-					throw error;
-				};
-				applicationManager.isApplicationInstalled = (appId: string) => Promise.resolve(true);
-				await assertDoesNotThrow();
-			});
-
 			it("when startApplications throws", async () => {
-				applicationManager.canStartApplication = () => true;
 				applicationManager.isApplicationInstalled = (appId: string) => Promise.resolve(true);
 				await assertDoesNotThrow({ shouldStartApplicatinThrow: true });
 			});

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -78,7 +78,6 @@ const iOSSimulator = {
 	},
 	applicationManager: {
 		getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2"]),
-		canStartApplication: () => true,
 		startApplication: (packageName: string, framework: string) => Promise.resolve(),
 		tryStartApplication: (packageName: string, framework: string) => Promise.resolve(),
 		reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
@@ -218,7 +217,6 @@ describe("devicesService", () => {
 		},
 		applicationManager: {
 			getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2"]),
-			canStartApplication: () => true,
 			startApplication: (appData: Mobile.IApplicationData) => Promise.resolve(),
 			tryStartApplication: (appData: Mobile.IApplicationData) => Promise.resolve(),
 			reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
@@ -238,7 +236,6 @@ describe("devicesService", () => {
 		},
 		applicationManager: {
 			getInstalledApplications: () => Promise.resolve(["com.telerik.unitTest1", "com.telerik.unitTest2", "com.telerik.unitTest3"]),
-			canStartApplication: () => true,
 			startApplication: (appData: Mobile.IApplicationData) => Promise.resolve(),
 			tryStartApplication: (appData: Mobile.IApplicationData) => Promise.resolve(),
 			reinstallApplication: (packageName: string, packageFile: string) => Promise.resolve(),
@@ -933,18 +930,6 @@ describe("devicesService", () => {
 				const realResult = deployOnDevicesResult;
 				assert.isTrue(realResult === undefined, "On success, undefined should be returned.");
 			});
-		});
-
-		it("does not call startApplication when canStartApplication returns false", async () => {
-			iOSDevice.applicationManager.canStartApplication = () => false;
-			iOSDevice.applicationManager.startApplication = (): Promise<void> => {
-				throw new Error("Start application must not be called for iOSDevice when canStartApplication returns false.");
-			};
-
-			const results = devicesService.deployOnDevices([androidDevice.deviceInfo.identifier, iOSDevice.deviceInfo.identifier], "path", "packageName", "cordova");
-			assert.isTrue(results.length > 0);
-			const deployOnDevicesResults = await Promise.all(results);
-			assert.deepEqual(deployOnDevicesResults, [undefined, undefined]);
 		});
 
 		it("throws error when invalid identifier is passed", async () => {


### PR DESCRIPTION
When the public method `devicesService.deployOnDevices` is used, the device logs for iOS are not shown. The problem is that the method calls `canStartApplication`, which returns false on Windows.
Remove the check and also ensure the set of projectName for the deviceLogProvider will be called no matter of the way we start iOS Applications (through the mounted image or through Safari on device).

### chore: Remove canStartApplication method
Remove `canStartApplication` method from application managers as it does not have a useful usage. Previously we've used it on Windows and Linux as we did not have a way to start iOS applications.
Now, as we have implemented such way through Safari, the method has lost its purpose.