### PR TITLE
feat(commands): Introduce postCommandAction

### DIFF
--- a/commands/post-install.ts
+++ b/commands/post-install.ts
@@ -5,7 +5,7 @@ export class PostInstallCommand implements ICommand {
 		private $helpService: IHelpService,
 		private $settingsService: ISettingsService,
 		private $analyticsService: IAnalyticsService,
-		private $logger: ILogger) {
+		protected $logger: ILogger) {
 	}
 
 	public disableAnalytics = true;

--- a/definitions/commands.d.ts
+++ b/definitions/commands.d.ts
@@ -14,6 +14,13 @@ interface ICommand extends ICommandOptions {
 	completionData?: string[];
 	dashedOptions?: IDictionary<IDashedOption>;
 	isHierarchicalCommand?: boolean;
+
+	/**
+	 * Describes the action that will be executed after the command succeeds.
+	 * @param {string[]} args Arguments passed to the command.
+	 * @returns {Promise<void>}
+	 */
+	postCommandAction?(args: string[]): Promise<void>;
 }
 
 interface IDynamicCommand extends ICommand { }


### PR DESCRIPTION
Introduce postCommandAction that is executed when command succeeds. This action should be used to print additional information to users how to continue after this command.