### PR TITLE
fix (ios-simulator): Show logs from all running iOS simulators

### DIFF
--- a/mobile/ios/simulator/ios-simulator-log-provider.ts
+++ b/mobile/ios/simulator/ios-simulator-log-provider.ts
@@ -1,20 +1,32 @@
 import { ChildProcess } from "child_process";
 
 export class IOSSimulatorLogProvider implements Mobile.IiOSSimulatorLogProvider {
-	private isStarted: boolean;
+	private simulatorsLoggingEnabled: IDictionary<boolean> = {};
 
 	constructor(private $iOSSimResolver: Mobile.IiOSSimResolver,
 		private $deviceLogProvider: Mobile.IDeviceLogProvider,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $logger: ILogger,
 		private $processService: IProcessService) { }
 
 	public startLogProcess(deviceIdentifier: string): void {
-		if (!this.isStarted) {
+		if (!this.simulatorsLoggingEnabled[deviceIdentifier]) {
 			const deviceLogChildProcess: ChildProcess = this.$iOSSimResolver.iOSSim.getDeviceLogProcess(deviceIdentifier, 'senderImagePath contains "NativeScript"');
 
 			const action = (data: NodeBuffer | string) => {
 				this.$deviceLogProvider.logData(data.toString(), this.$devicePlatformsConstants.iOS, deviceIdentifier);
 			};
+
+			if (deviceLogChildProcess) {
+				deviceLogChildProcess.once("close", () => {
+					this.simulatorsLoggingEnabled[deviceIdentifier] = false;
+				});
+
+				deviceLogChildProcess.once("error", (err) => {
+					this.$logger.trace(`Error is thrown for device with identifier ${deviceIdentifier}. More info: ${err.message}.`);
+					this.simulatorsLoggingEnabled[deviceIdentifier] = false;
+				});
+			}
 
 			if (deviceLogChildProcess.stdout) {
 				deviceLogChildProcess.stdout.on("data", action);
@@ -26,7 +38,7 @@ export class IOSSimulatorLogProvider implements Mobile.IiOSSimulatorLogProvider 
 
 			this.$processService.attachToProcessExitSignals(this, deviceLogChildProcess.kill);
 
-			this.isStarted = true;
+			this.simulatorsLoggingEnabled[deviceIdentifier] = true;
 		}
 	}
 }


### PR DESCRIPTION
In case when more than one simulator is running, logs are shown only from one of them.
Also fixes the behaviour when simulator's log process is interrupted in case when cli is used as library.