### PR TITLE
Fix `The parameter null is not valid for this command.` error when create command is executed.

### DIFF
--- a/services/commands-service.ts
+++ b/services/commands-service.ts
@@ -253,7 +253,7 @@ export class CommandsService implements ICommandsService {
 					// Remove the matched parameter from unverifiedAllowedParams collection, so it will not be used to verify another argument.
 					unverifiedAllowedParams.splice(index, 1);
 				} else {
-					this.$errors.fail("The parameter %s is not valid for this command.", parameter);
+					this.$errors.fail(`The parameter ${argument} is not valid for this command.`);
 				}
 			}
 		}


### PR DESCRIPTION
Current behaviour:
When `tns create wqeer sadadfad` command is executed, `The parameter null is not valid for this command.` error is thrown.

New behaviour:
When `tns create wqeer sadadfad` command is executed, `The parameter sadadfad is not valid for this command.` error is thrown.

Fixes https://github.com/NativeScript/nativescript-cli/issues/2727