### PR TITLE
feat(API): Expose androidProcessService - getAppProcessId

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -75,7 +75,7 @@ $injector.require("deviceAppDataFactory", "./mobile/device-app-data/device-app-d
 $injector.requirePublic("typeScriptService", "./services/typescript-service");
 
 $injector.requirePublic("devicesService", "./mobile/mobile-core/devices-service");
-$injector.require("androidProcessService", "./mobile/mobile-core/android-process-service");
+$injector.requirePublic("androidProcessService", "./mobile/mobile-core/android-process-service");
 $injector.require("projectNameValidator", "./validators/project-name-validator");
 
 $injector.require("androidEmulatorServices", "./mobile/android/android-emulator-services");

--- a/mobile/mobile-core/android-process-service.ts
+++ b/mobile/mobile-core/android-process-service.ts
@@ -2,6 +2,7 @@ import { EOL } from "os";
 import * as shelljs from "shelljs";
 import { DeviceAndroidDebugBridge } from "../android/device-android-debug-bridge";
 import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../constants";
+import { exported } from "../../decorators";
 
 export class AndroidProcessService implements Mobile.IAndroidProcessService {
 	private _devicesAdbs: IDictionary<Mobile.IDeviceAndroidDebugBridge>;
@@ -13,17 +14,6 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 		private $processService: IProcessService) {
 		this._devicesAdbs = {};
 		this._forwardedLocalPorts = [];
-	}
-
-	private get androidPortInformationRegExp(): RegExp {
-		// The RegExp should look like this:
-		// /(\d+):\s+([0-9A-Za-z]+:[0-9A-Za-z]+)\s+([0-9A-Za-z]+:[0-9A-Za-z]+)\s+[0-9A-Za-z]+\s+[0-9A-Za-z]+:[0-9A-Za-z]+\s+[0-9A-Za-z]+:[0-9A-Za-z]+\s+[0-9A-Za-z]+\s+(\d+)/g
-		const wordCharacters = "[0-9A-Za-z]+";
-		const hexIpAddressWithPort = "[0-9A-Za-z]+:[0-9A-Za-z]+";
-		const hexIpAddressWithPortWithSpace = `${hexIpAddressWithPort}\\s+`;
-		const hexIpAddressWithPortWithSpaceMatch = `(${hexIpAddressWithPort})\\s+`;
-
-		return new RegExp(`(\\d+):\\s+${hexIpAddressWithPortWithSpaceMatch}${hexIpAddressWithPortWithSpaceMatch}${wordCharacters}\\s+${hexIpAddressWithPortWithSpace}${hexIpAddressWithPortWithSpace}${wordCharacters}\\s+(\\d+)`, "g");
 	}
 
 	public async mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string, framework: string): Promise<string> {
@@ -118,6 +108,7 @@ export class AndroidProcessService implements Mobile.IAndroidProcessService {
 			.value();
 	}
 
+	@exported("androidProcessService")
 	public async getAppProcessId(deviceIdentifier: string, appIdentifier: string): Promise<string> {
 		const adb = this.getAdb(deviceIdentifier);
 		const processId = (await this.getProcessIds(adb, [appIdentifier]))[appIdentifier];


### PR DESCRIPTION
Expose the `getAppProcessId` method from `androidProcessService`, so it can be called when using CLI as a library.
Remove unused property from the class.