### PR TITLE
Fix unhandled exception that is thrown in case when there are a configuration problem on the machine

### DIFF
--- a/mobile/mobile-core/ios-simulator-discovery.ts
+++ b/mobile/mobile-core/ios-simulator-discovery.ts
@@ -16,12 +16,10 @@ export class IOSSimulatorDiscovery extends DeviceDiscovery {
 			return;
 		}
 
-		return new Promise<void>((resolve, reject) => {
-			return this.checkForDevices(resolve, reject);
-		});
+		return this.checkForDevices();
 	}
 
-	public async checkForDevices(resolve?: (value?: void | PromiseLike<void>) => void, reject?: (reason?: any) => void): Promise<void> {
+	public async checkForDevices(): Promise<void> {
 		if (this.$hostInfo.isDarwin) {
 			const currentSimulators: Mobile.IiSimDevice[] = await this.$iOSSimResolver.iOSSim.getRunningSimulators();
 
@@ -34,10 +32,6 @@ export class IOSSimulatorDiscovery extends DeviceDiscovery {
 			_(currentSimulators)
 				.reject(s => _.find(this.cachedSimulators, simulator => simulator && s && simulator.id === s.id && simulator.state === s.state))
 				.each(s => this.createAndAddDevice(s));
-		}
-
-		if (resolve) {
-			resolve();
 		}
 	}
 


### PR DESCRIPTION
In case when some configuration problem occurs on the machine, Sidekick hangs on splashscreen because unhandled exception is thrown.

Should be merged with this PR: https://github.com/telerik/ios-sim-portable/pull/105