### PR TITLE
 feat: Validate Java compiler version based on runtime version

### DIFF
--- a/commands/doctor.ts
+++ b/commands/doctor.ts
@@ -1,11 +1,12 @@
 export class DoctorCommand implements ICommand {
 
-	constructor(private $doctorService: IDoctorService) { }
+	constructor(private $doctorService: IDoctorService,
+		private $projectHelper: IProjectHelper) { }
 
 	public allowedParameters: ICommandParameter[] = [];
 
 	public execute(args: string[]): Promise<void> {
-		return this.$doctorService.printWarnings();
+		return this.$doctorService.printWarnings({ trackResult: false, projectDir: this.$projectHelper.projectDir });
 	}
 }
 

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1363,7 +1363,7 @@ interface IDoctorService {
 	 * @param configOptions: defines if the result should be tracked by Analytics
 	 * @returns {Promise<void>}
 	 */
-	printWarnings(configOptions?: { trackResult: boolean }): Promise<void>;
+	printWarnings(configOptions?: { trackResult: boolean, projectDir?: string }): Promise<void>;
 	/**
 	 * Runs the setup script on host machine
 	 * @returns {Promise<ISpawnResult>}
@@ -1374,7 +1374,7 @@ interface IDoctorService {
 	 * @param platform @optional The current platform
 	 * @returns {Promise<boolean>} true if the environment is properly configured for local builds
 	 */
-	canExecuteLocalBuild(platform?: string): Promise<boolean>;
+	canExecuteLocalBuild(platform?: string, projectDir?: string): Promise<boolean>;
 }
 
 interface IUtils {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "minimatch": "2.0.4",
     "mkdirp": "0.3.5",
     "mute-stream": "0.0.4",
-    "nativescript-doctor": "0.12.0",
+    "nativescript-doctor": "1.1.0-rc.0",
     "open": "0.0.4",
     "osenv": "0.1.0",
     "parse5": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "minimatch": "2.0.4",
     "mkdirp": "0.3.5",
     "mute-stream": "0.0.4",
-    "nativescript-doctor": "1.1.0-rc.0",
+    "nativescript-doctor": "1.1.0",
     "open": "0.0.4",
     "osenv": "0.1.0",
     "parse5": "2.2.0",


### PR DESCRIPTION
Update calls to `nativescript-doctor` package to pass projectDir where applicable. This allows the package to verify installed Java Compiler version against the project's Android runtime.
This is required in case the installed Java version is 10 or above and the Androud runtime in the project is older than 4.1.0. In this case the user cannot build this application for Android, but have to update the Android runtime version or downgrade the Java version.