### PR TITLE
feat: Introduce method for Android port forwarding

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -475,6 +475,15 @@ declare module Mobile {
 		getInstalledApplications(deviceIdentifier: string): Promise<string[]>;
 	}
 
+	interface IPortForwardDataBase {
+		deviceIdentifier: string;
+		appIdentifier: string;
+	}
+
+	interface IPortForwardData extends IPortForwardDataBase {
+		abstractPort: string;
+	}
+
 	/**
 	 * Describes methods for working with Android processes.
 	 */
@@ -511,6 +520,15 @@ declare module Mobile {
 		 * @return {string} Returns the process id matching the application identifier in the device process list.
 		 */
 		getAppProcessId(deviceIdentifier: string, appIdentifier: string): Promise<string>;
+
+		/**
+		 * Sets port forwarding to a specified abstract port.
+		 * First checks if there's already existing port forwarding and if yes, takes the TCP port from there and returns it to the result.
+		 * In case there's no port forwarding, gets a free TCP port and executes adb forward.
+		 * @param {IPortForwardData} portForwardInputData Data describing required information to setup port forwarding.
+		 * @returns {number} The TCP port that is used for the forwarding.
+		 */
+		forwardFreeTcpToAbstractPort(portForwardInputData: IPortForwardData): Promise<number>;
 	}
 
 	/**


### PR DESCRIPTION
Introduce new method for Android port forwarding in the android-process-service. This method is based on already existing ones, but it skips several checks that are not valid for the current case.
Also fix the removing of the port forward when multiple Android devices/emulators are attached - the current command does not work in this case as it does not specify `-s <device>`. Fix this by persisting the information for forwarded ports and devices