### PR TITLE
fix: Unable to launch application on specific iOS Simulator

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -677,6 +677,7 @@ declare module Mobile {
 		waitForDebugger?: boolean;
 		captureStdin?: boolean;
 		skipInstall?: boolean;
+		device?: string;
 	}
 
 	interface IPlatformsCapabilities {

--- a/mobile/ios/simulator/ios-emulator-services.ts
+++ b/mobile/ios/simulator/ios-emulator-services.ts
@@ -54,7 +54,7 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 		const options: any = {
 			timeout: this.$options.timeout,
 			sdkVersion: this.$options.sdk,
-			device: this.$options.device,
+			device: (emulatorOptions && emulatorOptions.device) || this.$options.device,
 			args: emulatorOptions.args,
 			waitForDebugger: emulatorOptions.waitForDebugger,
 			skipInstall: emulatorOptions.skipInstall


### PR DESCRIPTION
The current logic for launching application on specific iOS Simulator reads the device from the `$options` option. This does not work in many cases (for example `tns debug ios` when multiple simulators are running and CLI prompts you to select one.
So add option in the emulator options to specify device and read it from there.