### PR TITLE
 fix: Validate environment based on specified runtime version  

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1363,7 +1363,7 @@ interface IDoctorService {
 	 * @param configOptions: defines if the result should be tracked by Analytics
 	 * @returns {Promise<void>}
 	 */
-	printWarnings(configOptions?: { trackResult: boolean, projectDir?: string }): Promise<void>;
+	printWarnings(configOptions?: { trackResult: boolean, projectDir?: string, runtimeVersion?: string }): Promise<void>;
 	/**
 	 * Runs the setup script on host machine
 	 * @returns {Promise<ISpawnResult>}
@@ -1374,7 +1374,7 @@ interface IDoctorService {
 	 * @param platform @optional The current platform
 	 * @returns {Promise<boolean>} true if the environment is properly configured for local builds
 	 */
-	canExecuteLocalBuild(platform?: string, projectDir?: string): Promise<boolean>;
+	canExecuteLocalBuild(platform?: string, projectDir?: string, runtimeVersion?: string): Promise<boolean>;
 }
 
 interface IUtils {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "minimatch": "2.0.4",
     "mkdirp": "0.3.5",
     "mute-stream": "0.0.4",
-    "nativescript-doctor": "1.2.0-rc.0",
+    "nativescript-doctor": "1.2.0",
     "open": "0.0.4",
     "osenv": "0.1.0",
     "parse5": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "minimatch": "2.0.4",
     "mkdirp": "0.3.5",
     "mute-stream": "0.0.4",
-    "nativescript-doctor": "1.1.0",
+    "nativescript-doctor": "1.2.0-rc.0",
     "open": "0.0.4",
     "osenv": "0.1.0",
     "parse5": "2.2.0",


### PR DESCRIPTION
Add logic to validate environment based on the specified runtime version. This is required for the cases where the runtime version is not specified in the project's package.json but we need to verify if a runtime version can be used

Depends on: https://github.com/NativeScript/nativescript-doctor/pull/37