### PR TITLE
Speed up android livesync

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -363,6 +363,12 @@ declare module Mobile {
 		transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<Mobile.ILocalToDevicePathData[]>;
 		transferFile?(localFilePath: string, deviceFilePath: string): Promise<void>;
 		createFileOnDevice?(deviceFilePath: string, fileContent: string): Promise<void>;
+		/**
+		 * Updates the hash file on device with the current hashes of files.
+		 * @param hashes - All file's hashes
+		 * @param appIdentifier - The identifier of the application.
+		 */
+		updateHashesOnDevice(hashes: IStringDictionary, appIdentifier: string): Promise<void>;
 	}
 
 	interface IAndroidDebugBridgeCommandOptions {
@@ -1066,7 +1072,7 @@ declare module Mobile {
 		/**
 		 * Computes the shasums of localToDevicePaths and updates hash file on device
 		 */
-		updateHashes(localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<boolean>;
+		updateHashes(localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void>;
 		/**
 		 * Computes the shasums of localToDevicePaths and removes them from hash file on device
 		 */

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -383,6 +383,7 @@ declare module Mobile {
 		executeCommand(args: string[], options?: IAndroidDebugBridgeCommandOptions): Promise<any>;
 		executeShellCommand(args: string[], options?: IAndroidDebugBridgeCommandOptions): Promise<any>;
 		pushFile(localFilePath: string, deviceFilePath: string): Promise<void>;
+		removeFile(deviceFilePath: string): Promise<void>;
 		/**
 		 * Gets the property value from device
 		 * @param deviceId The identifier of device

--- a/mobile/android/android-debug-bridge.ts
+++ b/mobile/android/android-debug-bridge.ts
@@ -135,6 +135,10 @@ export class AndroidDebugBridge implements Mobile.IAndroidDebugBridge {
 		await this.executeCommand(["push", localFilePath, deviceFilePath]);
 		await this.executeShellCommand(["chmod", "0777", fileDirectory]);
 	}
+
+	public async removeFile(deviceFilePath: string): Promise<void> {
+		await this.executeShellCommand(["rm", "-rf", deviceFilePath]);
+	}
 }
 
 $injector.register("adb", AndroidDebugBridge);

--- a/mobile/android/android-device-file-system.ts
+++ b/mobile/android/android-device-file-system.ts
@@ -106,7 +106,7 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 	}
 
 	private async pushFiles(localToDevicePaths: Mobile.ILocalToDevicePathData[]) {
-		this.$logger.trace("Changed file hashes are:", localToDevicePaths);
+		this.$logger.trace("Changed hashes are:", localToDevicePaths);
 		const transferredFiles: Mobile.ILocalToDevicePathData[] = [];
 		const transferFileAction = async (localToDevicePathData: Mobile.ILocalToDevicePathData) => {
 			transferredFiles.push(localToDevicePathData);

--- a/mobile/android/android-device-file-system.ts
+++ b/mobile/android/android-device-file-system.ts
@@ -74,11 +74,8 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 
 		await executeActionByChunks<string>(_.uniq(directoriesToChmod), DEFAULT_CHUNK_SIZE, dirsChmodAction);
 
-		// Update hashes
 		const deviceHashService = this.getDeviceHashService(deviceAppData.appIdentifier);
-		if (! await deviceHashService.updateHashes(localToDevicePaths)) {
-			this.$logger.trace("Unable to find hash file on device. The next livesync command will create it.");
-		}
+		await deviceHashService.updateHashes(localToDevicePaths);
 
 		return transferredFiles;
 	}
@@ -160,6 +157,11 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 
 	public async deleteFile(deviceFilePath: string, appIdentifier: string): Promise<void> {
 		await this.adb.executeShellCommand(["rm", "-rf", deviceFilePath]);
+	}
+
+	public async updateHashesOnDevice(hashes: IStringDictionary, appIdentifier: string): Promise<void> {
+		const deviceHashService = this.getDeviceHashService(appIdentifier);
+		await deviceHashService.uploadHashFileToDevice(hashes);
 	}
 
 	private getTempDir(): string {

--- a/mobile/android/android-device-file-system.ts
+++ b/mobile/android/android-device-file-system.ts
@@ -12,8 +12,7 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 		private $fs: IFileSystem,
 		private $logger: ILogger,
 		private $mobileHelper: Mobile.IMobileHelper,
-		private $injector: IInjector,
-		private $options: ICommonOptions) { }
+		private $injector: IInjector) { }
 
 	public async listFiles(devicePath: string, appIdentifier?: string): Promise<any> {
 		let listCommandArgs = ["ls", "-a", devicePath];
@@ -74,9 +73,6 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 
 		await executeActionByChunks<string>(_.uniq(directoriesToChmod), DEFAULT_CHUNK_SIZE, dirsChmodAction);
 
-		const deviceHashService = this.getDeviceHashService(deviceAppData.appIdentifier);
-		await deviceHashService.updateHashes(localToDevicePaths);
-
 		return transferredFiles;
 	}
 
@@ -84,28 +80,21 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 		// starting from Android 9, adb push is throwing an exception when there are subfolders
 		// the check could be removed when we start supporting only runtime versions with sockets
 		const minAndroidWithoutAdbPushDir = "9.0.0";
-		const isAdbPushDirSupported =  semver.lt(semver.coerce(deviceAppData.device.deviceInfo.version), minAndroidWithoutAdbPushDir);
-		const deviceHashService = this.getDeviceHashService(deviceAppData.appIdentifier);
-		const oldShasums = this.$options.force ? null : await deviceHashService.getShasumsFromDevice();
-		const currentShasums: IStringDictionary = await deviceHashService.generateHashesFromLocalToDevicePaths(localToDevicePaths);
+		const isAdbPushDirSupported = semver.lt(semver.coerce(deviceAppData.device.deviceInfo.version), minAndroidWithoutAdbPushDir);
+		const deviceProjectDir = await deviceAppData.getDeviceProjectRootPath();
 		let transferredLocalToDevicePaths: Mobile.ILocalToDevicePathData[] = [];
 
-		if (isAdbPushDirSupported && !oldShasums) {
+		if (isAdbPushDirSupported) {
+			await this.adb.pushFile(projectFilesPath, deviceProjectDir);
 			transferredLocalToDevicePaths = localToDevicePaths;
-			const deviceProjectDir = await deviceAppData.getDeviceProjectRootPath();
-			await this.pushProjectDir(deviceHashService.hashFileDevicePath, projectFilesPath, deviceProjectDir);
 		} else {
-			const changedShasums = deviceHashService.getChangedShasums(oldShasums, currentShasums);
-			transferredLocalToDevicePaths = await this.pushFiles(changedShasums, localToDevicePaths);
+			transferredLocalToDevicePaths = await this.pushFiles(localToDevicePaths);
 		}
 
 		if (transferredLocalToDevicePaths.length) {
-			const deviceProjectDir = await deviceAppData.getDeviceProjectRootPath();
-			const filesToChmodOnDevice = await deviceHashService.getDevicePaths(transferredLocalToDevicePaths);
+			const filesToChmodOnDevice = transferredLocalToDevicePaths.map(localToDevicePath => localToDevicePath.getDevicePath());
 			await this.chmodFiles(deviceProjectDir, filesToChmodOnDevice);
 		}
-
-		await deviceHashService.uploadHashFileToDevice(currentShasums);
 
 		return transferredLocalToDevicePaths;
 	}
@@ -116,23 +105,17 @@ export class AndroidDeviceFileSystem implements Mobile.IDeviceFileSystem {
 		await this.adb.executeShellCommand([commandsDeviceFilePath]);
 	}
 
-	private async pushFiles(changedShasums: IStringDictionary, localToDevicePaths: Mobile.ILocalToDevicePathData[]) {
-		this.$logger.trace("Changed file hashes are:", changedShasums);
+	private async pushFiles(localToDevicePaths: Mobile.ILocalToDevicePathData[]) {
+		this.$logger.trace("Changed file hashes are:", localToDevicePaths);
 		const transferredFiles: Mobile.ILocalToDevicePathData[] = [];
-		const transferFileAction = async (hash: string, filePath: string) => {
-			const localToDevicePathData = _.find(localToDevicePaths, ldp => ldp.getLocalPath() === filePath);
+		const transferFileAction = async (localToDevicePathData: Mobile.ILocalToDevicePathData) => {
 			transferredFiles.push(localToDevicePathData);
-			return this.transferFile(localToDevicePathData.getLocalPath(), localToDevicePathData.getDevicePath());
+			await this.transferFile(localToDevicePathData.getLocalPath(), localToDevicePathData.getDevicePath());
 		};
 
-		await executeActionByChunks<string>(changedShasums, DEFAULT_CHUNK_SIZE, transferFileAction);
+		await executeActionByChunks<Mobile.ILocalToDevicePathData>(localToDevicePaths, DEFAULT_CHUNK_SIZE, transferFileAction);
 
 		return transferredFiles;
-	}
-
-	private async pushProjectDir(hashFileDevicePath: string, projectDir: string, deviceProjectDir: string) {
-		await this.adb.executeShellCommand(["rm", "-rf", hashFileDevicePath]);
-		await this.adb.pushFile(projectDir, deviceProjectDir);
 	}
 
 	public async transferFile(localPath: string, devicePath: string): Promise<void> {

--- a/mobile/android/android-device-hash-service.ts
+++ b/mobile/android/android-device-hash-service.ts
@@ -38,17 +38,11 @@ export class AndroidDeviceHashService implements Mobile.IAndroidDeviceHashServic
 		await this.adb.pushFile(this.hashFileLocalPath, this.hashFileDevicePath);
 	}
 
-	public async updateHashes(localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<boolean> {
-		const oldShasums = await this.getShasumsFromDevice();
-		if (oldShasums) {
-			await this.generateHashesFromLocalToDevicePaths(localToDevicePaths, oldShasums);
+	public async updateHashes(localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void> {
+		const oldShasums = await this.getShasumsFromDevice() || {};
+		await this.generateHashesFromLocalToDevicePaths(localToDevicePaths, oldShasums);
 
-			await this.uploadHashFileToDevice(oldShasums);
-
-			return true;
-		}
-
-		return false;
+		await this.uploadHashFileToDevice(oldShasums);
 	}
 
 	public async generateHashesFromLocalToDevicePaths(localToDevicePaths: Mobile.ILocalToDevicePathData[], initialShasums: IStringDictionary = {}): Promise<IStringDictionary> {

--- a/mobile/ios/device/ios-device-file-system.ts
+++ b/mobile/ios/device/ios-device-file-system.ts
@@ -66,6 +66,8 @@ export class IOSDeviceFileSystem implements Mobile.IDeviceFileSystem {
 		return localToDevicePaths;
 	}
 
+	public async updateHashesOnDevice(hashes: IStringDictionary, appIdentifier: string): Promise<void> { return; }
+
 	private async uploadFilesCore(filesToUpload: IOSDeviceLib.IUploadFilesData[]): Promise<void> {
 		await this.$iosDeviceOperations.uploadFiles(filesToUpload, (err: IOSDeviceLib.IDeviceError) => {
 			if (err.deviceId === this.device.deviceInfo.identifier) {

--- a/mobile/ios/simulator/ios-simulator-file-system.ts
+++ b/mobile/ios/simulator/ios-simulator-file-system.ts
@@ -48,4 +48,6 @@ export class IOSSimulatorFileSystem implements Mobile.IDeviceFileSystem {
 			shelljs.cp("-f", localFilePath, deviceFilePath);
 		}
 	}
+
+	public updateHashesOnDevice(hashes: IStringDictionary, appIdentifier: string): Promise<void> { return; }
 }

--- a/test/unit-tests/mobile/android-device-file-system.ts
+++ b/test/unit-tests/mobile/android-device-file-system.ts
@@ -89,6 +89,7 @@ function createTestInjector(): IInjector {
 	injector.register("errors", Errors);
 	injector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilitiesMock);
 	injector.register("devicePlatformsConstants", DevicePlatformsConstants);
+	injector.register("projectFilesManager", {});
 
 	return injector;
 }

--- a/test/unit-tests/mobile/android-device-file-system.ts
+++ b/test/unit-tests/mobile/android-device-file-system.ts
@@ -1,7 +1,6 @@
 import { AndroidDeviceFileSystem } from "../../../mobile/android/android-device-file-system";
 import { Yok } from "../../../yok";
 import { Errors } from "../../../errors";
-import { FileSystem } from "../../../file-system";
 import { Logger } from "../../../logger";
 import { MobileHelper } from "../../../mobile/mobile-helper";
 import { DevicePlatformsConstants } from "../../../mobile/device-platforms-constants";
@@ -13,8 +12,7 @@ import { LiveSyncPaths } from "../../../constants";
 const myTestAppIdentifier = "org.nativescript.myApp";
 let isAdbPushExecuted = false;
 let isAdbPushAppDirCalled = false;
-let androidDeviceFileSystem: any;
-let transferredFilesOnDevice: string[] = [];
+let androidDeviceFileSystem: Mobile.IDeviceFileSystem;
 
 class AndroidDebugBridgeMock {
 	public executeCommand(args: string[]) {
@@ -81,7 +79,7 @@ function mockFsStats(options: { isDirectory: boolean, isFile: boolean }): (fileP
 
 function createTestInjector(): IInjector {
 	const injector = new Yok();
-	injector.register("fs", FileSystem);
+	injector.register("fs", {});
 	injector.register("logger", Logger);
 	injector.register("mobileHelper", MobileHelper);
 	injector.register("config", {});
@@ -101,80 +99,53 @@ function createAndroidDeviceFileSystem(injector: IInjector) {
 	return androidDeviceFS;
 }
 
-function createDeviceAppData(androidVersion?: string) {
+function createDeviceAppData(androidVersion?: string): Mobile.IDeviceAppData {
 	return {
-		getDeviceProjectRootPath: async () => `${LiveSyncPaths.ANDROID_TMP_DIR_NAME}/${LiveSyncPaths.SYNC_DIR_NAME}`, appIdentifier: myTestAppIdentifier,
-		device: {
+		getDeviceProjectRootPath: async () => `${LiveSyncPaths.ANDROID_TMP_DIR_NAME}/${LiveSyncPaths.SYNC_DIR_NAME}`,
+		appIdentifier: myTestAppIdentifier,
+		device: <Mobile.IDevice>{
 			deviceInfo: {
 				version: androidVersion || "8.1.2"
 			}
-		}
+		},
+		isLiveSyncSupported: async () => true,
+		platform: "Android"
 	};
 }
 
 function setup(options?: {
-	addHashesFile?: boolean,
-	addUnmodifiedFile?: boolean,
-	forceTransfer?: boolean
 	deviceAndroidVersion?: string,
-	modifiedFileLocalName?: string,
-	unmodifiedFileLocalName?: string
 }) {
 	options = options || {};
+	const injector = createTestInjector();
+
 	const projectRoot = "~/TestApp/app";
 	const modifiedFileName = "test.js";
 	const unmodifiedFileName = "notChangedFile.js";
-	const modifiedFileLocalName = `${projectRoot}/${options.modifiedFileLocalName || modifiedFileName}`;
-	const unmodifiedFileLocalName = `${projectRoot}/${options.unmodifiedFileLocalName || unmodifiedFileName}`;
-	const filesToShasums: IStringDictionary = {};
-	filesToShasums[modifiedFileLocalName] = "1";
-	if (options.addUnmodifiedFile) {
-		filesToShasums[unmodifiedFileLocalName] = "2";
-	}
-	const injector = createTestInjector();
-	const deviceAppData = createDeviceAppData(options.deviceAndroidVersion);
-	const opts = injector.resolve("options");
-	opts.force = options.forceTransfer || false;
-	const localToDevicePaths = _.keys(filesToShasums).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
-	const fs = injector.resolve("fs");
-	fs.getFileShasum = async (filePath: string) => filesToShasums[filePath];
-	fs.exists = (filePath: string) => options.addHashesFile ? true : false;
-	fs.readText = () => "";
-	fs.readJson = (filePath: string) => {
-		const deviceHashesFileContent: IStringDictionary = {};
-		deviceHashesFileContent[`${projectRoot}/${modifiedFileName}`] = "11";
-		if (options.addUnmodifiedFile) {
-			deviceHashesFileContent[`${projectRoot}/${unmodifiedFileName}`] = "2";
-		}
+	const files = [`${projectRoot}/${modifiedFileName}`, `${projectRoot}/${unmodifiedFileName}`];
+	const localToDevicePaths = _.map(files, file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
 
-		return deviceHashesFileContent;
-	};
+	const deviceAppData = createDeviceAppData(options.deviceAndroidVersion);
+
+	const fs = injector.resolve("fs");
 	fs.getFsStats = mockFsStats({ isDirectory: false, isFile: true });
 
 	androidDeviceFileSystem = createAndroidDeviceFileSystem(injector);
-	androidDeviceFileSystem.transferFile = (localPath: string, devicePath: string) => {
-		transferredFilesOnDevice.push(localPath);
-	};
 
 	isAdbPushExecuted = false;
 	isAdbPushAppDirCalled = false;
-	transferredFilesOnDevice = [];
 
 	return {
 		localToDevicePaths,
 		deviceAppData,
-		projectRoot,
-		modifiedFileLocalName,
-		unmodifiedFileLocalName
+		projectRoot
 	};
 }
 
 describe("AndroidDeviceFileSystem", () => {
 	describe("transferDirectory", () => {
 		it("pushes the whole directory when hash file doesn't exist on device", async () => {
-			const testSetup = setup({
-				addHashesFile: false
-			});
+			const testSetup = setup();
 
 			await androidDeviceFileSystem.transferDirectory(testSetup.deviceAppData, testSetup.localToDevicePaths, testSetup.projectRoot);
 
@@ -184,7 +155,6 @@ describe("AndroidDeviceFileSystem", () => {
 
 		it("pushes the whole directory file by file on Android P when hash file doesn't exist on device", async () => {
 			const testSetup = setup({
-				addHashesFile: false,
 				deviceAndroidVersion: "9"
 			});
 
@@ -196,7 +166,6 @@ describe("AndroidDeviceFileSystem", () => {
 
 		it("pushes the whole directory file by file on any future Android version when hash file doesn't exist on device", async () => {
 			const testSetup = setup({
-				addHashesFile: false,
 				deviceAndroidVersion: "999"
 			});
 
@@ -206,80 +175,14 @@ describe("AndroidDeviceFileSystem", () => {
 			assert.isFalse(isAdbPushAppDirCalled);
 		});
 
-		it("pushes the whole directory when force option is specified", async () => {
+		it("pushes the whole directory file by file on Android P", async () => {
 			const testSetup = setup({
-				addHashesFile: false,
-				forceTransfer: true
-			});
-
-			await androidDeviceFileSystem.transferDirectory(testSetup.deviceAppData, [], testSetup.projectRoot);
-
-			assert.isTrue(isAdbPushExecuted);
-			assert.isTrue(isAdbPushAppDirCalled);
-		});
-
-		it("pushes the whole directory file by file on Android P when force option is specified", async () => {
-			const testSetup = setup({
-				addHashesFile: false,
-				forceTransfer: true,
 				deviceAndroidVersion: "9"
 			});
 
-			await androidDeviceFileSystem.transferDirectory(testSetup.deviceAppData, [], testSetup.projectRoot);
+			await androidDeviceFileSystem.transferDirectory(testSetup.deviceAppData, testSetup.localToDevicePaths, testSetup.projectRoot);
 
 			assert.isTrue(isAdbPushExecuted);
-			assert.isFalse(isAdbPushAppDirCalled);
-		});
-
-		it("pushes only changed file when hash file exists on device", async () => {
-			const testSetup = setup({
-				addHashesFile: true
-			});
-
-			await androidDeviceFileSystem.transferDirectory(testSetup.deviceAppData, testSetup.localToDevicePaths, testSetup.projectRoot);
-
-			assert.equal(transferredFilesOnDevice.length, 1);
-			assert.equal(transferredFilesOnDevice[0], testSetup.modifiedFileLocalName);
-			assert.isFalse(isAdbPushAppDirCalled);
-		});
-
-		it("pushes only changed files when hashes file exists on device", async () => {
-			const testSetup = setup({
-				addHashesFile: true,
-				addUnmodifiedFile: true
-			});
-
-			await androidDeviceFileSystem.transferDirectory(testSetup.deviceAppData, testSetup.localToDevicePaths, testSetup.projectRoot);
-
-			assert.equal(transferredFilesOnDevice.length, 1);
-			assert.equal(transferredFilesOnDevice[0], testSetup.modifiedFileLocalName);
-			assert.isFalse(isAdbPushAppDirCalled);
-		});
-
-		it("pushes files which has different location when hash file exists on device", async () => {
-			const testSetup = setup({
-				addHashesFile: true,
-				addUnmodifiedFile: true,
-				unmodifiedFileLocalName: "newLocation/notChangedFile.js"
-			});
-
-			await androidDeviceFileSystem.transferDirectory(testSetup.deviceAppData, testSetup.localToDevicePaths, testSetup.projectRoot);
-
-			assert.equal(transferredFilesOnDevice.length, 2);
-			assert.isTrue(_.includes(transferredFilesOnDevice, testSetup.unmodifiedFileLocalName));
-			assert.isFalse(isAdbPushAppDirCalled);
-		});
-
-		it("pushes files which has different location and different shasum when hash file exists on device", async () => {
-			const testSetup = setup({
-				addHashesFile: true,
-				modifiedFileLocalName: "newLocation/test.js"
-			});
-
-			await androidDeviceFileSystem.transferDirectory(testSetup.deviceAppData, testSetup.localToDevicePaths, testSetup.projectRoot);
-
-			assert.equal(transferredFilesOnDevice.length, 1);
-			assert.equal(transferredFilesOnDevice[0], testSetup.modifiedFileLocalName);
 			assert.isFalse(isAdbPushAppDirCalled);
 		});
 	});


### PR DESCRIPTION
`tns run android` command transfers all files on initial sync. Actually there is no need to transfer all files on device because the installed `.apk` contains them. So after the application is installed on device, calculate the hashes for files inside `\plaforms\android\app\*` and upload the hash file on device. When the initial sync is executed {N} CLI compares the hashes and no file is transferred on device because all files are the same (no change is occurred). This PR speeds up the initial livesync with around 15seconds for angular application.