### PR TITLE
feat: Speed up device detection

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1246,7 +1246,11 @@ interface IProfileDir {
 	profileDir: string;
 }
 
-interface ICommonOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvailableDevices, IProfileDir {
+interface IHasEmulatorOption {
+	emulator: boolean;
+}
+
+interface ICommonOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvailableDevices, IProfileDir, IHasEmulatorOption {
 	argv: IYargArgv;
 	validateOptions(commandSpecificDashedOptions?: IDictionary<IDashedOption>): void;
 	options: IDictionary<any>;
@@ -1276,7 +1280,6 @@ interface ICommonOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd,
 	analyticsClient: string;
 	force: boolean;
 	companion: boolean;
-	emulator: boolean;
 	sdk: string;
 	template: string;
 	certificate: string;

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -408,6 +408,10 @@ declare module Mobile {
 		 * Specifies whether we should skip the emulator starting.
 		 */
 		skipEmulatorStart?: boolean;
+		/**
+		 * Defines if the initialization should await the whole iOS detection to finish or it can just start the detection.
+		 */
+		shouldReturnImmediateResult?: boolean;
 	}
 
 	interface IDeviceActionResult<T> extends IDeviceIdentifier {
@@ -417,13 +421,6 @@ declare module Mobile {
 	interface IDevicesService extends NodeJS.EventEmitter, IPlatform {
 		hasDevices: boolean;
 		deviceCount: number;
-
-		/**
-		 * Optionally starts emulator depending on the passed options.
-		 * @param {IDevicesServicesInitializationOptions} data Defines wheather to start default or specific emulator.
-		 * @return {Promise<void>}
-		 */
-		startEmulatorIfNecessary(data?: Mobile.IDevicesServicesInitializationOptions): Promise<void>;
 
 		execute<T>(action: (device: Mobile.IDevice) => Promise<T>, canExecute?: (dev: Mobile.IDevice) => boolean, options?: { allowNoDevices?: boolean }): Promise<IDeviceActionResult<T>[]>;
 
@@ -458,11 +455,8 @@ declare module Mobile {
 		isAppInstalledOnDevices(deviceIdentifiers: string[], appIdentifier: string, framework: string): Promise<IAppInstalledInfo>[];
 		setLogLevel(logLevel: string, deviceIdentifier?: string): void;
 		deployOnDevices(deviceIdentifiers: string[], packageFile: string, packageName: string, framework: string): Promise<void>[];
-		startDeviceDetectionInterval(): Promise<void>;
 		getDeviceByIdentifier(identifier: string): Mobile.IDevice;
 		mapAbstractToTcpPort(deviceIdentifier: string, appIdentifier: string, framework: string): Promise<string>;
-		detectCurrentlyAttachedDevices(options?: Mobile.IDeviceLookingOptions): Promise<void>;
-		startEmulator(platform?: string, emulatorImage?: string): Promise<void>;
 		isCompanionAppInstalledOnDevices(deviceIdentifiers: string[], framework: string): Promise<IAppInstalledInfo>[];
 		getDebuggableApps(deviceIdentifiers: string[]): Promise<Mobile.IDeviceApplicationInformation[]>[];
 		getDebuggableViews(deviceIdentifier: string, appIdentifier: string): Promise<Mobile.IDebugWebViewInfo[]>;
@@ -748,9 +742,9 @@ declare module Mobile {
 		resolveProductName(deviceType: string): string;
 	}
 
-	interface IDeviceLookingOptions {
+	interface IDeviceLookingOptions extends IHasEmulatorOption {
 		shouldReturnImmediateResult: boolean;
-		platform: string
+		platform: string;
 	}
 
 	interface IAndroidDeviceHashService {

--- a/mobile/mobile-core/ios-device-discovery.ts
+++ b/mobile/mobile-core/ios-device-discovery.ts
@@ -25,9 +25,12 @@ export class IOSDeviceDiscovery extends DeviceDiscovery {
 	}
 
 	public async startLookingForDevices(options?: Mobile.IDeviceLookingOptions): Promise<void> {
-		if (options && options.platform && !this.$mobileHelper.isiOSPlatform(options.platform)) {
+		this.$logger.trace("Options for ios-device-discovery", options);
+
+		if (options && options.platform && (!this.$mobileHelper.isiOSPlatform(options.platform) || options.emulator)) {
 			return;
 		}
+
 		if (this.validateiTunes()) {
 			await this.$iosDeviceOperations.startLookingForDevices((deviceInfo: IOSDeviceLib.IDeviceActionInfo) => {
 				this.createAndAddDevice(deviceInfo);


### PR DESCRIPTION
Speed up device detection by:
* removing duplicate calls to all device detection services
* cache the Promise of initialize method - this way even when multiple calls are executed simultaneously, the result of the first one will be used. This allows Sidekick to call the method asynchronously.
* do not execute iOS device detection in case `--emulator` is passed

Remove several public methods from the service - make them protected as we already have tests for them.
Remove all calls to detectCurrentlyAttachedDevices method outside of the service - the initialize method will do it anyway, so no need to call it externally.
Remove duplicate calls in the startLookingForDevices method - previously it had to filter which device detection services to call. As now each device detection service checks its platform, we can safely call all of them and rely on their filters to skip the execution.