### PR TITLE
fix: Device detection is not working when --device is passed

### DIFF
--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -471,14 +471,14 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 
 		if (platform && deviceOption) {
 			this._platform = this.getPlatform(deviceInitOpts.platform);
-			this.detectCurrentlyAttachedDevices(deviceInitOpts);
+			await this.detectCurrentlyAttachedDevices(deviceInitOpts);
 			this._device = await this.getDevice(deviceOption);
 			if (this._device.deviceInfo.platform !== this._platform) {
 				this.$errors.fail(constants.ERROR_CANNOT_RESOLVE_DEVICE);
 			}
 			this.$logger.warn("Your application will be deployed only on the device specified by the provided index or identifier.");
 		} else if (!platform && deviceOption) {
-			this.detectCurrentlyAttachedDevices(deviceInitOpts);
+			await this.detectCurrentlyAttachedDevices(deviceInitOpts);
 			this._device = await this.getDevice(deviceOption);
 			this._platform = this._device.deviceInfo.platform;
 		} else if (platform && !deviceOption) {


### PR DESCRIPTION
Due to missing await in device detection, passing `--device` is not working in some cases. Add the missing await.