### PR TITLE
Fix the message for missing android emulator to be consistent with iOS

### DIFF
--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -73,7 +73,7 @@ export class AndroidEmulatorServices implements Mobile.IEmulatorPlatformService 
 		if (!emulator) {
 			return {
 				runningEmulator: null,
-				errors: [`No emulator image available for emulator '${options.emulatorIdOrName || options.imageIdentifier}'.`],
+				errors: [`No emulator image available for device identifier '${options.emulatorIdOrName || options.imageIdentifier}'.`],
 				endTimeEpoch
 			};
 		}


### PR DESCRIPTION
Fix the message to be consistent with the one here:  https://github.com/telerik/ios-sim-portable/blob/a8740c16eef3fe7e75a0e5950a2bc65cfeb77994/lib/iphone-simulator-xcode-simctl.ts#L253