### PR TITLE
fix: checking for iOS simulators on windows

### DIFF
--- a/mobile/mobile-core/ios-simulator-discovery.ts
+++ b/mobile/mobile-core/ios-simulator-discovery.ts
@@ -38,7 +38,11 @@ export class IOSSimulatorDiscovery extends DeviceDiscovery {
 		}
 	}
 
-	public async checkForAvailableSimulators() {
+	public async checkForAvailableSimulators(): Promise<Mobile.IDeviceInfo[]> {
+		if (!this.$hostInfo.isDarwin) {
+			return [];
+		}
+
 		const simulators = (await this.$iOSEmulatorServices.getAvailableEmulators()).devices;
 		const currentSimulators = _.values(this.availableSimulators);
 		const lostSimulators: Mobile.IDeviceInfo[] = [];


### PR DESCRIPTION
We don't check what is the operating system before executing shell commands for detecting running iOS simulators.