### PR TITLE
chore: Rename exposed methods and events for emulators

### DIFF
--- a/appbuilder/device-emitter.ts
+++ b/appbuilder/device-emitter.ts
@@ -36,12 +36,12 @@ export class DeviceEmitter extends EventEmitter {
 			this.emit(DEVICE_LOG_EVENT_NAME, identifier, data.toString());
 		});
 
-		this.$devicesService.on(EmulatorDiscoveryNames.EMULATOR_IMAGES_FOUND, (emulator: Mobile.IDeviceInfo) => {
-			this.emit(EmulatorDiscoveryNames.EMULATOR_IMAGES_FOUND, emulator);
+		this.$devicesService.on(EmulatorDiscoveryNames.EMULATOR_IMAGE_FOUND, (emulator: Mobile.IDeviceInfo) => {
+			this.emit(EmulatorDiscoveryNames.EMULATOR_IMAGE_FOUND, emulator);
 		});
 
-		this.$devicesService.on(EmulatorDiscoveryNames.EMULATOR_IMAGES_LOST, (emulator: Mobile.IDeviceInfo) => {
-			this.emit(EmulatorDiscoveryNames.EMULATOR_IMAGES_LOST, emulator);
+		this.$devicesService.on(EmulatorDiscoveryNames.EMULATOR_IMAGE_LOST, (emulator: Mobile.IDeviceInfo) => {
+			this.emit(EmulatorDiscoveryNames.EMULATOR_IMAGE_LOST, emulator);
 		});
 	}
 

--- a/commands/device/list-devices.ts
+++ b/commands/device/list-devices.ts
@@ -18,7 +18,7 @@ export class ListDevicesCommand implements ICommand {
 				this.$errors.failWithoutHelp(`${args[0]} is not a valid device platform. The valid platforms are ${formatListOfNames(this.$mobileHelper.platformNames)}`);
 			}
 
-			const availableEmulatorsOutput = await this.$devicesService.getAvailableEmulators({ platform });
+			const availableEmulatorsOutput = await this.$devicesService.getEmulatorImages({ platform });
 			const emulators = this.$emulatorHelper.getEmulatorsFromAvailableEmulatorsOutput(availableEmulatorsOutput);
 			this.printEmulators("\nAvailable emulators", emulators);
 		}

--- a/constants.ts
+++ b/constants.ts
@@ -55,8 +55,8 @@ export class DeviceDiscoveryEventNames {
 }
 
 export class EmulatorDiscoveryNames {
-	static EMULATOR_IMAGES_FOUND = "emulatorImagesFound";
-	static EMULATOR_IMAGES_LOST = "emulatorImagesLost";
+	static EMULATOR_IMAGE_FOUND = "emulatorImageFound";
+	static EMULATOR_IMAGE_LOST = "emulatorImageLost";
 }
 
 export const DEVICE_LOG_EVENT_NAME = "deviceLogData";

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -502,7 +502,7 @@ declare module Mobile {
 		 * @param options The options that can be passed to filter the result.
 		 * @returns {Promise<Mobile.IListEmulatorsOutput>} Dictionary with the following format: { ios: { devices: Mobile.IDeviceInfo[], errors: string[] }, android: { devices: Mobile.IDeviceInfo[], errors: string[]}}.
 		 */
-		getAvailableEmulators(options?: Mobile.IListEmulatorsOptions): Promise<Mobile.IListEmulatorsOutput>;
+		getEmulatorImages(options?: Mobile.IListEmulatorsOptions): Promise<Mobile.IListEmulatorsOutput>;
 
 		/**
 		 * Starts an emulator by provided options.
@@ -516,12 +516,12 @@ declare module Mobile {
 		platform?: string;
 	}
 
-	interface IListEmulatorsOutput extends IDictionary<IAvailableEmulatorsOutput> {
-		ios: IAvailableEmulatorsOutput;
-		android: IAvailableEmulatorsOutput;
+	interface IListEmulatorsOutput extends IDictionary<IEmulatorImagesOutput> {
+		ios: IEmulatorImagesOutput;
+		android: IEmulatorImagesOutput;
 	}
 
-	interface IAvailableEmulatorsOutput {
+	interface IEmulatorImagesOutput {
 		devices: Mobile.IDeviceInfo[];
 		errors: string[];
 	}
@@ -675,9 +675,9 @@ declare module Mobile {
 	interface IEmulatorPlatformService {
 		/**
 		 * Gets all available emulators
-		 * @returns {Promise<Mobile.IAvailableEmulatorsOutput>}
+		 * @returns {Promise<Mobile.IEmulatorImagesOutput>}
 		 */
-		getAvailableEmulators(): Promise<Mobile.IAvailableEmulatorsOutput>;
+		getEmulatorImages(): Promise<Mobile.IEmulatorImagesOutput>;
 		/**
 		 * Gets the ids of all running emulators
 		 * @returns {Promise<string[]>}
@@ -710,10 +710,10 @@ declare module Mobile {
 	interface IAndroidVirtualDeviceService {
 		/**
 		 * Gets all available emulators.
-		 * @returns {Promise<Mobile.IAvailableEmulatorsOutput>} - Dictionary in the following format: { devices: Mobile.IDevice[], errors: string[] }.
+		 * @returns {Promise<Mobile.IEmulatorImagesOutput>} - Dictionary in the following format: { devices: Mobile.IDevice[], errors: string[] }.
 		 * Returns array of all available android emulators - genymotion and native avd emulators and array of errors.
 		 */
-		getAvailableEmulators(adbDevicesOutput: string[]): Promise<Mobile.IAvailableEmulatorsOutput>;
+		getEmulatorImages(adbDevicesOutput: string[]): Promise<Mobile.IEmulatorImagesOutput>;
 		/**
 		 * Gets all identifiers of all running android emulators.
 		 * @param adbDevicesOutput The output from "adb devices" command

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -11,10 +11,10 @@ export class AndroidEmulatorServices implements Mobile.IEmulatorPlatformService 
 		private $logger: ILogger,
 		private $utils: IUtils) { }
 
-	public async getAvailableEmulators(): Promise<Mobile.IAvailableEmulatorsOutput> {
+	public async getEmulatorImages(): Promise<Mobile.IEmulatorImagesOutput> {
 		const adbDevicesOutput = await this.$adb.getDevices();
-		const avdAvailableEmulatorsOutput = await this.$androidVirtualDeviceService.getAvailableEmulators(adbDevicesOutput);
-		const genyAvailableDevicesOutput = await this.$androidGenymotionService.getAvailableEmulators(adbDevicesOutput);
+		const avdAvailableEmulatorsOutput = await this.$androidVirtualDeviceService.getEmulatorImages(adbDevicesOutput);
+		const genyAvailableDevicesOutput = await this.$androidGenymotionService.getEmulatorImages(adbDevicesOutput);
 
 		return {
 			devices: avdAvailableEmulatorsOutput.devices.concat(genyAvailableDevicesOutput.devices),
@@ -63,7 +63,7 @@ export class AndroidEmulatorServices implements Mobile.IEmulatorPlatformService 
 		const timeout = options.timeout || AndroidVirtualDevice.TIMEOUT_SECONDS;
 		const endTimeEpoch = getCurrentEpochTime() + this.$utils.getMilliSecondsTimeout(timeout);
 
-		const availableEmulators = (await this.getAvailableEmulators()).devices;
+		const availableEmulators = (await this.getEmulatorImages()).devices;
 
 		let emulator = this.$emulatorHelper.getEmulatorByStartEmulatorOptions(options, availableEmulators);
 		if (!emulator && !options.emulatorIdOrName && !options.imageIdentifier && !options.emulator) {
@@ -92,7 +92,7 @@ export class AndroidEmulatorServices implements Mobile.IEmulatorPlatformService 
 		let hasTimeLeft = getCurrentEpochTime() < endTimeEpoch;
 
 		while (hasTimeLeft || isInfiniteWait) {
-			const emulators = (await this.getAvailableEmulators()).devices;
+			const emulators = (await this.getEmulatorImages()).devices;
 			emulator = _.find(emulators, e => e.imageIdentifier === emulator.imageIdentifier);
 			if (emulator && this.$emulatorHelper.isEmulatorRunning(emulator)) {
 				return {

--- a/mobile/android/android-virtual-device-service.ts
+++ b/mobile/android/android-virtual-device-service.ts
@@ -20,8 +20,8 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 			this.androidHome = process.env.ANDROID_HOME;
 		}
 
-	public async getAvailableEmulators(adbDevicesOutput: string[]): Promise<Mobile.IAvailableEmulatorsOutput> {
-		const availableEmulatorsOutput = await this.getAvailableEmulatorsCore();
+	public async getEmulatorImages(adbDevicesOutput: string[]): Promise<Mobile.IEmulatorImagesOutput> {
+		const availableEmulatorsOutput = await this.getEmulatorImagesCore();
 		const avds = availableEmulatorsOutput.devices;
 		const runningEmulatorIds = await this.getRunningEmulatorIds(adbDevicesOutput);
 		const runningEmulators = await settlePromises(_.map(runningEmulatorIds, emulatorId => this.getRunningEmulatorData(emulatorId, avds)));
@@ -130,7 +130,7 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 		});
 	}
 
-	private async getAvailableEmulatorsCore(): Promise<Mobile.IAvailableEmulatorsOutput> {
+	private async getEmulatorImagesCore(): Promise<Mobile.IEmulatorImagesOutput> {
 		let result: ISpawnResult = null;
 		let devices: Mobile.IDeviceInfo[] = [];
 

--- a/mobile/android/genymotion/genymotion-service.ts
+++ b/mobile/android/genymotion/genymotion-service.ts
@@ -14,8 +14,8 @@ export class AndroidGenymotionService implements Mobile.IAndroidVirtualDeviceSer
 		private $logger: ILogger,
 		private $virtualBoxService: Mobile.IVirtualBoxService) { }
 
-	public async getAvailableEmulators(adbDevicesOutput: string[]): Promise<Mobile.IAvailableEmulatorsOutput> {
-		const availableEmulatorsOutput = await this.getAvailableEmulatorsCore();
+	public async getEmulatorImages(adbDevicesOutput: string[]): Promise<Mobile.IEmulatorImagesOutput> {
+		const availableEmulatorsOutput = await this.getEmulatorImagesCore();
 		const runningEmulatorIds = await this.getRunningEmulatorIds(adbDevicesOutput);
 		const runningEmulators = await settlePromises(_.map(runningEmulatorIds, emulatorId => this.getRunningEmulatorData(emulatorId, availableEmulatorsOutput.devices)));
 		const devices = availableEmulatorsOutput.devices.map(emulator => this.$emulatorHelper.getEmulatorByImageIdentifier(emulator.imageIdentifier, runningEmulators) || emulator);
@@ -57,7 +57,7 @@ export class AndroidGenymotionService implements Mobile.IAndroidVirtualDeviceSer
 		return ["--vm-name", imageIdentifier];
 	}
 
-	private async getAvailableEmulatorsCore(): Promise<Mobile.IAvailableEmulatorsOutput> {
+	private async getEmulatorImagesCore(): Promise<Mobile.IEmulatorImagesOutput> {
 		const output = await this.$virtualBoxService.listVms();
 		if (output.error) {
 			return { devices: [], errors: output.error ? [output.error] : [] };
@@ -74,7 +74,7 @@ export class AndroidGenymotionService implements Mobile.IAndroidVirtualDeviceSer
 	}
 
 	public async getRunningEmulatorImageIdentifier(emulatorId: string): Promise<string> {
-		const emulator = await this.getRunningEmulatorData(emulatorId, (await this.getAvailableEmulators(await this.$adb.getDevices())).devices);
+		const emulator = await this.getRunningEmulatorData(emulatorId, (await this.getEmulatorImages(await this.$adb.getDevices())).devices);
 		return emulator ? emulator.imageIdentifier : null;
 	}
 

--- a/mobile/emulator-helper.ts
+++ b/mobile/emulator-helper.ts
@@ -20,7 +20,7 @@ export class EmulatorHelper implements Mobile.IEmulatorHelper {
 	public getEmulatorsFromAvailableEmulatorsOutput(availableEmulatorsOutput: Mobile.IListEmulatorsOutput): Mobile.IDeviceInfo[] {
 		return <Mobile.IDeviceInfo[]>(_(availableEmulatorsOutput)
 			.valuesIn()
-			.map((value: Mobile.IAvailableEmulatorsOutput) => value.devices)
+			.map((value: Mobile.IEmulatorImagesOutput) => value.devices)
 			.concat()
 			.flatten()
 			.value());
@@ -29,7 +29,7 @@ export class EmulatorHelper implements Mobile.IEmulatorHelper {
 	public getErrorsFromAvailableEmulatorsOutput(availableEmulatorsOutput: Mobile.IListEmulatorsOutput): string[] {
 		return <string[]>(_(availableEmulatorsOutput)
 			.valuesIn()
-			.map((value: Mobile.IAvailableEmulatorsOutput) => value.errors)
+			.map((value: Mobile.IEmulatorImagesOutput) => value.errors)
 			.concat()
 			.flatten()
 			.value());

--- a/mobile/ios/simulator/ios-emulator-services.ts
+++ b/mobile/ios/simulator/ios-emulator-services.ts
@@ -79,7 +79,7 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 		}
 	}
 
-	public async getAvailableEmulators(): Promise<Mobile.IAvailableEmulatorsOutput> {
+	public async getEmulatorImages(): Promise<Mobile.IEmulatorImagesOutput> {
 		let devices: Mobile.IDeviceInfo[] = [];
 		const errors: string[] = [];
 

--- a/mobile/mobile-core/android-emulator-discovery.ts
+++ b/mobile/mobile-core/android-emulator-discovery.ts
@@ -12,7 +12,7 @@ export class AndroidEmulatorDiscovery extends EventEmitter implements Mobile.IDe
 			return;
 		}
 
-		const availableEmulatorsOutput = await this.$androidEmulatorServices.getAvailableEmulators();
+		const availableEmulatorsOutput = await this.$androidEmulatorServices.getEmulatorImages();
 		const currentEmulators = availableEmulatorsOutput.devices;
 		const cachedEmulators = _.values(this._emulators);
 
@@ -40,13 +40,17 @@ export class AndroidEmulatorDiscovery extends EventEmitter implements Mobile.IDe
 	}
 
 	private raiseOnEmulatorImagesFound(emulators: Mobile.IDeviceInfo[]) {
-		_.forEach(emulators, emulator => this._emulators[emulator.imageIdentifier] = emulator);
-		this.emit(EmulatorDiscoveryNames.EMULATOR_IMAGES_FOUND, emulators);
+		_.forEach(emulators, emulator => {
+			this._emulators[emulator.imageIdentifier] = emulator;
+			this.emit(EmulatorDiscoveryNames.EMULATOR_IMAGE_FOUND, emulator);
+		});
 	}
 
 	private raiseOnEmulatorImagesLost(emulators: Mobile.IDeviceInfo[]) {
-		_.forEach(emulators, emulator => delete this._emulators[emulator.imageIdentifier]);
-		this.emit(EmulatorDiscoveryNames.EMULATOR_IMAGES_LOST, emulators);
+		_.forEach(emulators, emulator => {
+			delete this._emulators[emulator.imageIdentifier];
+			this.emit(EmulatorDiscoveryNames.EMULATOR_IMAGE_LOST, emulator);
+		});
 	}
 }
 $injector.register("androidEmulatorDiscovery", AndroidEmulatorDiscovery);

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -50,15 +50,15 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	}
 
 	@exported("devicesService")
-	public async getAvailableEmulators(options?: Mobile.IListEmulatorsOptions): Promise<Mobile.IListEmulatorsOutput> {
+	public async getEmulatorImages(options?: Mobile.IListEmulatorsOptions): Promise<Mobile.IListEmulatorsOutput> {
 		const result = Object.create(null);
 
 		if (this.$hostInfo.isDarwin && (!options || !options.platform || this.$mobileHelper.isiOSPlatform(options.platform))) {
-			result.ios = await this.$iOSEmulatorServices.getAvailableEmulators();
+			result.ios = await this.$iOSEmulatorServices.getEmulatorImages();
 		}
 
 		if (!options || !options.platform || this.$mobileHelper.isAndroidPlatform(options.platform)) {
-			result.android = await this.$androidEmulatorServices.getAvailableEmulators();
+			result.android = await this.$androidEmulatorServices.getEmulatorImages();
 		}
 
 		return result;
@@ -72,7 +72,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 			return ["Missing mandatory image identifier or name option."];
 		}
 
-		const availableEmulatorsOutput = await this.getAvailableEmulators({platform: options.platform});
+		const availableEmulatorsOutput = await this.getEmulatorImages({platform: options.platform});
 		const emulators = this.$emulatorHelper.getEmulatorsFromAvailableEmulatorsOutput(availableEmulatorsOutput);
 		const errors = this.$emulatorHelper.getErrorsFromAvailableEmulatorsOutput(availableEmulatorsOutput);
 		if (errors.length) {
@@ -191,8 +191,8 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	}
 
 	private attachToKnownEmulatorDiscoveryEvents(): void {
-		this.$androidEmulatorDiscovery.on(constants.EmulatorDiscoveryNames.EMULATOR_IMAGES_FOUND, (emulators: Mobile.IDeviceInfo[]) => this.onEmulatorImagesFound(emulators));
-		this.$androidEmulatorDiscovery.on(constants.EmulatorDiscoveryNames.EMULATOR_IMAGES_LOST, (emulators: Mobile.IDeviceInfo[]) => this.onEmulatorImagesLost(emulators));
+		this.$androidEmulatorDiscovery.on(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_FOUND, (emulators: Mobile.IDeviceInfo[]) => this.onEmulatorImagesFound(emulators));
+		this.$androidEmulatorDiscovery.on(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_LOST, (emulators: Mobile.IDeviceInfo[]) => this.onEmulatorImagesLost(emulators));
 	}
 
 	private attachToDeviceDiscoveryEvents(deviceDiscovery: Mobile.IDeviceDiscovery): void {
@@ -220,13 +220,13 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	private onEmulatorImagesFound(emulators: Mobile.IDeviceInfo[]): void {
 		this.$logger.trace(`Found emulators with the following image identifiers: ${emulators.map(emulator => emulator.imageIdentifier).join(", ")}`);
 		_.forEach(emulators, emulator => this._availableEmulators[emulator.imageIdentifier] = emulator);
-		this.emit(constants.EmulatorDiscoveryNames.EMULATOR_IMAGES_FOUND, emulators);
+		this.emit(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_FOUND, emulators);
 	}
 
 	private onEmulatorImagesLost(emulators: Mobile.IDeviceInfo[]): void {
 		this.$logger.trace(`Lost emulators with the following image identifier ${emulators.map(emulator => emulator.imageIdentifier).join(", ")}`);
 		_.forEach(emulators, emulator => delete this._availableEmulators[emulator.imageIdentifier]);
-		this.emit(constants.EmulatorDiscoveryNames.EMULATOR_IMAGES_LOST, emulators);
+		this.emit(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_LOST, emulators);
 	}
 
 	/**

--- a/mobile/mobile-core/ios-simulator-discovery.ts
+++ b/mobile/mobile-core/ios-simulator-discovery.ts
@@ -43,7 +43,7 @@ export class IOSSimulatorDiscovery extends DeviceDiscovery {
 			return [];
 		}
 
-		const simulators = (await this.$iOSEmulatorServices.getAvailableEmulators()).devices;
+		const simulators = (await this.$iOSEmulatorServices.getEmulatorImages()).devices;
 		const currentSimulators = _.values(this.availableSimulators);
 		const lostSimulators: Mobile.IDeviceInfo[] = [];
 		const foundSimulators: Mobile.IDeviceInfo[] = [];
@@ -82,13 +82,17 @@ export class IOSSimulatorDiscovery extends DeviceDiscovery {
 	}
 
 	private raiseOnEmulatorImagesFound(simulators: Mobile.IDeviceInfo[]) {
-		_.forEach(simulators, simulator => this.availableSimulators[simulator.imageIdentifier] = simulator);
-		this.emit(EmulatorDiscoveryNames.EMULATOR_IMAGES_FOUND, simulators);
+		_.forEach(simulators, simulator => {
+			this.availableSimulators[simulator.imageIdentifier] = simulator;
+			this.emit(EmulatorDiscoveryNames.EMULATOR_IMAGE_FOUND, simulator);
+		});
 	}
 
 	private raiseOnEmulatorImagesLost(simulators: Mobile.IDeviceInfo[]) {
-		_.forEach(simulators, simulator => delete this.availableSimulators[simulator.imageIdentifier]);
-		this.emit(EmulatorDiscoveryNames.EMULATOR_IMAGES_LOST, simulators);
+		_.forEach(simulators, simulator => {
+			delete this.availableSimulators[simulator.imageIdentifier];
+			this.emit(EmulatorDiscoveryNames.EMULATOR_IMAGE_LOST, simulator);
+		});
 	}
 }
 

--- a/mobile/wp8/wp8-emulator-services.ts
+++ b/mobile/wp8/wp8-emulator-services.ts
@@ -37,7 +37,7 @@ class Wp8EmulatorServices implements Mobile.IEmulatorPlatformService {
 		this.$childProcess.spawn(emulatorStarter, ["/installlaunch", app, "/targetdevice:xd"], { stdio: "ignore", detached: true }).unref();
 	}
 
-	public async getAvailableEmulators(): Promise<Mobile.IAvailableEmulatorsOutput> {
+	public async getEmulatorImages(): Promise<Mobile.IEmulatorImagesOutput> {
 		return { devices: [], errors: []};
 	}
 

--- a/test/unit-tests/mobile/android-emulator-service.ts
+++ b/test/unit-tests/mobile/android-emulator-service.ts
@@ -67,9 +67,9 @@ describe("androidEmulatorService", () => {
 		androidGenymotionService = testInjector.resolve("androidGenymotionService");
 	});
 
-	function mockGetAvailableEmulators(avds: Mobile.IAvailableEmulatorsOutput, genies: Mobile.IAvailableEmulatorsOutput) {
-		androidVirtualDeviceService.getAvailableEmulators = () => Promise.resolve(avds);
-		androidGenymotionService.getAvailableEmulators = () => Promise.resolve(genies);
+	function mockGetEmulatorImages(avds: Mobile.IEmulatorImagesOutput, genies: Mobile.IEmulatorImagesOutput) {
+		androidVirtualDeviceService.getEmulatorImages = () => Promise.resolve(avds);
+		androidGenymotionService.getEmulatorImages = () => Promise.resolve(genies);
 	}
 
 	function mockGetRunningEmulatorIds(avds: string[], genies: string[]) {
@@ -77,46 +77,46 @@ describe("androidEmulatorService", () => {
 		androidGenymotionService.getRunningEmulatorIds = () => Promise.resolve(genies);
 	}
 
-	describe("getAvailableEmulators", () => {
+	describe("getEmulatorImages", () => {
 		it("should return [] when there are no emulators are available", async () => {
-			mockGetAvailableEmulators({devices: [], errors: []}, {devices: [], errors: []});
-			const output = await androidEmulatorServices.getAvailableEmulators();
+			mockGetEmulatorImages({devices: [], errors: []}, {devices: [], errors: []});
+			const output = await androidEmulatorServices.getEmulatorImages();
 			assert.deepEqual(output.devices, []);
 			assert.deepEqual(output.errors, []);
 		});
 		it("should return avd emulators when only avd emulators are available", async () => {
-			mockGetAvailableEmulators({devices: [avdEmulator], errors: []}, {devices: [], errors: []});
-			const output = await androidEmulatorServices.getAvailableEmulators();
+			mockGetEmulatorImages({devices: [avdEmulator], errors: []}, {devices: [], errors: []});
+			const output = await androidEmulatorServices.getEmulatorImages();
 			assert.deepEqual(output.devices, [avdEmulator]);
 			assert.deepEqual(output.errors, []);
 		});
 		it("should return geny emulators when only geny emulators are available", async () => {
-			mockGetAvailableEmulators({devices: [], errors: []}, {devices: [genyEmulator], errors: []});
-			const output = await androidEmulatorServices.getAvailableEmulators();
+			mockGetEmulatorImages({devices: [], errors: []}, {devices: [genyEmulator], errors: []});
+			const output = await androidEmulatorServices.getEmulatorImages();
 			assert.deepEqual(output.devices, [genyEmulator]);
 			assert.deepEqual(output.errors, []);
 		});
 		it("should return avd and geny emulators when avd and geny emulators are available", async () => {
-			mockGetAvailableEmulators({devices: [avdEmulator], errors: []}, {devices: [genyEmulator], errors: []});
-			const output = await androidEmulatorServices.getAvailableEmulators();
+			mockGetEmulatorImages({devices: [avdEmulator], errors: []}, {devices: [genyEmulator], errors: []});
+			const output = await androidEmulatorServices.getEmulatorImages();
 			assert.deepEqual(output.devices, [avdEmulator].concat([genyEmulator]));
 			assert.deepEqual(output.errors, []);
 		});
 		it("should return an error when avd error is thrown", async () => {
-			mockGetAvailableEmulators({devices: [], errors: [mockError]}, {devices: [], errors: []});
-			const output = await androidEmulatorServices.getAvailableEmulators();
+			mockGetEmulatorImages({devices: [], errors: [mockError]}, {devices: [], errors: []});
+			const output = await androidEmulatorServices.getEmulatorImages();
 			assert.deepEqual(output.devices, []);
 			assert.deepEqual(output.errors, [mockError]);
 		});
 		it("should return an error when geny error is thrown", async () => {
-			mockGetAvailableEmulators({devices: [], errors: []}, {devices: [], errors: [mockError]});
-			const output = await androidEmulatorServices.getAvailableEmulators();
+			mockGetEmulatorImages({devices: [], errors: []}, {devices: [], errors: [mockError]});
+			const output = await androidEmulatorServices.getEmulatorImages();
 			assert.deepEqual(output.devices, []);
 			assert.deepEqual(output.errors, [mockError]);
 		});
 		it("should return an error when avd and geny errors are thrown", async () => {
-			mockGetAvailableEmulators({devices: [], errors: [mockError]}, {devices: [], errors: [mockError]});
-			const output = await androidEmulatorServices.getAvailableEmulators();
+			mockGetEmulatorImages({devices: [], errors: [mockError]}, {devices: [], errors: [mockError]});
+			const output = await androidEmulatorServices.getEmulatorImages();
 			assert.deepEqual(output.devices, []);
 			assert.deepEqual(output.errors, [mockError, mockError]);
 		});
@@ -193,14 +193,14 @@ describe("androidEmulatorService", () => {
 
 		it("should start avd emulator", async () => {
 			mockGetRunningEmulatorIds([], []);
-			mockGetAvailableEmulators({devices: [avdEmulator], errors: []}, {devices: [], errors: []});
+			mockGetEmulatorImages({devices: [avdEmulator], errors: []}, {devices: [], errors: []});
 			const deviceInfo = mockStartEmulator(avdEmulator);
 			await androidEmulatorServices.startEmulator(avdEmulator);
 			assert.deepEqual(deviceInfo, avdEmulator);
 		});
 		it("should start geny emulator", async () => {
 			mockGetRunningEmulatorIds([], []);
-			mockGetAvailableEmulators({devices: [], errors: []}, {devices: [genyEmulator], errors: []});
+			mockGetEmulatorImages({devices: [], errors: []}, {devices: [genyEmulator], errors: []});
 			const deviceInfo = mockStartEmulator(genyEmulator);
 			assert.deepEqual(deviceInfo, genyEmulator);
 		});

--- a/test/unit-tests/mobile/android-virtual-device-service.ts
+++ b/test/unit-tests/mobile/android-virtual-device-service.ts
@@ -52,7 +52,7 @@ function mockParseIniFile(iniFilePath: string, data: any) {
 	}
 }
 
-function createTestInjector(data: {avdManagerOutput?: string, avdManagerError?: string, iniFilesData?: IDictionary<Mobile.IAvdInfo>}) {
+function createTestInjector(data: {avdManagerOutput?: string, avdManagerError?: string, iniFilesData?: IDictionary<Mobile.IAvdInfo>}): IInjector {
 	const testInjector = new Yok();
 	testInjector.register("androidVirtualDeviceService", AndroidVirtualDeviceService);
 	testInjector.register("androidIniFileParser", {
@@ -117,7 +117,7 @@ describe("androidVirtualDeviceService", () => {
 		return testInjector.resolve("androidVirtualDeviceService");
 	}
 
-	describe("getAvailableEmulators", () => {
+	describe("getEmulatorImages", () => {
 		describe("when avdmanager is found", () => {
 			beforeEach(() => {
 				process.env.ANDROID_HOME = "fake/android/home/path";
@@ -125,7 +125,7 @@ describe("androidVirtualDeviceService", () => {
 
 			it("should return an empty array when no emulators are available", async () => {
 				const avdService = mockAvdService({avdManagerOutput: ""});
-				const result = await avdService.getAvailableEmulators([]);
+				const result = await avdService.getEmulatorImages([]);
 				assert.lengthOf(result.devices, 0);
 				assert.deepEqual(result.devices, []);
 				assert.deepEqual(result.errors, []);
@@ -133,7 +133,7 @@ describe("androidVirtualDeviceService", () => {
 			it("should return an empty array when `avdmanager list avds` command fails", async () => {
 				const avdManagerError = "some error while executing avdmanager list avds";
 				const avdService = mockAvdService({ avdManagerError });
-				const result = await avdService.getAvailableEmulators([]);
+				const result = await avdService.getEmulatorImages([]);
 				assert.lengthOf(result.devices, 0);
 				assert.deepEqual(result.devices, []);
 				assert.lengthOf(result.errors, 1);
@@ -164,7 +164,7 @@ describe("androidVirtualDeviceService", () => {
 					}
 				}});
 
-				const result = await avdService.getAvailableEmulators([]);
+				const result = await avdService.getEmulatorImages([]);
 				assert.lengthOf(result.devices, 3);
 				assert.deepEqual(result.devices[0], getAvailableEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5_API_27", version: "8.1.0" }));
 				assert.deepEqual(result.devices[1], getAvailableEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5X_API_28", version: "9.0.0" }));
@@ -203,7 +203,7 @@ describe("androidVirtualDeviceService", () => {
 
 					return Promise.resolve("");
 				};
-				const result = (await avdService.getAvailableEmulators(["emulator-5554	device"])).devices;
+				const result = (await avdService.getEmulatorImages(["emulator-5554	device"])).devices;
 				assert.deepEqual(result[0], getRunningEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5_API_27", identifier: "emulator-5554", version: "8.1.0" }));
 				assert.deepEqual(result[1], getAvailableEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5X_API_28", version: "9.0.0" }));
 				assert.deepEqual(result[2], getAvailableEmulatorData({ displayName: "Nexus 6P", imageIdentifier: "Nexus_6P_API_28", version: "9.0.0" }));
@@ -215,7 +215,7 @@ describe("androidVirtualDeviceService", () => {
 				const androidHomeDir = process.env.ANDROID_HOME;
 				process.env.ANDROID_HOME = undefined;
 				const avdService = mockAvdService();
-				const result = (await avdService.getAvailableEmulators([])).devices;
+				const result = (await avdService.getEmulatorImages([])).devices;
 				assert.lengthOf(result, 0);
 				assert.deepEqual(result, []);
 				process.env.ANDROID_HOME = androidHomeDir;
@@ -255,7 +255,7 @@ describe("androidVirtualDeviceService", () => {
 					}
 				}});
 
-				const result = await avdService.getAvailableEmulators([]);
+				const result = await avdService.getEmulatorImages([]);
 
 				assert.lengthOf(result.devices, 4);
 				assert.deepEqual(result.devices[0], getAvailableEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5_API_27", version: "8.1.0" }));
@@ -298,7 +298,7 @@ describe("androidVirtualDeviceService", () => {
 					}
 				};
 				const testInjector = createTestInjector(mockData);
-				const avdService = testInjector.resolve("androidVirtualDeviceService");
+				const avdService = testInjector.resolve<Mobile.IAndroidVirtualDeviceService>("androidVirtualDeviceService");
 				const androidIniFileParser = testInjector.resolve("androidIniFileParser");
 				androidIniFileParser.parseIniFile = (iniFilePath: string) => {
 					if (iniFilePath.indexOf("Pixel_2_XL_API_28") !== -1) {
@@ -308,7 +308,7 @@ describe("androidVirtualDeviceService", () => {
 					return mockParseIniFile(iniFilePath, mockData);
 				};
 
-				const result = await avdService.getAvailableEmulators([]);
+				const result = await avdService.getEmulatorImages([]);
 
 				assert.lengthOf(result.devices, 3);
 				assert.deepEqual(result.devices[0], getAvailableEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5_API_27", version: "8.1.0" }));

--- a/test/unit-tests/mobile/genymotion/genymotion-service.ts
+++ b/test/unit-tests/mobile/genymotion/genymotion-service.ts
@@ -272,17 +272,17 @@ describe("GenymotionService", () => {
 		}
 	}
 
-	describe("getAvailableEmulators", () => {
+	describe("getEmulatorImages", () => {
 		it("should return [] when no emulators are available", async () => {
 			mockVirtualBoxService({ vms: [], error: null });
-			const result = await androidGenymotionService.getAvailableEmulators([]);
+			const result = await androidGenymotionService.getEmulatorImages([]);
 			assert.lengthOf(result.devices, 0);
 			assert.deepEqual(result.devices, []);
 			assert.deepEqual(result.errors, []);
 		});
 		it("should return an empty array when an error is thrown", async () => {
 			mockVirtualBoxService({ vms: [], error });
-			const result = await androidGenymotionService.getAvailableEmulators([]);
+			const result = await androidGenymotionService.getEmulatorImages([]);
 			assert.lengthOf(result.devices, 0);
 			assert.deepEqual(result.devices, []);
 			assert.deepEqual(result.errors, [error]);
@@ -296,7 +296,7 @@ describe("GenymotionService", () => {
 			};
 
 			mockVirtualBoxService({ vms, error: null }, mapEnumerateGuestPropertiesOutput);
-			const result = await androidGenymotionService.getAvailableEmulators([]);
+			const result = await androidGenymotionService.getEmulatorImages([]);
 			assert.lengthOf(result.devices, 4);
 			assert.deepEqual(result.devices[0], getAvailableEmulatorData({ displayName: "Google Nexus 4 - 5.0.0 - API 21 - 768x1280", imageIdentifier: "9d9beef2-cc60-4a54-bcc0-cc1dbf89811f", version: "5.0" }));
 			assert.deepEqual(result.devices[1], getAvailableEmulatorData({ displayName: "Custom Tablet - 6.0.0 - API 23 - 1536x2048", imageIdentifier: "da83e290-4d54-4b94-8654-540cf0c96604", version: "5.0" }));
@@ -314,7 +314,7 @@ describe("GenymotionService", () => {
 			mockVirtualBoxService({ vms, error: null }, mapEnumerateGuestPropertiesOutput);
 			(<any>androidGenymotionService).isGenymotionEmulator = (emulatorId: string) => Promise.resolve(true);
 			androidGenymotionService.getRunningEmulatorName = (emulatorId: string) => Promise.resolve("test");
-			const result = await androidGenymotionService.getAvailableEmulators(["192.168.56.101:5555	device"]);
+			const result = await androidGenymotionService.getEmulatorImages(["192.168.56.101:5555	device"]);
 			assert.lengthOf(result.devices, 4);
 			assert.deepEqual(result.devices[0], getAvailableEmulatorData({ displayName: "Google Nexus 4 - 5.0.0 - API 21 - 768x1280", imageIdentifier: "9d9beef2-cc60-4a54-bcc0-cc1dbf89811f", version: "5.0" }));
 			assert.deepEqual(result.devices[1], getAvailableEmulatorData({ displayName: "Custom Tablet - 6.0.0 - API 23 - 1536x2048", imageIdentifier: "da83e290-4d54-4b94-8654-540cf0c96604", version: "5.0" }));


### PR DESCRIPTION
Rename `getAvailableEmulators` to `getEmulatorImages` as we return information for all emulator images - running and not.
Rename the events `emulatorImagesFound` and `emulatorImagesLost` to `emulatorImageFound` and `emulatorImageLost` as emitted data contains a single emulator image.