### PR TITLE
fix: `tns run android` command fails when no emulators are available

### DIFF
--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -382,6 +382,12 @@ declare module Mobile {
 		 * @returns {Promise<string>} Returns all connected android devices
 		 */
 		getDevices(): Promise<string[]>;
+
+		/**
+		 * Returns current Android devices or empty array in case of an error.
+		 * @returns {Promise<string[]>} Array of currently running devices.
+		 */
+		getDevicesSafe(): Promise<string[]>;
 	}
 
 	interface IDeviceAndroidDebugBridge extends IAndroidDebugBridge {

--- a/mobile/android/android-emulator-services.ts
+++ b/mobile/android/android-emulator-services.ts
@@ -12,7 +12,7 @@ export class AndroidEmulatorServices implements Mobile.IEmulatorPlatformService 
 		private $utils: IUtils) { }
 
 	public async getEmulatorImages(): Promise<Mobile.IEmulatorImagesOutput> {
-		const adbDevicesOutput = await this.$adb.getDevices();
+		const adbDevicesOutput = await this.$adb.getDevicesSafe();
 		const avdAvailableEmulatorsOutput = await this.$androidVirtualDeviceService.getEmulatorImages(adbDevicesOutput);
 		const genyAvailableDevicesOutput = await this.$androidGenymotionService.getEmulatorImages(adbDevicesOutput);
 
@@ -23,7 +23,7 @@ export class AndroidEmulatorServices implements Mobile.IEmulatorPlatformService 
 	}
 
 	public async getRunningEmulatorIds(): Promise<string[]> {
-		const adbDevicesOutput = await this.$adb.getDevices();
+		const adbDevicesOutput = await this.$adb.getDevicesSafe();
 		const avds = await this.$androidVirtualDeviceService.getRunningEmulatorIds(adbDevicesOutput);
 		const genies = await this.$androidGenymotionService.getRunningEmulatorIds(adbDevicesOutput);
 		return avds.concat(genies);

--- a/mobile/android/android-virtual-device-service.ts
+++ b/mobile/android/android-virtual-device-service.ts
@@ -17,8 +17,8 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 		private $fs: IFileSystem,
 		private $hostInfo: IHostInfo,
 		private $logger: ILogger) {
-			this.androidHome = process.env.ANDROID_HOME;
-		}
+		this.androidHome = process.env.ANDROID_HOME;
+	}
 
 	public async getEmulatorImages(adbDevicesOutput: string[]): Promise<Mobile.IEmulatorImagesOutput> {
 		const availableEmulatorsOutput = await this.getEmulatorImagesCore();
@@ -177,7 +177,7 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 	private get pathToAvdManagerExecutable(): string {
 		let avdManagerPath = null;
 		if (this.androidHome) {
-			avdManagerPath = path.join(this.androidHome, "tools", "bin", "avdmanager");
+			avdManagerPath = path.join(this.androidHome, "tools", "bin", this.getExecutableName("avdmanager"));
 		}
 
 		return avdManagerPath;
@@ -187,7 +187,7 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 	private get pathToAndroidExecutable(): string {
 		let androidPath = null;
 		if (this.androidHome) {
-			androidPath = path.join(this.androidHome, "tools", "android");
+			androidPath = path.join(this.androidHome, "tools", this.getExecutableName("android"));
 		}
 
 		return androidPath;
@@ -209,6 +209,14 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 		return null;
 	}
 
+	private getExecutableName(executable: string): string {
+		if (this.$hostInfo.isWindows) {
+			return `${executable}.bat`;
+		}
+
+		return executable;
+	}
+
 	private listAvdsFromDirectory(): Mobile.IDeviceInfo[] {
 		let devices: Mobile.IDeviceInfo[] = [];
 
@@ -228,8 +236,9 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 	private parseListAvdsOutput(output: string): Mobile.IDeviceInfo[] {
 		let devices: Mobile.IDeviceInfo[] = [];
 
-		const avialableDevices = output.split(AndroidVirtualDevice.AVAILABLE_AVDS_MESSAGE);
-		if (avialableDevices && avialableDevices[1]) {
+		const avdOutput = output.split(AndroidVirtualDevice.AVAILABLE_AVDS_MESSAGE);
+		const availableDevices = avdOutput && avdOutput[1] && avdOutput[1].trim();
+		if (availableDevices) {
 			// In some cases `avdmanager list avds` command prints:
 			//	`The following Android Virtual Devices could not be loaded:
 			//	Name: Pixel_2_XL_API_28
@@ -237,7 +246,7 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 			//	Error: Google pixel_2_xl no longer exists as a device`
 			// These devices sometimes are valid so try to parse them.
 			// Also these devices are printed at the end of the output and are separated with 2 new lines from the valid devices output.
-			const parts = avialableDevices[1].split(/(?:\r?\n){2}/);
+			const parts = availableDevices.split(/(?:\r?\n){2}/);
 			const items = [parts[0], parts[1]].filter(item => !!item);
 
 			for (const item of items) {

--- a/mobile/android/genymotion/genymotion-service.ts
+++ b/mobile/android/genymotion/genymotion-service.ts
@@ -74,7 +74,9 @@ export class AndroidGenymotionService implements Mobile.IAndroidVirtualDeviceSer
 	}
 
 	public async getRunningEmulatorImageIdentifier(emulatorId: string): Promise<string> {
-		const emulator = await this.getRunningEmulatorData(emulatorId, (await this.getEmulatorImages(await this.$adb.getDevices())).devices);
+		const adbDevices = await this.$adb.getDevicesSafe();
+		const emulatorImages = (await this.getEmulatorImages(adbDevices)).devices;
+		const emulator = await this.getRunningEmulatorData(emulatorId, emulatorImages);
 		return emulator ? emulator.imageIdentifier : null;
 	}
 

--- a/test/unit-tests/mobile/android-emulator-service.ts
+++ b/test/unit-tests/mobile/android-emulator-service.ts
@@ -7,7 +7,7 @@ function createTestInjector() {
 	const testInjector = new Yok();
 
 	testInjector.register("adb", {
-		getDevices: () => Promise.resolve()
+		getDevicesSafe: () => Promise.resolve()
 	});
 	testInjector.register("androidVirtualDeviceService", {});
 	testInjector.register("androidGenymotionService", {});

--- a/test/unit-tests/mobile/android-virtual-device-service.ts
+++ b/test/unit-tests/mobile/android-virtual-device-service.ts
@@ -4,6 +4,7 @@ import { Yok } from "../../../yok";
 
 import { assert } from "chai";
 import * as path from "path";
+import { AndroidVirtualDevice } from "../../../constants";
 
 const avdManagerOutput = `Parsing /Users/havaluova/Library/Android/sdk/build-tools/27.0.3/package.xmlParsing /Users/havaluova/Library/Android/sdk/build-tools/28.0.0/package.xmlParsing /Users/havaluova/Library/Android/sdk/emulator/package.xmlParsing /Users/havaluova/Library/Android/sdk/extras/android/m2repository/package.xmlParsing /Users/havaluova/Library/Android/sdk/extras/google/google_play_services/package.xmlParsing /Users/havaluova/Library/Android/sdk/extras/google/m2repository/package.xmlParsing /Users/havaluova/Library/Android/sdk/extras/intel/Hardware_Accelerated_Execution_Manager/package.xmlParsing /Users/havaluova/Library/Android/sdk/extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.2/package.xmlParsing /Users/havaluova/Library/Android/sdk/extras/m2repository/com/android/support/constraint/constraint-layout/1.0.2/package.xmlParsing /Users/havaluova/Library/Android/sdk/patcher/v4/package.xmlParsing /Users/havaluova/Library/Android/sdk/platform-tools/package.xmlParsing /Users/havaluova/Library/Android/sdk/platforms/android-27/package.xmlParsing /Users/havaluova/Library/Android/sdk/platforms/android-28/package.xmlParsing /Users/havaluova/Library/Android/sdk/sources/android-27/package.xmlParsing /Users/havaluova/Library/Android/sdk/system-images/android-27/google_apis_playstore/x86/package.xmlParsing /Users/havaluova/Library/Android/sdk/system-images/android-28/google_apis/x86/package.xmlParsing /Users/havaluova/Library/Android/sdk/system-images/android-28/google_apis_playstore/x86/package.xmlParsing /Users/havaluova/Library/Android/sdk/tools/package.xmlAvailable Android Virtual Devices:
 	Name: Nexus_5_API_27
@@ -52,7 +53,7 @@ function mockParseIniFile(iniFilePath: string, data: any) {
 	}
 }
 
-function createTestInjector(data: {avdManagerOutput?: string, avdManagerError?: string, iniFilesData?: IDictionary<Mobile.IAvdInfo>}): IInjector {
+function createTestInjector(data: { avdManagerOutput?: string, avdManagerError?: string, iniFilesData?: IDictionary<Mobile.IAvdInfo> }): IInjector {
 	const testInjector = new Yok();
 	testInjector.register("androidVirtualDeviceService", AndroidVirtualDeviceService);
 	testInjector.register("androidIniFileParser", {
@@ -66,20 +67,20 @@ function createTestInjector(data: {avdManagerOutput?: string, avdManagerError?: 
 			};
 		}
 	});
-	testInjector.register("devicePlatformsConstants", {Android: "android"});
+	testInjector.register("devicePlatformsConstants", { Android: "android" });
 	testInjector.register("fs", {
 		exists: () => true,
 		readText: (filePath: string) => ((data && data.iniFilesData) || {})[filePath],
-		readDirectory: () =>  <string[]>[]
+		readDirectory: () => <string[]>[]
 	});
 	testInjector.register("emulatorHelper", EmulatorHelper);
 	testInjector.register("hostInfo", {});
-	testInjector.register("logger", { trace: () => ({})});
+	testInjector.register("logger", { trace: () => ({}) });
 
 	return testInjector;
 }
 
-function getAvailableEmulatorData(data: {displayName: string, imageIdentifier: string, version: string}): Mobile.IDeviceInfo {
+function getAvailableEmulatorData(data: { displayName: string, imageIdentifier: string, version: string }): Mobile.IDeviceInfo {
 	return {
 		displayName: data.displayName,
 		errorHelp: null,
@@ -95,7 +96,7 @@ function getAvailableEmulatorData(data: {displayName: string, imageIdentifier: s
 	};
 }
 
-function getRunningEmulatorData(data: {displayName: string, imageIdentifier: string, identifier: string, version: string}): Mobile.IDeviceInfo {
+function getRunningEmulatorData(data: { displayName: string, imageIdentifier: string, identifier: string, version: string }): Mobile.IDeviceInfo {
 	return {
 		identifier: data.identifier,
 		imageIdentifier: data.imageIdentifier,
@@ -112,7 +113,7 @@ function getRunningEmulatorData(data: {displayName: string, imageIdentifier: str
 }
 
 describe("androidVirtualDeviceService", () => {
-	function mockAvdService(data?: {avdManagerOutput?: string, avdManagerError?: string, iniFilesData?: IDictionary<Mobile.IAvdInfo>}): Mobile.IAndroidVirtualDeviceService {
+	function mockAvdService(data?: { avdManagerOutput?: string, avdManagerError?: string, iniFilesData?: IDictionary<Mobile.IAvdInfo> }): Mobile.IAndroidVirtualDeviceService {
 		const testInjector = createTestInjector(data);
 		return testInjector.resolve("androidVirtualDeviceService");
 	}
@@ -124,7 +125,15 @@ describe("androidVirtualDeviceService", () => {
 			});
 
 			it("should return an empty array when no emulators are available", async () => {
-				const avdService = mockAvdService({avdManagerOutput: ""});
+				const avdService = mockAvdService({ avdManagerOutput: "" });
+				const result = await avdService.getEmulatorImages([]);
+				assert.lengthOf(result.devices, 0);
+				assert.deepEqual(result.devices, []);
+				assert.deepEqual(result.errors, []);
+			});
+
+			it(`should return an empty array when no emulators are available (only ${AndroidVirtualDevice.AVAILABLE_AVDS_MESSAGE} message is printed)`, async () => {
+				const avdService = mockAvdService({ avdManagerOutput: `${AndroidVirtualDevice.AVAILABLE_AVDS_MESSAGE}\n` });
 				const result = await avdService.getEmulatorImages([]);
 				assert.lengthOf(result.devices, 0);
 				assert.deepEqual(result.devices, []);
@@ -140,29 +149,31 @@ describe("androidVirtualDeviceService", () => {
 				assert.deepEqual(result.errors, [avdManagerError]);
 			});
 			it("should return all emulators when there are available emulators and no running emulators", async () => {
-				const avdService = mockAvdService({avdManagerOutput, iniFilesData: {
-					"/fake/path/Nexus_5_API_27.avd": {
-						target: "android-27",
-						targetNum: 8,
-						path: null,
-						device: "Nexus 5X",
-						avdId: "Nexus_5_API_27"
-					},
-					"/fake/path/Nexus_5X_API_28.avd": {
-						target: "android-28",
-						targetNum: 9,
-						path: null,
-						device: "Nexus 5X",
-						avdId: "Nexus_5X_API_28"
-					},
-					"/fake/path/Nexus_6P_API_28.avd": {
-						target: "android-28",
-						targetNum: 9,
-						path: null,
-						device: "Nexus 6P",
-						avdId: "Nexus_6P_API_28"
+				const avdService = mockAvdService({
+					avdManagerOutput, iniFilesData: {
+						"/fake/path/Nexus_5_API_27.avd": {
+							target: "android-27",
+							targetNum: 8,
+							path: null,
+							device: "Nexus 5X",
+							avdId: "Nexus_5_API_27"
+						},
+						"/fake/path/Nexus_5X_API_28.avd": {
+							target: "android-28",
+							targetNum: 9,
+							path: null,
+							device: "Nexus 5X",
+							avdId: "Nexus_5X_API_28"
+						},
+						"/fake/path/Nexus_6P_API_28.avd": {
+							target: "android-28",
+							targetNum: 9,
+							path: null,
+							device: "Nexus 6P",
+							avdId: "Nexus_6P_API_28"
+						}
 					}
-				}});
+				});
 
 				const result = await avdService.getEmulatorImages([]);
 				assert.lengthOf(result.devices, 3);
@@ -172,29 +183,31 @@ describe("androidVirtualDeviceService", () => {
 				assert.deepEqual(result.errors, []);
 			});
 			it("should return all emulators when there are available and running emulators", async () => {
-				const avdService = mockAvdService({avdManagerOutput, iniFilesData: {
-					"/fake/path/Nexus_5_API_27.avd": {
-						target: "android-27",
-						targetNum: 8,
-						path: null,
-						device: "Nexus 5X",
-						avdId: "Nexus_5_API_27"
-					},
-					"/fake/path/Nexus_5X_API_28.avd": {
-						target: "android-28",
-						targetNum: 9,
-						path: null,
-						device: "Nexus 5X",
-						avdId: "Nexus_5X_API_28"
-					},
-					"/fake/path/Nexus_6P_API_28.avd": {
-						target: "android-28",
-						targetNum: 9,
-						path: null,
-						device: "Nexus 6P",
-						avdId: "Nexus_6P_API_28"
+				const avdService = mockAvdService({
+					avdManagerOutput, iniFilesData: {
+						"/fake/path/Nexus_5_API_27.avd": {
+							target: "android-27",
+							targetNum: 8,
+							path: null,
+							device: "Nexus 5X",
+							avdId: "Nexus_5_API_27"
+						},
+						"/fake/path/Nexus_5X_API_28.avd": {
+							target: "android-28",
+							targetNum: 9,
+							path: null,
+							device: "Nexus 5X",
+							avdId: "Nexus_5X_API_28"
+						},
+						"/fake/path/Nexus_6P_API_28.avd": {
+							target: "android-28",
+							targetNum: 9,
+							path: null,
+							device: "Nexus 6P",
+							avdId: "Nexus_6P_API_28"
+						}
 					}
-				}});
+				});
 
 				avdService.getRunningEmulatorImageIdentifier = (emulatorId: string) => {
 					if (emulatorId === "emulator-5554") {
@@ -224,36 +237,38 @@ describe("androidVirtualDeviceService", () => {
 
 		describe("when avdmanager reports some device no longer exists", () => {
 			it("should return the emulator when it actually exists", async () => {
-				const avdService = mockAvdService({avdManagerOutput: avdManagerOutputWithInvalidDevice, iniFilesData: {
-					"/fake/path/Nexus_5_API_27.avd": {
-						target: "android-27",
-						targetNum: 8,
-						path: null,
-						device: "Nexus 5X",
-						avdId: "Nexus_5_API_27"
-					},
-					"/fake/path/Nexus_5X_API_28.avd": {
-						target: "android-28",
-						targetNum: 9,
-						path: null,
-						device: "Nexus 5X",
-						avdId: "Nexus_5X_API_28"
-					},
-					"/fake/path/Nexus_6P_API_28.avd": {
-						target: "android-28",
-						targetNum: 9,
-						path: null,
-						device: "Nexus 6P",
-						avdId: "Nexus_6P_API_28"
-					},
-					"/fake/path/Pixel_2_XL_API_28.avd": {
-						target: "android-28",
-						targetNum: 9,
-						path: null,
-						device: "Pixel 2 XL",
-						avdId: "Pixel_2_XL_API_28"
+				const avdService = mockAvdService({
+					avdManagerOutput: avdManagerOutputWithInvalidDevice, iniFilesData: {
+						"/fake/path/Nexus_5_API_27.avd": {
+							target: "android-27",
+							targetNum: 8,
+							path: null,
+							device: "Nexus 5X",
+							avdId: "Nexus_5_API_27"
+						},
+						"/fake/path/Nexus_5X_API_28.avd": {
+							target: "android-28",
+							targetNum: 9,
+							path: null,
+							device: "Nexus 5X",
+							avdId: "Nexus_5X_API_28"
+						},
+						"/fake/path/Nexus_6P_API_28.avd": {
+							target: "android-28",
+							targetNum: 9,
+							path: null,
+							device: "Nexus 6P",
+							avdId: "Nexus_6P_API_28"
+						},
+						"/fake/path/Pixel_2_XL_API_28.avd": {
+							target: "android-28",
+							targetNum: 9,
+							path: null,
+							device: "Pixel 2 XL",
+							avdId: "Pixel_2_XL_API_28"
+						}
 					}
-				}});
+				});
 
 				const result = await avdService.getEmulatorImages([]);
 
@@ -265,7 +280,8 @@ describe("androidVirtualDeviceService", () => {
 				assert.deepEqual(result.errors, []);
 			});
 			it("shouldn't return the emulator when it actually does not exist", async () => {
-				const mockData = {avdManagerOutput: avdManagerOutputWithInvalidDevice,
+				const mockData = {
+					avdManagerOutput: avdManagerOutputWithInvalidDevice,
 					iniFilesData: {
 						"/fake/path/Nexus_5_API_27.avd": {
 							target: "android-27",


### PR DESCRIPTION
`tns run android` command fails when there are no Android emulators available. The problem is that the output of `avdmanager list avds` is incorrectly parsed by CLI and it fails (output is `Available Android Virtual Devices:\n`).
Fix this by improving the parsing logic.
Also fix incorrect checks for executables on Windows - the files have `.bat` extension, which was not added, so the check if the file exist was failing.
Unify the calls to `adb devices` - curently there are two implementations on different places in the code - unify them and add a new method that does not fail in case `adb devices` command fails. The new method is usable when we want to list currently available simulators/emulators.