### PR TITLE
fix: status of iOS Sim images and Android Emulator images are different

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -22,7 +22,6 @@ export const ERROR_NO_VALID_SUBCOMMAND_FORMAT = "The input is not valid sub-comm
 
 export const UNREACHABLE_STATUS = "Unreachable";
 export const CONNECTED_STATUS = "Connected";
-export const DISCONNECTED_STATUS = "Disconnected";
 
 export const RUNNING_EMULATOR_STATUS = "Running";
 export const NOT_RUNNING_EMULATOR_STATUS = "Not running";

--- a/definitions/mobile.d.ts
+++ b/definitions/mobile.d.ts
@@ -80,7 +80,7 @@ declare module Mobile {
 		 * Available only for emulators. Should be null for devices.
 		 * The identifier of the image. For geny emulators - the vm's identifier
 		 * For avd emulators - the name of the .ini file
-		 * Currently null for iOS simulators
+		 * For iOS simulators - same as the identifier.
 		 */
 		imageIdentifier?: string;
 	}

--- a/mobile/android/android-virtual-device-service.ts
+++ b/mobile/android/android-virtual-device-service.ts
@@ -266,7 +266,8 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 	private getAvdManagerDeviceInfo(output: string): Mobile.IAvdManagerDeviceInfo {
 		const avdManagerDeviceInfo: Mobile.IAvdManagerDeviceInfo = Object.create(null);
 
-		_.reduce(output.split(EOL), (result: Mobile.IAvdManagerDeviceInfo, row: string) => {
+		// Split by `\n`, not EOL as the avdmanager and android executables print results with `\n` only even on Windows
+		_.reduce(output.split("\n"), (result: Mobile.IAvdManagerDeviceInfo, row: string) => {
 			const [key, value] = row.split(": ").map(part => part.trim());
 
 			switch (key) {

--- a/mobile/ios/simulator/ios-emulator-services.ts
+++ b/mobile/ios/simulator/ios-emulator-services.ts
@@ -1,6 +1,6 @@
 import * as net from "net";
 import { connectEventuallyUntilTimeout } from "../../../helpers";
-import { CONNECTED_STATUS, DISCONNECTED_STATUS, APPLE_VENDOR_NAME, DeviceTypes } from "../../../constants";
+import { APPLE_VENDOR_NAME, DeviceTypes, RUNNING_EMULATOR_STATUS, NOT_RUNNING_EMULATOR_STATUS } from "../../../constants";
 
 class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 	private static DEFAULT_TIMEOUT = 10000;
@@ -117,12 +117,13 @@ class IosEmulatorServices implements Mobile.IiOSSimulatorService {
 
 	private convertSimDeviceToDeviceInfo(simDevice: Mobile.IiSimDevice): Mobile.IDeviceInfo {
 		return {
+			imageIdentifier: simDevice.id,
 			identifier: simDevice.id,
 			displayName: simDevice.name,
 			model: simDevice.name,
 			version: simDevice.runtimeVersion,
 			vendor: APPLE_VENDOR_NAME,
-			status: simDevice.state && simDevice.state.toLowerCase() === "booted" ? CONNECTED_STATUS : DISCONNECTED_STATUS,
+			status: simDevice.state && simDevice.state.toLowerCase() === "booted" ? RUNNING_EMULATOR_STATUS : NOT_RUNNING_EMULATOR_STATUS,
 			errorHelp: null,
 			isTablet: this.$mobileHelper.isiOSTablet(simDevice.name),
 			type: DeviceTypes.Emulator,

--- a/mobile/ios/simulator/ios-simulator-device.ts
+++ b/mobile/ios/simulator/ios-simulator-device.ts
@@ -17,6 +17,7 @@ export class IOSSimulator implements Mobile.IiOSSimulator {
 
 	public get deviceInfo(): Mobile.IDeviceInfo {
 		return {
+			imageIdentifier: this.simulator.id,
 			identifier: this.simulator.id,
 			displayName: this.simulator.name,
 			model: _.last(this.simulator.fullId.split(".")),

--- a/test/unit-tests/mobile/android-emulator-service.ts
+++ b/test/unit-tests/mobile/android-emulator-service.ts
@@ -2,6 +2,7 @@ import { Yok } from "../../../yok";
 import { AndroidEmulatorServices } from "../../../mobile/android/android-emulator-services";
 import { EmulatorHelper } from "../../../mobile/emulator-helper";
 import { assert } from "chai";
+import { RUNNING_EMULATOR_STATUS } from "../../../constants";
 
 function createTestInjector() {
 	const testInjector = new Yok();
@@ -34,7 +35,7 @@ const avdEmulator = {
 	model: "model",
 	version: "version",
 	vendor: "Avd",
-	status: "Running",
+	status: RUNNING_EMULATOR_STATUS,
 	errorHelp: "",
 	isTablet: false,
 	type: "type",
@@ -47,7 +48,7 @@ const genyEmulator = {
 	model: "model",
 	version: "version",
 	vendor: "Genymotion",
-	status: "Running",
+	status: RUNNING_EMULATOR_STATUS,
 	errorHelp: "",
 	isTablet: false,
 	type: "type",

--- a/test/unit-tests/mobile/android-virtual-device-service.ts
+++ b/test/unit-tests/mobile/android-virtual-device-service.ts
@@ -4,12 +4,12 @@ import { Yok } from "../../../yok";
 
 import { assert } from "chai";
 import * as path from "path";
-import { AndroidVirtualDevice } from "../../../constants";
+import { AndroidVirtualDevice, NOT_RUNNING_EMULATOR_STATUS, RUNNING_EMULATOR_STATUS } from '../../../constants';
 
 const avdManagerOutput = `Parsing /Users/havaluova/Library/Android/sdk/build-tools/27.0.3/package.xmlParsing /Users/havaluova/Library/Android/sdk/build-tools/28.0.0/package.xmlParsing /Users/havaluova/Library/Android/sdk/emulator/package.xmlParsing /Users/havaluova/Library/Android/sdk/extras/android/m2repository/package.xmlParsing /Users/havaluova/Library/Android/sdk/extras/google/google_play_services/package.xmlParsing /Users/havaluova/Library/Android/sdk/extras/google/m2repository/package.xmlParsing /Users/havaluova/Library/Android/sdk/extras/intel/Hardware_Accelerated_Execution_Manager/package.xmlParsing /Users/havaluova/Library/Android/sdk/extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.2/package.xmlParsing /Users/havaluova/Library/Android/sdk/extras/m2repository/com/android/support/constraint/constraint-layout/1.0.2/package.xmlParsing /Users/havaluova/Library/Android/sdk/patcher/v4/package.xmlParsing /Users/havaluova/Library/Android/sdk/platform-tools/package.xmlParsing /Users/havaluova/Library/Android/sdk/platforms/android-27/package.xmlParsing /Users/havaluova/Library/Android/sdk/platforms/android-28/package.xmlParsing /Users/havaluova/Library/Android/sdk/sources/android-27/package.xmlParsing /Users/havaluova/Library/Android/sdk/system-images/android-27/google_apis_playstore/x86/package.xmlParsing /Users/havaluova/Library/Android/sdk/system-images/android-28/google_apis/x86/package.xmlParsing /Users/havaluova/Library/Android/sdk/system-images/android-28/google_apis_playstore/x86/package.xmlParsing /Users/havaluova/Library/Android/sdk/tools/package.xmlAvailable Android Virtual Devices:
 	Name: Nexus_5_API_27
 	Device: Nexus 5 (Google)
-	Path: /fake/path/Nexus_5_API_27.avd
+	Path: ${path.join("/fake", "path", "Nexus_5_API_27.avd")}
 	Target: Google Play (Google Inc.)
 			Based on: Android API 27 Tag/ABI: google_apis_playstore/x86
 	Skin: nexus_5
@@ -17,7 +17,7 @@ const avdManagerOutput = `Parsing /Users/havaluova/Library/Android/sdk/build-too
 	---------
 	Name: Nexus_5X_API_28
 	Device: Nexus 5X (Google)
-	Path: /fake/path/Nexus_5X_API_28.avd
+	Path: ${path.join("/fake", "path", "Nexus_5X_API_28.avd")}
 	Target: Google Play (Google Inc.)
 			Based on: Android API 28 Tag/ABI: google_apis_playstore/x86
 	Skin: nexus_5x
@@ -25,7 +25,7 @@ const avdManagerOutput = `Parsing /Users/havaluova/Library/Android/sdk/build-too
 	---------
 	Name: Nexus_6P_API_28
 	Device: Nexus 6P (Google)
-	Path: /fake/path/Nexus_6P_API_28.avd
+	Path: ${path.join("/fake", "path", "Nexus_6P_API_28.avd")}
 	Target: Google APIs (Google Inc.)
 			Based on: Android API 28 Tag/ABI: google_apis/x86
 	Skin: nexus_6p
@@ -34,7 +34,7 @@ const avdManagerOutput = `Parsing /Users/havaluova/Library/Android/sdk/build-too
 const avdManagerOutputWithInvalidDevice = `${avdManagerOutput} \n` + `
 	The following Android Virtual Devices could not be loaded:
 	Name: Pixel_2_XL_API_28
-	Path: /fake/path/Pixel_2_XL_API_28.avd
+	Path: ${path.join("/fake", "path", "Pixel_2_XL_API_28.avd")}
 	Error: Google pixel_2_xl no longer exists as a device`;
 
 function getValueFromIniFilesData(propertyName: string, iniFilePath: string, iniFilesData: IDictionary<Mobile.IAvdInfo>) {
@@ -89,7 +89,7 @@ function getAvailableEmulatorData(data: { displayName: string, imageIdentifier: 
 		isTablet: false,
 		model: data.displayName,
 		platform: "android",
-		status: "Not running",
+		status: NOT_RUNNING_EMULATOR_STATUS,
 		type: "Emulator",
 		vendor: "Avd",
 		version: data.version
@@ -104,7 +104,7 @@ function getRunningEmulatorData(data: { displayName: string, imageIdentifier: st
 		model: data.displayName,
 		version: data.version,
 		vendor: 'Avd',
-		status: 'Running',
+		status: RUNNING_EMULATOR_STATUS,
 		errorHelp: null,
 		isTablet: false,
 		type: 'Device',
@@ -118,6 +118,43 @@ describe("androidVirtualDeviceService", () => {
 		return testInjector.resolve("androidVirtualDeviceService");
 	}
 
+	function getIniFilesData(opts?: { includePixel: boolean }): any {
+		const data: any = {
+			[path.join("/fake", "path", "Nexus_5_API_27.avd")]: {
+				target: "android-27",
+				targetNum: 8,
+				path: null,
+				device: "Nexus 5X",
+				avdId: "Nexus_5_API_27"
+			},
+			[path.join("/fake", "path", "Nexus_5X_API_28.avd")]: {
+				target: "android-28",
+				targetNum: 9,
+				path: null,
+				device: "Nexus 5X",
+				avdId: "Nexus_5X_API_28"
+			},
+			[path.join("/fake", "path", "Nexus_6P_API_28.avd")]: {
+				target: "android-28",
+				targetNum: 9,
+				path: null,
+				device: "Nexus 6P",
+				avdId: "Nexus_6P_API_28"
+			},
+		};
+
+		if (opts && opts.includePixel) {
+			data[path.join("/fake", "path", "Pixel_2_XL_API_28.avd")] = {
+				target: "android-28",
+				targetNum: 9,
+				path: null,
+				device: "Pixel 2 XL",
+				avdId: "Pixel_2_XL_API_28"
+			};
+		}
+
+		return data;
+	}
 	describe("getEmulatorImages", () => {
 		describe("when avdmanager is found", () => {
 			beforeEach(() => {
@@ -150,29 +187,7 @@ describe("androidVirtualDeviceService", () => {
 			});
 			it("should return all emulators when there are available emulators and no running emulators", async () => {
 				const avdService = mockAvdService({
-					avdManagerOutput, iniFilesData: {
-						"/fake/path/Nexus_5_API_27.avd": {
-							target: "android-27",
-							targetNum: 8,
-							path: null,
-							device: "Nexus 5X",
-							avdId: "Nexus_5_API_27"
-						},
-						"/fake/path/Nexus_5X_API_28.avd": {
-							target: "android-28",
-							targetNum: 9,
-							path: null,
-							device: "Nexus 5X",
-							avdId: "Nexus_5X_API_28"
-						},
-						"/fake/path/Nexus_6P_API_28.avd": {
-							target: "android-28",
-							targetNum: 9,
-							path: null,
-							device: "Nexus 6P",
-							avdId: "Nexus_6P_API_28"
-						}
-					}
+					avdManagerOutput, iniFilesData: getIniFilesData()
 				});
 
 				const result = await avdService.getEmulatorImages([]);
@@ -184,29 +199,7 @@ describe("androidVirtualDeviceService", () => {
 			});
 			it("should return all emulators when there are available and running emulators", async () => {
 				const avdService = mockAvdService({
-					avdManagerOutput, iniFilesData: {
-						"/fake/path/Nexus_5_API_27.avd": {
-							target: "android-27",
-							targetNum: 8,
-							path: null,
-							device: "Nexus 5X",
-							avdId: "Nexus_5_API_27"
-						},
-						"/fake/path/Nexus_5X_API_28.avd": {
-							target: "android-28",
-							targetNum: 9,
-							path: null,
-							device: "Nexus 5X",
-							avdId: "Nexus_5X_API_28"
-						},
-						"/fake/path/Nexus_6P_API_28.avd": {
-							target: "android-28",
-							targetNum: 9,
-							path: null,
-							device: "Nexus 6P",
-							avdId: "Nexus_6P_API_28"
-						}
-					}
+					avdManagerOutput, iniFilesData: getIniFilesData()
 				});
 
 				avdService.getRunningEmulatorImageIdentifier = (emulatorId: string) => {
@@ -238,36 +231,7 @@ describe("androidVirtualDeviceService", () => {
 		describe("when avdmanager reports some device no longer exists", () => {
 			it("should return the emulator when it actually exists", async () => {
 				const avdService = mockAvdService({
-					avdManagerOutput: avdManagerOutputWithInvalidDevice, iniFilesData: {
-						"/fake/path/Nexus_5_API_27.avd": {
-							target: "android-27",
-							targetNum: 8,
-							path: null,
-							device: "Nexus 5X",
-							avdId: "Nexus_5_API_27"
-						},
-						"/fake/path/Nexus_5X_API_28.avd": {
-							target: "android-28",
-							targetNum: 9,
-							path: null,
-							device: "Nexus 5X",
-							avdId: "Nexus_5X_API_28"
-						},
-						"/fake/path/Nexus_6P_API_28.avd": {
-							target: "android-28",
-							targetNum: 9,
-							path: null,
-							device: "Nexus 6P",
-							avdId: "Nexus_6P_API_28"
-						},
-						"/fake/path/Pixel_2_XL_API_28.avd": {
-							target: "android-28",
-							targetNum: 9,
-							path: null,
-							device: "Pixel 2 XL",
-							avdId: "Pixel_2_XL_API_28"
-						}
-					}
+					avdManagerOutput: avdManagerOutputWithInvalidDevice, iniFilesData: getIniFilesData({ includePixel: true })
 				});
 
 				const result = await avdService.getEmulatorImages([]);
@@ -282,36 +246,7 @@ describe("androidVirtualDeviceService", () => {
 			it("shouldn't return the emulator when it actually does not exist", async () => {
 				const mockData = {
 					avdManagerOutput: avdManagerOutputWithInvalidDevice,
-					iniFilesData: {
-						"/fake/path/Nexus_5_API_27.avd": {
-							target: "android-27",
-							targetNum: 8,
-							path: "",
-							device: "Nexus 5X",
-							avdId: "Nexus_5_API_27"
-						},
-						"/fake/path/Nexus_5X_API_28.avd": {
-							target: "android-28",
-							targetNum: 9,
-							path: "",
-							device: "Nexus 5X",
-							avdId: "Nexus_5X_API_28"
-						},
-						"/fake/path/Nexus_6P_API_28.avd": {
-							target: "android-28",
-							targetNum: 9,
-							path: "",
-							device: "Nexus 6P",
-							avdId: "Nexus_6P_API_28"
-						},
-						"/fake/path/Pixel_2_XL_API_28.avd": {
-							target: "android-28",
-							targetNum: 9,
-							path: "",
-							device: "Pixel 2 XL",
-							avdId: "Pixel_2_XL_API_28"
-						}
-					}
+					iniFilesData: getIniFilesData({ includePixel: true })
 				};
 				const testInjector = createTestInjector(mockData);
 				const avdService = testInjector.resolve<Mobile.IAndroidVirtualDeviceService>("androidVirtualDeviceService");

--- a/test/unit-tests/mobile/genymotion/genymotion-service.ts
+++ b/test/unit-tests/mobile/genymotion/genymotion-service.ts
@@ -4,6 +4,7 @@ import { AndroidGenymotionService } from "../../../../mobile/android/genymotion/
 import { EmulatorHelper } from "../../../../mobile/emulator-helper";
 
 import { assert } from "chai";
+import { NOT_RUNNING_EMULATOR_STATUS, RUNNING_EMULATOR_STATUS } from '../../../../constants';
 
 const error = "some test error";
 const enumerateGuestPropertiesOutput = `Name: hardware_opengl, value: 1, timestamp: 1519225339826058000, flags:
@@ -219,7 +220,7 @@ function getAvailableEmulatorData(data: {displayName: string, imageIdentifier: s
 		isTablet: false,
 		model: data.displayName,
 		platform: "android",
-		status: "Not running",
+		status: NOT_RUNNING_EMULATOR_STATUS,
 		type: "Emulator",
 		vendor: "Genymotion",
 		version: data.version
@@ -234,7 +235,7 @@ function getRunningEmulatorData(data: {displayName: string, imageIdentifier: str
 		model: data.displayName,
 		version: data.version,
 		vendor: 'Genymotion',
-		status: 'Running',
+		status: RUNNING_EMULATOR_STATUS,
 		errorHelp: null,
 		isTablet: false,
 		type: 'Device',

--- a/test/unit-tests/mobile/ios-simulator-discovery.ts
+++ b/test/unit-tests/mobile/ios-simulator-discovery.ts
@@ -2,7 +2,7 @@ import { IOSSimulatorDiscovery } from "../../../mobile/mobile-core/ios-simulator
 import { Yok } from "../../../yok";
 
 import { assert } from "chai";
-import { DeviceDiscoveryEventNames } from "../../../constants";
+import { DeviceDiscoveryEventNames, CONNECTED_STATUS } from "../../../constants";
 import { DevicePlatformsConstants } from "../../../mobile/device-platforms-constants";
 
 let currentlyRunningSimulators: Mobile.IiSimDevice[];
@@ -38,13 +38,14 @@ function createTestInjector(): IInjector {
 
 function getDeviceInfo(simulator: Mobile.IiSimDevice): Mobile.IDeviceInfo {
 	return {
+		imageIdentifier: simulator.id,
 		identifier: simulator.id,
 		displayName: simulator.name,
 		model: 'c',
 		version: simulator.runtimeVersion,
 		vendor: 'Apple',
 		platform: 'iOS',
-		status: 'Connected',
+		status: CONNECTED_STATUS,
 		errorHelp: null,
 		isTablet: false,
 		type: 'Emulator'
@@ -106,13 +107,14 @@ describe("ios-simulator-discovery", () => {
 		testInjector = createTestInjector();
 		iOSSimulatorDiscovery = testInjector.resolve("iOSSimulatorDiscovery");
 		expectedDeviceInfo = {
+			imageIdentifier: "id",
 			identifier: "id",
 			displayName: 'name',
 			model: 'c',
 			version: '9.2.1',
 			vendor: 'Apple',
 			platform: 'iOS',
-			status: 'Connected',
+			status: CONNECTED_STATUS,
 			errorHelp: null,
 			isTablet: false,
 			type: 'Emulator'
@@ -139,13 +141,14 @@ describe("ios-simulator-discovery", () => {
 	});
 
 	it("raises deviceLost and deviceFound when device's id has changed (change simulator type)", async () => {
-		const device = await detectNewSimulatorAttached(defaultRunningSimulator),
-			newId = "newId";
+		const device = await detectNewSimulatorAttached(defaultRunningSimulator);
+		const newId = "newId";
 		assert.deepEqual(device.deviceInfo, expectedDeviceInfo);
 
 		const devices = await detectSimulatorChanged(device.deviceInfo.identifier, newId);
 		assert.deepEqual(devices.deviceLost, device);
 		expectedDeviceInfo.identifier = newId;
+		expectedDeviceInfo.imageIdentifier = newId;
 		assert.deepEqual(devices.deviceFound.deviceInfo, expectedDeviceInfo);
 	});
 


### PR DESCRIPTION
Whenever CLI returns information for available emulators/simulators, the returned object for each of the image has a status property.
For Android the status is "Running" or "Not running", for iOS it is "Connected" or "Disconnected".
Unify the status properties - use "Running" and "Not running" for both of the images.

Also, for iOS images, the imageIdentifier property has not been populated - fill it with the value of the identifier property, so the API will be consistent for both Android and iOS.
As the property has not been populated for iOS Simulators, the events "emulatorImageFound" and "emulatorImageLost" were never triggered in case you add new iOS Simulator images. Now this should work correctly.

Fix unit tests on Windows - the split by EOL when parsing the output of avdmanager executable is not working on Windows, as the EOL is `\r\n`, while the avdmanager prints results with `\n` only.
Also the tests were failing on Windows due to the same reason - test case has `\n`, while split is by `\r\n`.

Use some constants in the tests instead of strings for status property.