### PR TITLE
fix: error is shown for Genymotion emulators with old Geny player

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -147,6 +147,7 @@ export class AndroidVirtualDevice {
 	static GENYMOTION_VENDOR_NAME = "Genymotion";
 	static AVD_VENDOR_NAME = "Avd";
 	static TIMEOUT_SECONDS = 120;
+	static GENYMOTION_DEFAULT_STDERR_STRING = "Logging activities to file";
 
 	static UNABLE_TO_START_EMULATOR_MESSAGE = "Cannot run your app in the native emulator. Increase the timeout of the operation with the --timeout option or try to restart your adb server with 'adb kill-server' command. Alternatively, run the Android Virtual Device manager and increase the allocated RAM for the virtual device.";
 }

--- a/mobile/android/genymotion/genymotion-service.ts
+++ b/mobile/android/genymotion/genymotion-service.ts
@@ -168,11 +168,21 @@ export class AndroidGenymotionService implements Mobile.IAndroidVirtualDeviceSer
 	}
 
 	@cache()
+	private getConfigurationPlatformSpecficErrorMessage(): string {
+		const searchPaths = this.playerSearchPaths[process.platform];
+		return `Unable to find the Genymotion player in the following location${searchPaths.length > 1 ? "s" : ""}:
+${searchPaths.join(EOL)}
+In case you have installed Genymotion in a different location, please add the path to player executable to your PATH environment variable.`;
+
+	}
+
+	@cache()
 	private async getConfigurationError(): Promise<string> {
-		const result = await this.$childProcess.trySpawnFromCloseEvent(this.pathToEmulatorExecutable, []);
+		const result = await this.$childProcess.trySpawnFromCloseEvent(this.pathToEmulatorExecutable, [], {}, { throwError: false });
 		// When player is spawned, it always prints message on stderr.
-		if (result && result.stderr && result.stderr.indexOf("Logging activities to file") === -1) {
-			return "Unable to find the path to genymotion player and will not be able to start the emulator.";
+		if (result && result.stderr && result.stderr.indexOf(AndroidVirtualDevice.GENYMOTION_DEFAULT_STDERR_STRING) === -1) {
+			this.$logger.trace("Configuration error for Genymotion", result);
+			return this.getConfigurationPlatformSpecficErrorMessage();
 		}
 
 		return null;


### PR DESCRIPTION
In previous versions of Genymotion, trying to execute the `player` command fails with exit code 1, without real error. In order to handle this case, do not fail in case there's nothing on the stderr (or the process errors really bad).
In recent versions of Genymotion, the stderr contains a string that for Logging activities to file even when the command succeeds. So we have ignored this error for the moment.
Improve the message when there's an error.