### PR TITLE
fix: comparing shasums takes a lot of time

### DIFF
--- a/mobile/android/android-device-hash-service.ts
+++ b/mobile/android/android-device-hash-service.ts
@@ -73,7 +73,11 @@ export class AndroidDeviceHashService implements Mobile.IAndroidDeviceHashServic
 	}
 
 	public getChangedShasums(oldShasums: IStringDictionary, currentShasums: IStringDictionary): IStringDictionary {
-		return _.omitBy(currentShasums, (hash: string, pathToFile: string) => !!_.find(oldShasums, (oldHash: string, oldPath: string) => pathToFile === oldPath && hash === oldHash));
+		if (!oldShasums) {
+			return currentShasums;
+		}
+
+		return _.omitBy(currentShasums, (hash: string, pathToFile: string) => !!oldShasums[pathToFile] && oldShasums[pathToFile] === hash);
 	}
 
 	public async removeHashes(localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<boolean> {


### PR DESCRIPTION
Comparing the old shasums and new shasums takes a lot of time as we use find for searching in a map. Instead, just check if we have the entry we are looking for.
In bigger projects (for example with more than 20 000 files including node_modules), the comparison may take more than 100 seconds, which breaks the LiveSync for Android as the socket is closed after 70 seconds without action.
So, in case you have a huge project and try `tns run android`, you'll probably receive:
```
Unable to apply changes on device: 192.168.3.101:5555. Error is: Socket Error:
Error: write ECONNABORTED.
```

After the change, the time for comparing 24 000 shasums is 25 ms instead of more than 100 seconds