### PR TITLE
fix: emulator API fixes

### DIFF
--- a/mobile/android/android-virtual-device-service.ts
+++ b/mobile/android/android-virtual-device-service.ts
@@ -306,7 +306,7 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 		return {
 			identifier: null,
 			imageIdentifier: avdInfo.avdId || avdInfo.displayName,
-			displayName: avdInfo.displayName || avdInfo.device || avdInfo.avdId,
+			displayName: avdInfo.displayName || avdInfo.avdId || avdInfo.device,
 			model: avdInfo.device,
 			version: this.$emulatorHelper.mapAndroidApiLevelToVersion[avdInfo.target],
 			vendor: AndroidVirtualDevice.AVD_VENDOR_NAME,

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -191,8 +191,10 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	}
 
 	private attachToKnownEmulatorDiscoveryEvents(): void {
-		this.$androidEmulatorDiscovery.on(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_FOUND, (emulators: Mobile.IDeviceInfo[]) => this.onEmulatorImagesFound(emulators));
-		this.$androidEmulatorDiscovery.on(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_LOST, (emulators: Mobile.IDeviceInfo[]) => this.onEmulatorImagesLost(emulators));
+		this.$androidEmulatorDiscovery.on(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_FOUND, (emulator: Mobile.IDeviceInfo) => this.onEmulatorImageFound(emulator));
+		this.$androidEmulatorDiscovery.on(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_LOST, (emulator: Mobile.IDeviceInfo) => this.onEmulatorImageLost(emulator));
+		this.$iOSSimulatorDiscovery.on(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_FOUND, (emulator: Mobile.IDeviceInfo) => this.onEmulatorImageFound(emulator));
+		this.$iOSSimulatorDiscovery.on(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_LOST, (emulator: Mobile.IDeviceInfo) => this.onEmulatorImageLost(emulator));
 	}
 
 	private attachToDeviceDiscoveryEvents(deviceDiscovery: Mobile.IDeviceDiscovery): void {
@@ -217,16 +219,16 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 		this.emit(constants.DeviceDiscoveryEventNames.DEVICE_LOST, device);
 	}
 
-	private onEmulatorImagesFound(emulators: Mobile.IDeviceInfo[]): void {
-		this.$logger.trace(`Found emulators with the following image identifiers: ${emulators.map(emulator => emulator.imageIdentifier).join(", ")}`);
-		_.forEach(emulators, emulator => this._availableEmulators[emulator.imageIdentifier] = emulator);
-		this.emit(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_FOUND, emulators);
+	private onEmulatorImageFound(emulator: Mobile.IDeviceInfo): void {
+		this.$logger.trace(`Found emulator with image identifier: ${emulator.imageIdentifier}`);
+		this._availableEmulators[emulator.imageIdentifier] = emulator;
+		this.emit(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_FOUND, emulator);
 	}
 
-	private onEmulatorImagesLost(emulators: Mobile.IDeviceInfo[]): void {
-		this.$logger.trace(`Lost emulators with the following image identifier ${emulators.map(emulator => emulator.imageIdentifier).join(", ")}`);
-		_.forEach(emulators, emulator => delete this._availableEmulators[emulator.imageIdentifier]);
-		this.emit(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_LOST, emulators);
+	private onEmulatorImageLost(emulator: Mobile.IDeviceInfo): void {
+		this.$logger.trace(`Lost emulator with image identifier ${emulator.imageIdentifier}`);
+		delete this._availableEmulators[emulator.imageIdentifier];
+		this.emit(constants.EmulatorDiscoveryNames.EMULATOR_IMAGE_LOST, emulator);
 	}
 
 	/**

--- a/test/unit-tests/mobile/android-virtual-device-service.ts
+++ b/test/unit-tests/mobile/android-virtual-device-service.ts
@@ -80,14 +80,14 @@ function createTestInjector(data: { avdManagerOutput?: string, avdManagerError?:
 	return testInjector;
 }
 
-function getAvailableEmulatorData(data: { displayName: string, imageIdentifier: string, version: string }): Mobile.IDeviceInfo {
+function getAvailableEmulatorData(data: { displayName: string, imageIdentifier: string, version: string, model: string }): Mobile.IDeviceInfo {
 	return {
 		displayName: data.displayName,
 		errorHelp: null,
 		identifier: null,
 		imageIdentifier: data.imageIdentifier,
 		isTablet: false,
-		model: data.displayName,
+		model: data.model,
 		platform: "android",
 		status: NOT_RUNNING_EMULATOR_STATUS,
 		type: "Emulator",
@@ -96,12 +96,12 @@ function getAvailableEmulatorData(data: { displayName: string, imageIdentifier: 
 	};
 }
 
-function getRunningEmulatorData(data: { displayName: string, imageIdentifier: string, identifier: string, version: string }): Mobile.IDeviceInfo {
+function getRunningEmulatorData(data: { displayName: string, imageIdentifier: string, identifier: string, version: string, model: string }): Mobile.IDeviceInfo {
 	return {
 		identifier: data.identifier,
 		imageIdentifier: data.imageIdentifier,
 		displayName: data.displayName,
-		model: data.displayName,
+		model: data.model,
 		version: data.version,
 		vendor: 'Avd',
 		status: RUNNING_EMULATOR_STATUS,
@@ -192,9 +192,9 @@ describe("androidVirtualDeviceService", () => {
 
 				const result = await avdService.getEmulatorImages([]);
 				assert.lengthOf(result.devices, 3);
-				assert.deepEqual(result.devices[0], getAvailableEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5_API_27", version: "8.1.0" }));
-				assert.deepEqual(result.devices[1], getAvailableEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5X_API_28", version: "9.0.0" }));
-				assert.deepEqual(result.devices[2], getAvailableEmulatorData({ displayName: "Nexus 6P", imageIdentifier: "Nexus_6P_API_28", version: "9.0.0" }));
+				assert.deepEqual(result.devices[0], getAvailableEmulatorData({ displayName: "Nexus_5_API_27", imageIdentifier: "Nexus_5_API_27", version: "8.1.0", model: "Nexus 5X" }));
+				assert.deepEqual(result.devices[1], getAvailableEmulatorData({ displayName: "Nexus_5X_API_28", imageIdentifier: "Nexus_5X_API_28", version: "9.0.0", model: "Nexus 5X" }));
+				assert.deepEqual(result.devices[2], getAvailableEmulatorData({ displayName: "Nexus_6P_API_28", imageIdentifier: "Nexus_6P_API_28", version: "9.0.0", model: "Nexus 6P" }));
 				assert.deepEqual(result.errors, []);
 			});
 			it("should return all emulators when there are available and running emulators", async () => {
@@ -210,9 +210,9 @@ describe("androidVirtualDeviceService", () => {
 					return Promise.resolve("");
 				};
 				const result = (await avdService.getEmulatorImages(["emulator-5554	device"])).devices;
-				assert.deepEqual(result[0], getRunningEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5_API_27", identifier: "emulator-5554", version: "8.1.0" }));
-				assert.deepEqual(result[1], getAvailableEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5X_API_28", version: "9.0.0" }));
-				assert.deepEqual(result[2], getAvailableEmulatorData({ displayName: "Nexus 6P", imageIdentifier: "Nexus_6P_API_28", version: "9.0.0" }));
+				assert.deepEqual(result[0], getRunningEmulatorData({ displayName: "Nexus_5_API_27", imageIdentifier: "Nexus_5_API_27", identifier: "emulator-5554", version: "8.1.0", model: "Nexus 5X" }));
+				assert.deepEqual(result[1], getAvailableEmulatorData({ displayName: "Nexus_5X_API_28", imageIdentifier: "Nexus_5X_API_28", version: "9.0.0", model: "Nexus 5X" }));
+				assert.deepEqual(result[2], getAvailableEmulatorData({ displayName: "Nexus_6P_API_28", imageIdentifier: "Nexus_6P_API_28", version: "9.0.0", model: "Nexus 6P" }));
 			});
 		});
 
@@ -237,10 +237,10 @@ describe("androidVirtualDeviceService", () => {
 				const result = await avdService.getEmulatorImages([]);
 
 				assert.lengthOf(result.devices, 4);
-				assert.deepEqual(result.devices[0], getAvailableEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5_API_27", version: "8.1.0" }));
-				assert.deepEqual(result.devices[1], getAvailableEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5X_API_28", version: "9.0.0" }));
-				assert.deepEqual(result.devices[2], getAvailableEmulatorData({ displayName: "Nexus 6P", imageIdentifier: "Nexus_6P_API_28", version: "9.0.0" }));
-				assert.deepEqual(result.devices[3], getAvailableEmulatorData({ displayName: "Pixel 2 XL", imageIdentifier: "Pixel_2_XL_API_28", version: "9.0.0" }));
+				assert.deepEqual(result.devices[0], getAvailableEmulatorData({ displayName: "Nexus_5_API_27", model: "Nexus 5X", imageIdentifier: "Nexus_5_API_27", version: "8.1.0" }));
+				assert.deepEqual(result.devices[1], getAvailableEmulatorData({ displayName: "Nexus_5X_API_28", model: "Nexus 5X", imageIdentifier: "Nexus_5X_API_28", version: "9.0.0" }));
+				assert.deepEqual(result.devices[2], getAvailableEmulatorData({ displayName: "Nexus_6P_API_28", model: "Nexus 6P", imageIdentifier: "Nexus_6P_API_28", version: "9.0.0" }));
+				assert.deepEqual(result.devices[3], getAvailableEmulatorData({ displayName: "Pixel_2_XL_API_28", model: "Pixel 2 XL", imageIdentifier: "Pixel_2_XL_API_28", version: "9.0.0" }));
 				assert.deepEqual(result.errors, []);
 			});
 			it("shouldn't return the emulator when it actually does not exist", async () => {
@@ -262,9 +262,9 @@ describe("androidVirtualDeviceService", () => {
 				const result = await avdService.getEmulatorImages([]);
 
 				assert.lengthOf(result.devices, 3);
-				assert.deepEqual(result.devices[0], getAvailableEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5_API_27", version: "8.1.0" }));
-				assert.deepEqual(result.devices[1], getAvailableEmulatorData({ displayName: "Nexus 5X", imageIdentifier: "Nexus_5X_API_28", version: "9.0.0" }));
-				assert.deepEqual(result.devices[2], getAvailableEmulatorData({ displayName: "Nexus 6P", imageIdentifier: "Nexus_6P_API_28", version: "9.0.0" }));
+				assert.deepEqual(result.devices[0], getAvailableEmulatorData({ displayName: "Nexus_5_API_27", model: "Nexus 5X", imageIdentifier: "Nexus_5_API_27", version: "8.1.0" }));
+				assert.deepEqual(result.devices[1], getAvailableEmulatorData({ displayName: "Nexus_5X_API_28", model: "Nexus 5X", imageIdentifier: "Nexus_5X_API_28", version: "9.0.0" }));
+				assert.deepEqual(result.devices[2], getAvailableEmulatorData({ displayName: "Nexus_6P_API_28", model: "Nexus 6P", imageIdentifier: "Nexus_6P_API_28", version: "9.0.0" }));
 				assert.deepEqual(result.errors, []);
 			});
 		});


### PR DESCRIPTION
### fix: errors are raised when emulator lost/found event is raised
Whenever androidEmulatorDiscovery raises `emulatorImageFound` or `emulatorImageLost` event, an error is raised in the code as `devicesService` expects to receive an array, but it receives a single image instead.
Fix the code in devicesService to handle correctly the event. Also add logic to handle the same events from iOSSimulatorDiscovery.

### fix: Android emulator images are not correct
In case the Android Emulator image does not have displayName set in the config.ini file, the displayName that CLI sets fallbacks to `hw.device.name` property.
However, this name is not the one that is visible in other tools, like Android Studio for example. As a user I expect to see the same name as in Android Studio.
In order to fix this, fallback to the AvdId value from config.ini file and if it is missing, fallback to `hw.device.name`.
Here's an image showing the mentioned properties:
![screen shot 2018-09-13 at 18 45 07](https://user-images.githubusercontent.com/8351653/45500647-cf3ab800-b787-11e8-8592-1619d3e25b73.png)


NOTE: When displayName has spaces, the AvdId is not the same, however it is much similar than the `hw.device.name` propery:
![screen shot 2018-09-13 at 18 29 12](https://user-images.githubusercontent.com/8351653/45500711-f09ba400-b787-11e8-8a7b-7cf4dfcab174.png)
