### PR TITLE
fix: unable to work with devices with numeric identifiers

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -262,8 +262,9 @@ export function block(operation: () => void): void {
 	}
 }
 
-export function isNumber(n: any): boolean {
-	return !isNaN(parseFloat(n)) && isFinite(n);
+export function isNumberWithoutExponent(n: any): boolean {
+	const parsedNum = parseFloat(n);
+	return !isNaN(parsedNum) && isFinite(n) && n.toString && n.toString() === parsedNum.toString();
 }
 
 export function fromWindowsRelativePathToUnix(windowsRelativePath: string): string {

--- a/mobile/mobile-core/devices-service.ts
+++ b/mobile/mobile-core/devices-service.ts
@@ -66,8 +66,6 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 
 	@exported("devicesService")
 	public async startEmulator(options: Mobile.IStartEmulatorOptions): Promise<string[]> {
-		console.log(`startEmulator options`);
-		console.log(options);
 		if (!options || (!options.imageIdentifier && !options.emulatorIdOrName)) {
 			return ["Missing mandatory image identifier or name option."];
 		}
@@ -349,15 +347,15 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	public async getDevice(deviceOption: string): Promise<Mobile.IDevice> {
 		let device: Mobile.IDevice = null;
 
-		if (helpers.isNumber(deviceOption)) {
-			device = this.getDeviceByIndex(parseInt(deviceOption, 10));
-		}
-
 		if (!device) {
 			device = _.find(this.getDeviceInstances(), d =>
 				(d.deviceInfo.identifier && d.deviceInfo.identifier === deviceOption) ||
 				(d.deviceInfo.displayName && d.deviceInfo.displayName === deviceOption) ||
 				(d.deviceInfo.imageIdentifier && d.deviceInfo.imageIdentifier === deviceOption));
+		}
+
+		if (!device && helpers.isNumberWithoutExponent(deviceOption)) {
+			device = this.getDeviceByIndex(parseInt(deviceOption, 10));
 		}
 
 		if (!device) {
@@ -500,7 +498,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 
 		//check if --device(value) is running, if it's not or it's not the same as is specified, start with name from --device(value)
 		if (data.deviceId) {
-			if (!helpers.isNumber(data.deviceId)) {
+			if (!helpers.isNumberWithoutExponent(data.deviceId)) {
 				const activeDeviceInstance = _.find(deviceInstances, (device: Mobile.IDevice) => device.deviceInfo.identifier === data.deviceId);
 				if (!activeDeviceInstance) {
 					return this.startEmulatorCore(data);

--- a/test/unit-tests/helpers.ts
+++ b/test/unit-tests/helpers.ts
@@ -654,4 +654,47 @@ describe("helpers", () => {
 			_.each(getValueFromNestedObjectTestData, testData => assertValueFromNestedObjectTestData(testData));
 		});
 	});
+
+	describe("isNumberWithoutExponent", () => {
+		const testData: ITestData[] = [
+			{
+				input: 42,
+				expectedResult: true
+			},
+			{
+				input: "42",
+				expectedResult: true
+			},
+			{
+				input: null,
+				expectedResult: false
+			},
+			{
+				input: undefined,
+				expectedResult: false
+			},
+			{
+				input: {},
+				expectedResult: false
+			},
+			{
+				input: "some text",
+				expectedResult: false
+			},
+			{
+				input: "1e7",
+				expectedResult: false
+			},
+			{
+				input: "3.14",
+				expectedResult: true
+			}
+		];
+
+		it("returns correct result", () => {
+			_.each(testData, testCase => {
+				assert.deepEqual(helpers.isNumberWithoutExponent(testCase.input), testCase.expectedResult);
+			});
+		});
+	});
 });

--- a/test/unit-tests/mobile/devices-service.ts
+++ b/test/unit-tests/mobile/devices-service.ts
@@ -593,6 +593,20 @@ describe("devicesService", () => {
 				await assertAllMethodsResults("1");
 			});
 
+			it("when deviceId is deviceIdentifier that looks like number (with exponent)", async () => {
+				const androidDeviceOriginalId = androidDevice.deviceInfo.identifier;
+				androidDevice.deviceInfo.identifier = "16089e09";
+				await assertAllMethodsResults(androidDevice.deviceInfo.identifier);
+				androidDevice.deviceInfo.identifier = androidDeviceOriginalId;
+			});
+
+			it("when deviceId is deviceIdentifier that looks like number", async () => {
+				const androidDeviceOriginalId = androidDevice.deviceInfo.identifier;
+				androidDevice.deviceInfo.identifier = "4153465641573398";
+				await assertAllMethodsResults(androidDevice.deviceInfo.identifier);
+				androidDevice.deviceInfo.identifier = androidDeviceOriginalId;
+			});
+
 			it("fails when deviceId is invalid index (less than 0)", async () => {
 				const expectedErrorMessage = getErrorMessage(testInjector, "NotFoundDeviceByIndexErrorMessage", "-2");
 				await assert.isRejected(devicesService.initialize({ platform: "android", deviceId: "-1" }), expectedErrorMessage);


### PR DESCRIPTION
In case the device identifier contains only numeric symbols or in case it looks like a number (16089e09 for example), CLI fails to work with it.
The problem is that CLI thinks an index is passed to it, so it removes "one" from the passed number and tries to find the device on the new index.
The other issue is with the `isNumber` helper method which works incorrectly when the string looks like number. Improve the logic in the method and rename it. We cannot parse safely values with exponent (`1e6` for example), but we do not need such functionality.
The new method name and tests reflects the described behavior.