### PR TITLE
fix: don't execute hooks for directories that do not exist

### DIFF
--- a/services/hooks-service.ts
+++ b/services/hooks-service.ts
@@ -31,11 +31,7 @@ export class HooksService implements IHooksService {
 	private initialize(projectDir: string): void {
 		this.cachedHooks = {};
 
-		const relativeToLibPath = path.join(__dirname, "../../");
-		this.hooksDirectories = [
-			path.join(relativeToLibPath, HooksService.HOOKS_DIRECTORY_NAME),
-			path.join(relativeToLibPath, "common", HooksService.HOOKS_DIRECTORY_NAME)
-		];
+		this.hooksDirectories = [];
 
 		projectDir = projectDir || this.$projectHelper.projectDir;
 


### PR DESCRIPTION
Currently `hooksService` is initialized with the following directories:
```
<path-to-cli>/lib/hooks
<path-to-cli>/lib/common/hooks
```

Actually this directories do not exist and no need to iterate them.
This fix should speed up the hooks execution.